### PR TITLE
fix(core): Correctly handle delimiter-only strings in normalizeCostum…

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function findBestMatch(combined, regexes, settings, quoteRanges) {
 }
 
 function normalizeStreamText(s){return s?String(s).replace(/[\uFEFF\u200B\u200C\u200D]/g,"").replace(/[\u2018\u2019\u201A\u201B]/g,"'").replace(/[\u201C\u201D\u201E\u201F]/g,'"').replace(/(\*\*|__|~~|`{1,3})/g,"").replace(/\u00A0/g," "):""}
-function normalizeCostumeName(n){if(!n)return"";let s=String(n).trim();s.startsWith("/")&&(s=s.slice(1).trim());const first=s.split(/[\/\s]+/).filter(Boolean)[0]||s;return String(first).replace(/[-_](?:sama|san)$/i,"").trim()}
+function normalizeCostumeName(n){if(!n)return"";let s=String(n).trim();s.startsWith("/")&&(s=s.slice(1).trim());const first=(s.split(/[\/\s]+/).filter(Boolean)[0]||'');return String(first).replace(/[-_](?:sama|san)$/i,"").trim()}
 const perMessageBuffers=new Map,perMessageStates=new Map;let lastIssuedCostume=null,lastSwitchTimestamp=0;const lastTriggerTimes=new Map,failedTriggerTimes=new Map;let _streamHandler=null,_genStartHandler=null,_genEndHandler=null,_msgRecvHandler=null,_chatChangedHandler=null;const MAX_MESSAGE_BUFFERS=60;
 function ensureBufferLimit(){if(!(perMessageBuffers.size<=60)){for(;perMessageBuffers.size>60;){const firstKey=perMessageBuffers.keys().next().value;perMessageBuffers.delete(firstKey),perMessageStates.delete(firstKey)}}}
 function waitForSelector(selector,timeout=3e3,interval=120){return new Promise(resolve=>{const start=Date.now(),iv=setInterval(()=>{const el=document.querySelector(selector);if(el)return clearInterval(iv),void resolve(!0);Date.now()-start>timeout&&(clearInterval(iv),resolve(!1))},interval)})}


### PR DESCRIPTION
…eName

This commit fixes a bug in the `normalizeCostumeName` function where inputs consisting only of delimiters (e.g., "/ /") would result in an incorrect, partially-processed output (e.g., "/") instead of an empty string.

Bug Details:
- File: `index.js`
- Function: `normalizeCostumeName(n)`
- Description: The function's fallback logic (`|| s`) caused it to return a partially processed string when the initial split/filter operation yielded no results.

The fix changes the fallback to `|| ''`, ensuring that such invalid inputs are cleanly resolved to an empty string.

Verification:
Since no testing framework was present, the fix was verified manually:
1. A temporary test button was added to the UI to execute `normalizeCostumeName("/ /")`.
2. Before the fix, the test returned an incorrect value of "/".
3. After the fix, the test returned the correct empty string.
4. The temporary test code was removed after verification.