### PR TITLE
Adjust scene roster weighting to allow new matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,28 +242,33 @@ function findBestMatch(combined) {
     const allMatches = findAllMatches(combined);
     if (allMatches.length === 0) return null;
 
+    let rosterSet = null;
     if (profile.enableSceneRoster) {
         const msgState = Array.from(state.perMessageStates.values()).pop();
         if (msgState && msgState.sceneRoster.size > 0) {
-            const rosterMatches = allMatches.filter(m => msgState.sceneRoster.has(m.name.toLowerCase()));
-            if (rosterMatches.length > 0) {
-                // Roster is active, only consider matches from the roster
-                return getWinner(rosterMatches, profile.detectionBias, combined.length);
-            }
+            rosterSet = msgState.sceneRoster;
         }
     }
 
-    return getWinner(allMatches, profile.detectionBias, combined.length);
+    return getWinner(allMatches, profile.detectionBias, combined.length, { rosterSet });
 }
 
-function getWinner(matches, bias = 0, textLength = 0) {
+function getWinner(matches, bias = 0, textLength = 0, options = {}) {
+    const rosterSet = options?.rosterSet instanceof Set ? options.rosterSet : null;
+    const rosterBonus = Number.isFinite(options?.rosterBonus) ? options.rosterBonus : 150;
     const scoredMatches = matches.map(match => {
         const isActive = match.priority >= 3; // speaker, attribution, action
         const distanceFromEnd = Number.isFinite(textLength)
             ? Math.max(0, textLength - match.matchIndex)
             : 0;
         const baseScore = match.priority * 100 - distanceFromEnd;
-        const score = baseScore + (isActive ? bias : 0);
+        let score = baseScore + (isActive ? bias : 0);
+        if (rosterSet) {
+            const normalized = String(match.name || '').toLowerCase();
+            if (normalized && rosterSet.has(normalized)) {
+                score += rosterBonus;
+            }
+        }
         return { ...match, score };
     });
     scoredMatches.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary
- stop filtering detections strictly to the scene roster when it contains entries
- add a roster bonus to scoring so existing participants are still favored without blocking new characters

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa9d449a608325955de612677e969b