### PR TITLE
Overhaul costume switcher UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,207 +1,151 @@
 # Costume Switcher for SillyTavern
 
-**Costume Switcher** is a powerful extension for SillyTavern that brings your multi-character scenes to life. It intelligently and automatically changes the displayed character avatar in real-time as the AI generates its response, creating a dynamic, narrative-driven experience.
-
-Instead of being limited to a single character avatar, Costume Switcher analyzes the story as it's written and ensures the correct character is always on-screen, making it perfect for single-card narrator or ensemble cast roleplays.
-
-## Table of Contents
-
--   [How It Works](#how-it-works)
--   [Key Features](#key-features)
--   [Prerequisites](#prerequisites)
--   [Installation](#installation)
--   [Quick Start Guide](#quick-start-guide)
--   [Detailed Feature Guide](#detailed-feature-guide)
--   [Complete Guide to Settings](#complete-guide-to-settings)
--   [Tips & Best Practices](#tips--best-practices)
--   [Recommended Extensions](#recommended-extensions)
--   [Troubleshooting](#troubleshooting)
-
-
-## How It Works
-
-At its core, Costume Switcher simulates reading a story as it's being written. As the AI generates a response token by token, the extension maintains a buffer of the recent text. With every new word, it re-evaluates the entire buffer and runs a sophisticated analysis to determine the most likely active character.
-
-This analysis scores every potential character mention based on two key factors:
-
-1.  **Priority:** *How* was the character mentioned? A direct dialogue tag (e.g., `"Hello," she said.`) has a much higher priority than a passing name drop.
-2.  **Recency:** *When* was the character mentioned? A name that appeared more recently has a higher chance of being the active character.
-
-The **Detection Bias** slider in the settings lets you fine-tune the balance between these two factors. The "winner" of this constant evaluation becomes the active costume. This process happens dozens of times per second, ensuring the avatar is always in sync with the story.
-
-## Key Features
-
-* **Intelligent Narrative Detection:** The core of the extension. It doesn't just look for simple `Name:` tags; it understands the flow and context of a story.
-* **Scene Awareness:** An optional mode that dramatically improves accuracy in scenes with multiple characters by maintaining a "roster" of recently active participants.
-* **On-the-Fly Slash Commands:** Manage your character list without ever leaving the chat for quick additions or adjustments.
-* **Advanced Profile Management:** Create, save, and switch between different configurations for various scenarios. Import and export profiles to share your setups.
-* **Live Pattern Tester:** An indispensable tool to test your settings in real-time and understand the engine's logic.
-* **Performance Tuning:** Fine-tune cooldowns and thresholds to match your preferences and system performance.
-* **Costume Mapping:** Map multiple names or regular expressions to a single costume folder.
-
-## Prerequisites
-
-* **SillyTavern Version:** It is recommended to use the **latest version** of SillyTavern (either Release or Staging).
-* **Streaming must be enabled:** This extension relies on analyzing the AI's response as it's being generated. You **must** have streaming enabled in your chosen API's settings for it to function.
-
-## Installation
-
-1.  **Install Costume Switcher**: In the **SillyTavern Extension Manager**, use "Install from URL" and paste the following Git URL:
-    ```
-    https://github.com/archkrrr/SillyTavern-CostumeSwitch
-    ```
-
-## Quick Start Guide
-
-For the best experience right out of the box, follow this simple setup guide.
-
-1.  **Add Your Characters:** Go to the settings and list all character names in the **Character Patterns** box, one per line.
-2.  **Configure Detection:** Scroll down to **Detection Methods** and enable the following for the most accurate, narrative-driven experience:
-    * `[x] Detect Attribution`
-    * `[x] Detect Action`
-    * `[x] Detect Pronoun`
-3.  **Improve Multi-Character Accuracy (If Needed):** If your scenes frequently involve 3+ characters, also enable:
-    * `[x] Enable Scene Roster`
-4.  **Save Profile:** Give your configuration a name at the top and click **Save**. You're ready to go!
+Costume Switcher keeps the right avatar in focus while you write. It listens to the live stream coming from your model, scores every character mention it finds, and immediately swaps the displayed costume to match the active speaker. The extension ships with powerful tooling, scene awareness, and a fully redesigned configuration UI so you can understand *why* a switch happened and tune the behaviour to fit any story.
 
 ---
 
-## Detailed Feature Guide
+## Highlights at a Glance
 
-### Intelligent Narrative Detection
+- **Narrative-aware detection** – Attribution, action, vocative, possessive, pronoun, and general mention detectors can be mixed to match the format of your prose.
+- **Scene roster logic** – Track who is currently in the conversation and favour them during tight scoring races.
+- **Modern profile workflow** – Save, duplicate, rename, and export complete configurations with a couple of clicks.
+- **Performance tuning** – Adjust global, per-trigger, and failed-trigger cooldowns plus the maximum buffer size and processing cadence.
+- **Live Pattern Tester** – Paste sample prose, inspect every detection, review switch decisions, and copy a rich report for debugging or support requests.
+- **Slash command helpers** – Add, ignore, or map characters on the fly without leaving the chat window, and log mention stats for the last message.
 
-This is the engine of the extension. By enabling different methods, you can control how deeply it reads the story.
+---
 
-* **Detect Speaker (`Name: Dialogue`)**
-    * **What it is:** The most basic and accurate method. It looks for a character's name at the beginning of a line, followed by a colon. This is enabled by default and cannot be turned off.
-    * **Example:** `Arthur: "I'll be there in a moment."` -> Switches to `Arthur`.
+## Requirements
 
-* **Detect Attribution**
-    * **What it is:** Detects the speaker from dialogue tags that appear *after* a line of dialogue. Essential for novel-style writing.
-    * **Example:** `"I'll be there in a moment," Arthur said.` -> Switches to `Arthur`.
+- **SillyTavern** v1.10.9 or newer (release or staging). Earlier builds may lack UI hooks required by the extension.
+- **Streaming enabled** in your model or API connector. Costume Switcher listens to streaming tokens; without streaming no automatic switches will occur.
+- **Browser permissions** to read and write extension settings (enabled by default in SillyTavern).
 
-* **Detect Action**
-    * **What it is:** Detects the active character when they perform an action, especially at the start of a paragraph.
-    * **Example:** `Arthur nodded and walked towards the door.` -> Switches to `Arthur`.
+---
 
-* **Detect Pronoun**
-    * **What it is:** A powerful feature that tracks the last explicitly named character. It then attributes subsequent actions by pronouns (he, she, they) to that character, ensuring their avatar remains active even when their name isn't used.
-    * **Example:** `Arthur entered the room. He looked around and sighed.` -> Switches to `Arthur` on the first sentence and *stays on* `Arthur` for the second.
+## Installation
 
-* **Detect Vocative**
-    * **What it is:** Detects when a character is spoken *to* within dialogue. Can be useful but may sometimes cause incorrect switches if you only want the speaker to be active.
-    * **Example:** `"What do you think we should do, Arthur?" she asked.` -> Switches to `Arthur`.
+1. Open **Settings → Extensions → Extension Manager** in SillyTavern.
+2. Click **Install from URL** and paste the repository address:
+   ```
+   https://github.com/archkrrr/SillyTavern-CostumeSwitch
+   ```
+3. Press **Install**. SillyTavern downloads the extension and refreshes the page.
+4. Enable **Costume Switcher** from the Extensions list if it is not activated automatically.
 
-* **Detect Possessive**
-    * **What it is:** Detects when a character's possessive form is used.
-    * **Example:** `Her eyes widened in surprise.` -> This is a weaker detection and may not always trigger a switch unless no better match is found. However, `Merlin's eyes widened...` will correctly switch to `Merlin`.
+To update, return to the Extension Manager and click **Update all** or reinstall from the same URL.
 
-* **Detect General Mentions**
-    * **What it is:** The broadest and most dangerous method. It will trigger a switch any time a character's name is mentioned anywhere. Use with caution, as it can lead to flickering.
-    * **Example:** `He thought about Arthur's plan.` -> Switches to `Arthur`.
+---
 
-### Scene Awareness (Scene Roster)
+## Getting Started in Five Minutes
 
-This feature is designed to fix the most common problem in complex, multi-character scenes: an old character mention causing an incorrect switch.
+1. **Enable the extension.** Expand the Costume Switcher drawer and toggle **Enable Costume Switching** on.
+2. **List your characters.** Enter one name (or `/regex/`) per line inside **Active Characters**. Longer names should appear above abbreviations.
+3. **Pick the core detectors.** Under **Detection Strategy**, enable **Detect Attribution**, **Detect Action**, and **Detect Pronoun** for narrative-style writing. Add **Scene Roster** if multiple characters speak in the same scene.
+4. **Test a sample.** Paste a recent reply into the **Live Pattern Tester** and click **Test Pattern**. Review the detections to confirm the correct costume is chosen.
+5. **Save the profile.** Use the **Save** button in the Profiles card to store the configuration for future sessions.
 
-When enabled, the extension maintains a temporary "roster" of characters who have been mentioned recently. The `Scene Roster TTL (messages)` setting determines how many messages a character stays on the roster without being mentioned before they are dropped. The detection engine will then *strongly* prioritize characters on this roster, improving accuracy in active conversations with many participants.
+That’s it—you can now focus on storytelling while the avatars keep up automatically.
 
-### On-the-Fly Slash Commands
+---
 
-These commands allow you to make quick adjustments to the extension's behavior directly from the chat input box. These changes are temporary and will be reset on a page refresh.
+## Tour of the Settings UI
 
-* `/cs-addchar [Character Name]`
-    * Adds a new character to the list of patterns for the current session.
-    * **Example:** `/cs-addchar Lancelot`
+### Header & Master Toggle
+The hero header summarises what the extension does and houses the **Enable Costume Switching** toggle. Turn it off temporarily to pause detection without losing any settings.
 
-* `/cs-ignore [Character Name]`
-    * Temporarily stops the extension from detecting a specific character.
-    * **Example:** `/cs-ignore Merlin`
+### Profiles
+Create tailored setups for different stories or formats:
+- **Select** swaps between saved profiles.
+- **Save** writes changes back to the currently selected profile.
+- **Save As** copies the active profile under a new name typed in the field.
+- **Rename** updates the active profile’s name to the text input value.
+- **New (Defaults)** starts from the built-in defaults; **Duplicate Current** clones the active profile first.
+- **Delete**, **Import**, and **Export** round out the lifecycle so you can archive and share JSON profiles.
 
-* `/cs-map [Name] to [Costume Folder]`
-    * Creates a temporary mapping from a detected name to a specific costume folder.
-    * **Example:** `/cs-map The King to Arthur`
+### Character Patterns & Filters
+Teach the detector which names to recognise:
+- **Active Characters** accepts plain names or `/regex/` entries—one per line.
+- **Ignored Characters** suppresses specific matches without removing them from the character list.
+- **Veto Phrases** stops detection entirely for a message when the phrase or regex is found (useful for OOC tags).
 
-### Profile Management
+### Presets & Focus
+Kickstart new profiles with curated presets, configure a **Default Costume** to fall back to, and optionally engage **Manual Focus Lock** to pin the avatar to a specific character until you unlock it.
 
-The profile system allows you to save and load entire configurations. This is perfect for switching between different stories, character groups, or detection styles without having to manually re-enter settings every time. You can import and export profiles as `.json` files to back them up or share them.
+### Detection Strategy
+Toggle the individual detectors the engine can use. Tooltips in the UI explain the common scenarios for each detection type. Enable **Scene Roster** to maintain a rolling list of characters active in the conversation and adjust the **Scene Roster TTL (messages)** to control how long they stay on that list.
+
+### Performance & Bias
+Fine-tune responsiveness and tie-breaking behaviour:
+- **Global Cooldown (ms)** – Minimum time between any two costume changes.
+- **Repeat Suppression (ms)** – Minimum time before the same character can switch again.
+- **Per-Trigger Cooldown (ms)** – Delay before the same detection type (e.g., action) can trigger again.
+- **Failed Trigger Cooldown (ms)** – Backoff applied after a switch attempt is rejected.
+- **Max Buffer Size (chars)** – Hard cap on how much of the recent stream is analysed.
+- **Token Process Threshold (chars)** – Number of characters that must arrive before the buffer is rescored.
+- **Detection Bias** – Slider balancing match priority versus recency; positive numbers favour dialogue/action tags, negative values favour the latest mention.
+
+### Costume Mappings
+Map any detected name or alias to a specific costume folder. Use **Add Mapping** to append rows, then fill in the character and destination folder names.
 
 ### Live Pattern Tester
+Paste sample prose and inspect:
+- **All Detections** – Every match in order with its type and priority.
+- **Live Switch Decisions** – Real-time simulation showing switches, skips, scores, and veto events.
+- **Copy Report** – Generates an extensive plain-text report containing summaries, skip breakdowns, switch stats, final state details, and key settings so you can share diagnostics quickly.
 
-This is your primary diagnostic tool. Paste any block of text into the tester and click "Test Pattern" to see how the engine analyzes it with your current settings.
+### Footer Controls
+Use **Save Current Profile** as a one-click commit for any edits and **Manual Reset** to snap back to your default costume or main avatar. Status and error banners let you know when actions succeed or if validation fails.
 
-* **All Detections:** Shows every single time a character pattern was found, in the order they appear in the text.
-* **Winning Detections:** Simulates the real-time process, showing a log of every time the "winning" character changed as the message was being "written." This helps you understand why the final avatar was chosen.
+---
 
-## Complete Guide to Settings
+## Understanding Live Tester Reports
+Every report copied from the tester includes:
+- **Input metadata** – Profile name, timestamps, original/processed length, and veto status.
+- **Detection log** – List of every detection with match type, character index, and priority.
+- **Switch timeline** – Each decision, including score, detection kind, and why switches were skipped.
+- **Detection summary** – Aggregated counts per character, highest priority hit, and the range of positions that matched.
+- **Switch summary** – Total and unique costumes, the last switch, and the top scoring triggers.
+- **Skip reasons** – Counts of why detections were ignored (cooldowns, existing costume, veto, etc.).
+- **Final stream state** – Scene roster contents, last accepted name, last subject, processed length, and simulated duration.
+- **Key settings snapshot** – Cooldowns, thresholds, roster flag, and bias value in effect during the test.
+Attach these reports when filing bug reports or asking for tuning advice—everything needed to reproduce the issue is included.
 
--   **Profiles:**
-    -   **Dropdown:** Select a saved profile to load it.
-    -   **Delete:** Deletes the currently selected profile.
-    -   **Text Input / Save:** Type a new name to create a new profile, or use an existing name to overwrite and save changes to the current profile.
-    -   **Import / Export:** Save your profile to a file or load one from your computer.
+---
 
--   **Manual Focus Lock:** Force the costume to a specific character, disabling all automatic detection until you click "Unlock".
+## Advanced Configuration Tips
+- **Tune the buffer** when working with long-form prose. Reduce **Max Buffer Size** to keep focus on the latest paragraphs or increase it to catch callbacks to earlier exposition.
+- **Combine cooldowns** to eliminate flicker. A short global cooldown paired with per-trigger cooldowns stops rapid-fire switches without muting genuinely new speakers.
+- **Scene roster** excels in multi-character RP. Keep the TTL close to the number of alternating speakers to maintain context without dragging in old participants.
+- **Custom verb lists** (Attribution/Action) help the detectors understand bespoke writing styles. Add uncommon dialogue tags or narrative verbs as needed.
 
--   **Enable Costume Switch:** The master on/off switch for the entire extension.
+---
 
--   **Character Patterns:** The list of names or `/regex/` patterns the extension will look for. One pattern per line.
+## Slash Commands
+All commands are session-scoped—they modify the active profile until you reload the page.
 
--   **Default Costume:** The costume folder to use when no character is detected. Leave blank to use the main character card's avatar.
+| Command | Description |
+| --- | --- |
+| `/cs-addchar <name>` | Appends a character or regex to the profile’s patterns list and recompiles detections. |
+| `/cs-ignore <name>` | Adds a character or regex to the ignore list for the current session. |
+| `/cs-map <alias> to <folder>` | Creates a temporary mapping from `alias` to the specified costume folder. |
+| `/cs-stats` | Logs a breakdown of detected character mentions for the most recent AI message to the browser console. |
 
--   **Ignored Characters:** Any pattern on this list will be completely ignored by the detection engine.
+---
 
--   **Veto Phrases:** If any phrase or `/regex/` on this list is found anywhere in the message, the extension will stop all detection for that message entirely. Perfect for ignoring OOC comments.
+## Troubleshooting Checklist
+1. **No switches happen:** verify streaming is enabled, the master toggle is on, at least one detection method is selected, and the characters appear in the patterns list exactly as they do in the story.
+2. **The wrong character is chosen:** run the Live Pattern Tester, read the skip reasons, and adjust Detection Bias or enable Scene Roster to give dialogue tags more weight.
+3. **Switches flicker between characters:** raise the global cooldown, tweak per-trigger cooldowns, or disable **Detect General Mentions** for subtle references.
+4. **Reports show a veto:** check the Veto Phrases list to confirm the text did not match an OOC filter.
+5. **Profiles do not persist:** ensure you click **Save** after editing and confirm the SillyTavern browser tab has permission to write local storage.
 
--   **Detection Methods:** See the [Detailed Feature Guide](#detailed-feature-guide) above for a full explanation of each method.
+---
 
--   **Enable Scene Roster:** Toggles the Scene Awareness feature for scenes with many characters.
-    -   **Scene Roster TTL (messages):** Sets how many messages a character remains "active" in the scene before being dropped from the priority roster.
+## Support & Contributions
+Issues and pull requests are welcome. When reporting a problem, include:
+- The copied Live Pattern Tester report (using **Copy Report**).
+- Your SillyTavern build number and API provider.
+- Any custom detector, cooldown, or buffer settings that differ from defaults.
 
--   **Attribution / Action Verbs:** Comma-separated lists of verbs used by the "Detect Attribution" and "Detect Action" methods. You can add or remove verbs to fine-tune detection.
-
--   **Performance Tuning:**
-    -   **Global Cooldown (ms):** The minimum time (in milliseconds) that must pass between *any* two costume switches. Prevents flickering.
-    -   **Repeat Suppression (ms):** The minimum time before the *same* character can trigger another switch.
-    -   **Token Process Threshold (chars):** How many characters the extension waits before re-evaluating the text. Lower values are more reactive but use more CPU.
-    -   **Detection Bias:** The slider that balances Priority vs. Recency.
-        -   **Positive values (+):** Favor high-priority matches (dialogue/action tags) even if they appeared earlier in the text.
-        -   **Negative values (-):** Favor the most recently mentioned character, even if it was a lower-priority mention.
-
--   **Costume Mappings:** Map a detected name (left column) to a specific costume folder name (right column).
-
--   **Debug Logging:** Check this to print detailed decision-making logs to the browser's developer console (F12) for advanced troubleshooting.
-
-## Tips & Best Practices
-
--   **Order Your Patterns:** When listing names in Character Patterns, always list longer names before shorter names that are part of them (e.g., list 'Bartholomew' before 'Bart').
--   **Use the Live Tester:** Before asking for help, paste your text into the Live Pattern Tester. It will often show you exactly why a switch did or didn't happen. It's also the best way to test and perfect your regular expressions.
--   **Start with Recommended Settings:** For most novel-style roleplays, the recommended detection settings (`Attribution`, `Action`, `Pronoun`) provide the best balance of accuracy and performance. Only enable other methods if you have a specific need.
--   **Turn off "Request model reasoning":** If you are using a model that supports a "thinking" or "reasoning" phase, it is highly recommended to **disable** the "Request model reasoning" option in SillyTavern's settings. The model's internal thoughts may contain character names that will cause the extension to switch costumes prematurely before the actual response is written.
--   **Be Wary of "General Mentions":** This detection method is powerful but can easily cause incorrect switches in complex sentences. Only use it if you understand its behavior.
-
-## Recommended Extensions
-
-These extensions work well alongside Costume Switcher to enhance your storytelling experience.
-
-* **[Moonlit Echoes Theme]**: A really good theme extension that improves your roleplay experience, and makes this extensions settings page look better.
-    ```
-    https://github.com/RivelleDays/SillyTavern-MoonlitEchoesTheme
-    ```
-* **[Extension Name Placeholder]**: A brief description of what this extension does and why it's a good companion.
-    * [GitHub Link Placeholder]
-
-## Troubleshooting
-
--   **Switches aren't happening at all:**
-    1.  **Is Streaming enabled in your API settings?** This is the most common issue. The extension requires streaming to work.
-    2.  Is "Enable Costume Switch" checked in the extension settings?
-    3.  Are your character names spelled correctly in "Character Patterns"?
-    4.  Is at least one "Detection Method" enabled?
-    5.  Could a "Veto Phrase" be present in the message?
-
--   **The wrong character is being selected:**
-    1.  Paste the full message into the "Live Pattern Tester" to see the engine's logic.
-    2.  Try adjusting the "Detection Bias" slider. A more positive bias will help if older dialogue tags are being ignored in favor of recent name drops.
-    3.  For scenes with many active characters, enable the "Scene Roster".
-    4.  Check if an overly broad detection method like "General Mentions" is enabled.
+This information helps others reproduce the behaviour quickly and suggest accurate fixes or tuning advice.

--- a/settings.html
+++ b/settings.html
@@ -1,5 +1,11 @@
 <div id="costume-switcher-settings" class="extension_container cs-theme">
-  <div class="cs-shell">
+  <div class="inline-drawer is-open">
+    <div class="inline-drawer-toggle inline-drawer-header">
+      <b>Costume Switcher</b>
+      <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
+    </div>
+    <div class="inline-drawer-content">
+      <div class="cs-shell">
     <section class="cs-card cs-header-card">
       <div class="cs-header-intro">
         <h2 class="cs-title">Costume Switcher</h2>
@@ -285,20 +291,21 @@
           </label>
         </section>
       </div>
-    </div>
+      </div>
 
-    <div class="cs-footer">
-      <div class="cs-toolbar cs-toolbar--wrap">
-        <button id="cs-save" class="menu_button interactable cs-button-primary">Save Current Profile</button>
-        <button id="cs-reset" class="menu_button interactable" title="Switch back to your default costume, or the main avatar if none is set.">Manual Reset</button>
-      </div>
-      <div id="cs-status" class="cs-status-message" aria-live="polite">
-        <i class="fa-solid fa-circle-info"></i>
-        <span class="cs-status-text">Ready</span>
-      </div>
-      <div id="cs-error" class="cs-error-message" role="alert" aria-live="assertive" hidden>
-        <i class="fa-solid fa-triangle-exclamation"></i>
-        <span class="cs-status-text"></span>
+      <div class="cs-footer">
+        <div class="cs-toolbar cs-toolbar--wrap">
+          <button id="cs-save" class="menu_button interactable cs-button-primary">Save Current Profile</button>
+          <button id="cs-reset" class="menu_button interactable" title="Switch back to your default costume, or the main avatar if none is set.">Manual Reset</button>
+        </div>
+        <div id="cs-status" class="cs-status-message" aria-live="polite">
+          <i class="fa-solid fa-circle-info"></i>
+          <span class="cs-status-text">Ready</span>
+        </div>
+        <div id="cs-error" class="cs-error-message" role="alert" aria-live="assertive" hidden>
+          <i class="fa-solid fa-triangle-exclamation"></i>
+          <span class="cs-status-text"></span>
+        </div>
       </div>
     </div>
   </div>

--- a/settings.html
+++ b/settings.html
@@ -1,220 +1,297 @@
-<div id="costume-switcher-settings" class="extension_container">
-  <div class="inline-drawer is-open">
-    <div class="inline-drawer-toggle inline-drawer-header">
-      <b>Character Switcher</b>
-      <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
-    </div>
-    <div class="inline-drawer-content">
-      
-      <div class="cs-block">
-        <label for="cs-profile-select" class="cs-label-with-icon">
-          <i class="fa-solid fa-users"></i>
-          <b>Profiles</b>
-        </label>
-        <small>Save and load different configurations for various chats or characters.</small>
-        <div class="cs-flex-container">
-          <select id="cs-profile-select" class="text_pole" style="flex-grow: 1;" title="Select a saved profile to load it."></select>
-          <button id="cs-profile-delete" class="menu_button interactable cs-button-danger" title="Delete Selected Profile">Delete</button>
-        </div>
-        <div class="cs-flex-container">
-          <input id="cs-profile-name" class="text_pole" type="text" placeholder="Enter profile name..." style="flex-grow: 1;" title="Type a new name to create a new profile, or use an existing name to overwrite.">
-          <button id="cs-profile-save" class="menu_button interactable" title="Save changes to the current profile.">Save</button>
-        </div>
-        <div class="cs-flex-container">
-          <button id="cs-profile-import" class="menu_button interactable" title="Import a profile from a .json file.">Import Profile</button>
-          <button id="cs-profile-export" class="menu_button interactable" title="Export the current profile to a .json file.">Export Profile</button>
-          <input type="file" id="cs-profile-file-input" style="display: none;" accept=".json">
+<div id="costume-switcher-settings" class="extension_container cs-theme">
+  <div class="cs-shell">
+    <section class="cs-card cs-header-card">
+      <div class="cs-header-intro">
+        <h2 class="cs-title">Costume Switcher</h2>
+        <p class="cs-subtitle">Automatically match your avatar to the active character with rich controls for scene detection, performance tuning, and live testing.</p>
+        <div class="cs-pill-row" aria-hidden="true">
+          <span class="cs-pill">Scene aware</span>
+          <span class="cs-pill">Live tester</span>
+          <span class="cs-pill">Profiles</span>
+          <span class="cs-pill">Advanced rules</span>
         </div>
       </div>
-
-      <div class="cs-block">
-        <label for="cs-preset-select" class="cs-label-with-icon">
-            <i class="fa-solid fa-wand-magic-sparkles"></i>
-            <b>Preset Configurations</b>
-        </label>
-        <small id="cs-preset-description">Load a recommended configuration into the current profile.</small>
-        <div class="cs-flex-container">
-            <select id="cs-preset-select" class="text_pole" style="flex-grow: 1;"></select>
-            <button id="cs-preset-load" class="menu_button interactable" title="Apply the selected preset's settings to your currently active profile.">Load Preset</button>
+      <label class="cs-master-toggle">
+        <input id="cs-enable" type="checkbox" />
+        <span class="cs-switch-thumb" aria-hidden="true"></span>
+        <div class="cs-switch-copy">
+          <strong>Enable Costume Switching</strong>
+          <small>Master toggle to pause detection without changing your settings.</small>
         </div>
-    </div>
+      </label>
+    </section>
 
-
-      <div class="cs-block">
-        <label for="cs-focus-lock-select" class="cs-label-with-icon">
-          <i class="fa-solid fa-lock"></i>
-          <b>Manual Focus Lock</b>
-        </label>
-        <small>Force the costume to a specific character, overriding all automatic detection.</small>
-        <div class="cs-flex-container">
-            <select id="cs-focus-lock-select" class="text_pole" style="flex-grow: 1;" title="Select a character from your patterns list."></select>
-            <button id="cs-focus-lock-toggle" class="menu_button interactable" title="Lock the costume to the selected character, or unlock it.">Lock</button>
-        </div>
-      </div>
-
-      <div class="cs-block">
-        <input id="cs-enable" type="checkbox" title="Master toggle for the extension. Uncheck to disable all functionality."/>
-        <label for="cs-enable"><b>Enable Costume Switch</b></label>
-      </div>
-
-      <div class="cs-block">
-        <label for="cs-patterns" class="cs-label-with-icon">
-          <i class="fa-solid fa-address-card"></i>
-          <b>Character Patterns</b>
-        </label>
-        <textarea id="cs-patterns" class="text_pole" rows="3" placeholder="Character One&#10;Character Two&#10;/Regular Expression/" title="Enter character names or /regex/, one per line."></textarea>
-        <small class="cs-tip"><b>Tip:</b> List longer names before shorter names that are part of them (e.g., list 'Arthur' before 'Art').</small>
-      </div>
-
-      <div class="cs-block">
-        <label for="cs-default"><b>Default Costume</b></label>
-        <input id="cs-default" class="text_pole" type="text" placeholder="e.g., neutral" title="The costume folder to use when no character is detected. Leave blank for the main avatar."/>
-        <small>The costume folder to use when no character is detected. Leave blank for the main avatar.</small>
-      </div>
-
-      <div class="inline-drawer">
-        <div class="inline-drawer-toggle inline-drawer-header">
-          <b class="cs-label-with-icon"><i class="fa-solid fa-cogs"></i>Advanced Settings</b>
-          <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
-        </div>
-        <div class="inline-drawer-content">
-
-          <div class="cs-block">
-            <label for="cs-ignore-patterns"><b>Ignored Characters</b></label>
-            <textarea id="cs-ignore-patterns" class="text_pole" rows="2" placeholder="Char A&#10;/Narrator/" title="Any character pattern on this list will be ignored during detection."></textarea>
-          </div>
-
-          <div class="cs-block">
-            <label for="cs-veto-patterns"><b>Veto Phrases</b></label>
-            <textarea id="cs-veto-patterns" class="text_pole" rows="2" placeholder="OOC:&#10;(OOC)" title="If any of these phrases or /regex/ are found, the entire message will be ignored."></textarea>
-          </div>
-
-          <div class="cs-block">
-            <label><b>Detection Methods (for Novel Style)</b></label>
-            <small>Enable these for flexible detection in narrative text. Uncheck all for simple `Name: "Dialogue"` style.</small>
-            <div class="cs-detection-methods">
-                <div class="cs-detection-method" title="Finds dialogue tags, like 'Hello,' she said.">
-                    <div><input id="cs-detect-attribution" type="checkbox" /><label for="cs-detect-attribution" class="cs-label-with-icon"><i class="fa-solid fa-quote-left"></i>Detect Attribution</label></div>
-                </div>
-                <div class="cs-detection-method" title="Finds character actions, like He nodded.">
-                    <div><input id="cs-detect-action" type="checkbox" /><label for="cs-detect-action" class="cs-label-with-icon"><i class="fa-solid fa-person-running"></i>Detect Action</label></div>
-                </div>
-                <div class="cs-detection-method" title="Finds when a character is addressed by name within dialogue.">
-                    <div><input id="cs-detect-vocative" type="checkbox" /><label for="cs-detect-vocative" class="cs-label-with-icon"><i class="fa-solid fa-bullhorn"></i>Detect Vocative</label></div>
-                </div>
-                <div class="cs-detection-method" title="Finds ownership, like Her eyes widened or Merlin's staff.">
-                    <div><input id="cs-detect-possessive" type="checkbox" /><label for="cs-detect-possessive" class="cs-label-with-icon"><i class="fa-solid fa-hand-holding"></i>Detect Possessive</label></div>
-                </div>
-                <div class="cs-detection-method" title="EXPERIMENTAL: Tries to figure out who 'he' or 'she' refers to based on the last mentioned character.">
-                    <div><input id="cs-detect-pronoun" type="checkbox" /><label for="cs-detect-pronoun" class="cs-label-with-icon"><i class="fa-solid fa-user-friends"></i>Detect Pronoun</label></div>
-                </div>
-                <div class="cs-detection-method" title="USE WITH CAUTION: Triggers on any mention of a character's name anywhere in the text. Can cause flickering.">
-                    <div><input id="cs-detect-general" type="checkbox" /><label for="cs-detect-general" class="cs-label-with-icon"><i class="fa-solid fa-magnifying-glass"></i>Detect General Mentions</label></div>
-                </div>
+    <div class="cs-layout">
+      <div class="cs-column">
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-users"></i>
+              <div>
+                <h3>Profiles</h3>
+                <p>Organize different configurations for varied chats or characters.</p>
+              </div>
+            </div>
+          </header>
+          <div class="cs-card-body">
+            <div class="cs-toolbar">
+              <select id="cs-profile-select" class="text_pole" title="Select a saved profile to load it."></select>
+              <button id="cs-profile-save" class="menu_button interactable cs-button-primary" title="Save changes to the active profile.">Save</button>
+            </div>
+            <div class="cs-toolbar">
+              <input id="cs-profile-name" class="text_pole" type="text" placeholder="Enter a name…" title="Enter a name to rename the active profile or create a new one." />
+              <button id="cs-profile-saveas" class="menu_button interactable" title="Save the active profile's settings under a new name.">Save As</button>
+              <button id="cs-profile-rename" class="menu_button interactable" title="Rename the active profile to the entered name.">Rename</button>
+            </div>
+            <p class="cs-helper-text">Use the name field above to create or rename profiles. Leave it blank when simply saving edits to the current profile.</p>
+            <div class="cs-toolbar cs-toolbar--wrap">
+              <button id="cs-profile-new" class="menu_button interactable" title="Create a fresh profile using default settings.">New (Defaults)</button>
+              <button id="cs-profile-duplicate" class="menu_button interactable" title="Duplicate the active profile to a new name.">Duplicate Current</button>
+              <button id="cs-profile-delete" class="menu_button interactable cs-button-danger" title="Delete the active profile.">Delete</button>
+            </div>
+            <div class="cs-toolbar cs-toolbar--wrap">
+              <button id="cs-profile-import" class="menu_button interactable" title="Import a profile from a .json file.">Import Profile</button>
+              <button id="cs-profile-export" class="menu_button interactable" title="Export the current profile to a .json file.">Export Profile</button>
+              <input type="file" id="cs-profile-file-input" accept=".json" hidden />
             </div>
           </div>
-          
-          <div class="cs-block">
-              <label class="cs-label-with-icon"><i class="fa-solid fa-users-viewfinder"></i><b>Scene Awareness</b></label>
-              <div class="cs-detection-method">
-                  <div title="Improves group scenario accuracy by tracking recently active characters."><input id="cs-scene-roster-enable" type="checkbox" /><label for="cs-scene-roster-enable">Enable Scene Roster</label></div>
+        </section>
+
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-address-card"></i>
+              <div>
+                <h3>Character Patterns</h3>
+                <p>Teach the switcher which characters to watch for.</p>
               </div>
-              <div class="inline-group cs-flex-container">
+            </div>
+          </header>
+          <div class="cs-card-body cs-card-body--stacked">
+            <div class="cs-field">
+              <label for="cs-patterns">Active Characters</label>
+              <textarea id="cs-patterns" class="text_pole" rows="3" placeholder="Character One&#10;Character Two&#10;/Regular Expression/" title="Enter character names or /regex/, one per line."></textarea>
+              <small class="cs-tip"><strong>Tip:</strong> List longer names before shorter ones that are part of them (e.g., put “Arthur” before “Art”).</small>
+            </div>
+            <div class="cs-field">
+              <label for="cs-ignore-patterns">Ignored Characters</label>
+              <textarea id="cs-ignore-patterns" class="text_pole" rows="2" placeholder="Char A&#10;/Narrator/" title="Any character pattern on this list will be ignored during detection."></textarea>
+            </div>
+            <div class="cs-field">
+              <label for="cs-veto-patterns">Veto Phrases</label>
+              <textarea id="cs-veto-patterns" class="text_pole" rows="2" placeholder="OOC:&#10;(OOC)" title="If any of these phrases or /regex/ are found, the entire message will be ignored."></textarea>
+            </div>
+          </div>
+        </section>
+
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-wand-magic-sparkles"></i>
+              <div>
+                <h3>Presets & Focus</h3>
+                <p>Kickstart a profile with curated defaults or lock to a specific character.</p>
+              </div>
+            </div>
+          </header>
+          <div class="cs-card-body cs-card-body--stacked">
+            <div class="cs-toolbar cs-toolbar--wrap">
+              <label class="cs-inline-label" for="cs-preset-select">Preset Configurations</label>
+              <select id="cs-preset-select" class="text_pole" title="Choose a preset to load into the current profile."></select>
+              <button id="cs-preset-load" class="menu_button interactable" title="Apply the selected preset's settings to your currently active profile.">Load Preset</button>
+            </div>
+            <p id="cs-preset-description" class="cs-helper-text">Load a recommended configuration into the current profile.</p>
+            <div class="cs-field-group">
+              <label for="cs-default">Default Costume</label>
+              <input id="cs-default" class="text_pole" type="text" placeholder="e.g., neutral" title="The costume folder to use when no character is detected. Leave blank for the main avatar." />
+              <small>The costume folder to use when no character is detected. Leave blank for the main avatar.</small>
+            </div>
+            <div class="cs-field-group">
+              <label for="cs-focus-lock-select">Manual Focus Lock</label>
+              <div class="cs-toolbar">
+                <select id="cs-focus-lock-select" class="text_pole" title="Select a character from your patterns list."></select>
+                <button id="cs-focus-lock-toggle" class="menu_button interactable" title="Lock the costume to the selected character, or unlock it.">Lock</button>
+              </div>
+              <small>Force the costume to a specific character, overriding automatic detection.</small>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="cs-column">
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-sliders"></i>
+              <div>
+                <h3>Detection Strategy</h3>
+                <p>Fine-tune how the extension interprets each scene.</p>
+              </div>
+            </div>
+          </header>
+          <div class="cs-card-body cs-card-body--stacked">
+            <div class="cs-detection-grid">
+              <label class="cs-toggle" title="Finds dialogue tags, like 'Hello,' she said.">
+                <input id="cs-detect-attribution" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-quote-left"></i>Detect Attribution</span>
+              </label>
+              <label class="cs-toggle" title="Finds character actions, like He nodded.">
+                <input id="cs-detect-action" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-person-running"></i>Detect Action</span>
+              </label>
+              <label class="cs-toggle" title="Finds when a character is addressed by name within dialogue.">
+                <input id="cs-detect-vocative" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-bullhorn"></i>Detect Vocative</span>
+              </label>
+              <label class="cs-toggle" title="Finds ownership, like Her eyes widened or Merlin's staff.">
+                <input id="cs-detect-possessive" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-hand-holding"></i>Detect Possessive</span>
+              </label>
+              <label class="cs-toggle" title="EXPERIMENTAL: Resolves pronouns based on the last mentioned character.">
+                <input id="cs-detect-pronoun" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-user-friends"></i>Detect Pronoun</span>
+              </label>
+              <label class="cs-toggle" title="USE WITH CAUTION: Triggers on any mention of a character's name anywhere in the text. Can cause flickering.">
+                <input id="cs-detect-general" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Mentions</span>
+              </label>
+            </div>
+            <div class="cs-field-group">
+              <label class="cs-inline-label" for="cs-scene-roster-enable">Scene Awareness</label>
+              <label class="cs-toggle cs-toggle--inline" title="Improves group scenario accuracy by tracking recently active characters.">
+                <input id="cs-scene-roster-enable" type="checkbox" />
+                <span class="cs-toggle-indicator"></span>
+                <span>Enable Scene Roster</span>
+              </label>
+              <div class="cs-number-field">
                 <label for="cs-scene-roster-ttl">Scene Roster TTL (messages)</label>
-                <input id="cs-scene-roster-ttl" class="text_pole" type="number" min="1" title="How many messages a character stays 'active' in the scene without being mentioned."/>
+                <input id="cs-scene-roster-ttl" class="text_pole" type="number" min="1" title="How many messages a character stays 'active' in the scene without being mentioned." />
               </div>
+            </div>
+            <div class="cs-field-group">
+              <label for="cs-attribution-verbs">Attribution Verbs</label>
+              <small>Comma-separated list used by the attribution detector.</small>
+              <textarea id="cs-attribution-verbs" class="text_pole" rows="3"></textarea>
+            </div>
+            <div class="cs-field-group">
+              <label for="cs-action-verbs">Action Verbs</label>
+              <small>Comma-separated list used by the action detector.</small>
+              <textarea id="cs-action-verbs" class="text_pole" rows="3"></textarea>
+            </div>
           </div>
+        </section>
 
-          <div class="cs-block">
-            <label for="cs-attribution-verbs"><b>Attribution Verbs</b></label>
-            <small>Comma-separated list of verbs used for `Detect Attribution`.</small>
-            <textarea id="cs-attribution-verbs" class="text_pole" rows="4"></textarea>
-          </div>
-
-          <div class="cs-block">
-            <label for="cs-action-verbs"><b>Action Verbs</b></label>
-            <small>Comma-separated list of verbs used for `Detect Action`.</small>
-            <textarea id="cs-action-verbs" class="text_pole" rows="4"></textarea>
-          </div>
-
-          <div class="cs-block">
-            <label class="cs-label-with-icon"><i class="fa-solid fa-tachometer-alt"></i><b>Performance Tuning</b></label>
-            <div class="inline-group cs-flex-container">
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-gauge-high"></i>
+              <div>
+                <h3>Performance & Bias</h3>
+                <p>Control responsiveness and tie-breaking behaviour.</p>
+              </div>
+            </div>
+          </header>
+          <div class="cs-card-body cs-card-body--stacked">
+            <div class="cs-grid">
               <label for="cs-global-cooldown">Global Cooldown (ms)</label>
-              <input id="cs-global-cooldown" class="text_pole" type="number" min="0" title="Minimum time between ANY two switches to prevent flickering."/>
-            </div>
-            <div class="inline-group cs-flex-container">
+              <input id="cs-global-cooldown" class="text_pole" type="number" min="0" title="Minimum time between ANY two switches to prevent flickering." />
               <label for="cs-repeat-suppress">Repeat Suppression (ms)</label>
-              <input id="cs-repeat-suppress" class="text_pole" type="number" min="0" title="Minimum time before the SAME character can trigger another switch."/>
-            </div>
-            <div class="inline-group cs-flex-container">
+              <input id="cs-repeat-suppress" class="text_pole" type="number" min="0" title="Minimum time before the SAME character can trigger another switch." />
+              <label for="cs-per-trigger-cooldown">Per-Trigger Cooldown (ms)</label>
+              <input id="cs-per-trigger-cooldown" class="text_pole" type="number" min="0" title="How long to wait before the same detection type can fire again." />
+              <label for="cs-failed-trigger-cooldown">Failed Trigger Cooldown (ms)</label>
+              <input id="cs-failed-trigger-cooldown" class="text_pole" type="number" min="0" title="Backoff delay after a failed switch attempt before trying again." />
+              <label for="cs-max-buffer-chars">Max Buffer Size (chars)</label>
+              <input id="cs-max-buffer-chars" class="text_pole" type="number" min="0" title="Maximum characters of recent text to keep while scanning the stream." />
               <label for="cs-token-process-threshold">Token Process Threshold (chars)</label>
-              <input id="cs-token-process-threshold" class="text_pole" type="number" min="0" title="How many characters to wait before checking. Lower is more reactive but uses more CPU."/>
+              <input id="cs-token-process-threshold" class="text_pole" type="number" min="0" title="How many characters to wait before checking. Lower is more reactive but uses more CPU." />
             </div>
-            <div class="inline-group" style="margin-top: 15px;">
-              <label for="cs-detection-bias">Detection Bias (<span id="cs-detection-bias-value">0</span>)</label>
-              <input id="cs-detection-bias" type="range" min="-200" max="200" value="0" class="cs-slider" title="Balances accuracy. Positive values favor action/dialogue tags. Negative values favor the most recently mentioned character."/>
+            <div class="cs-slider-field">
+              <label for="cs-detection-bias">Detection Bias <span id="cs-detection-bias-value">0</span></label>
+              <input id="cs-detection-bias" type="range" min="-200" max="200" value="0" class="cs-slider" title="Balances accuracy. Positive values favor action/dialogue tags. Negative values favor the most recently mentioned character." />
             </div>
           </div>
+        </section>
 
-          <div class="cs-block">
-            <label for="cs-mappings"><b>Costume Mappings</b></label>
-            <small>Map a detected name to a specific costume folder.</small>
-            <table id="cs-mappings" class="text_pole" style="margin-top: 10px;">
-              <thead><tr><th>Character Name</th><th>Costume Folder</th><th>Action</th></tr></thead>
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-layer-group"></i>
+              <div>
+                <h3>Costume Mappings</h3>
+                <p>Map detected names to specific costume folders.</p>
+              </div>
+            </div>
+          </header>
+          <div class="cs-card-body">
+            <table id="cs-mappings" class="text_pole">
+              <thead>
+                <tr><th>Character Name</th><th>Costume Folder</th><th>Action</th></tr>
+              </thead>
               <tbody id="cs-mappings-tbody"></tbody>
             </table>
-            <button id="cs-mapping-add" class="menu_button interactable">Add Mapping</button>
+            <button id="cs-mapping-add" class="menu_button interactable" style="margin-top: 12px;">Add Mapping</button>
           </div>
-          
-          <div class="cs-block">
-            <label class="cs-label-with-icon"><i class="fa-solid fa-chart-simple"></i><b>Scene Statistics</b></label>
-            <small>Analyze character mentions in the last generated message. Results appear in the browser console (F12).</small>
-            <button id="cs-stats-log" class="menu_button interactable" style="margin-top: 10px;">Log Last Scene Stats</button>
-          </div>
+        </section>
 
-          <div class="cs-block">
-            <label class="cs-label-with-icon"><i class="fa-solid fa-vial"></i><b>Live Pattern Tester</b></label>
-            <small>Paste text to see detections based on your current unsaved settings.</small>
-            <textarea id="cs-regex-test-input" class="text_pole" rows="4" placeholder="Paste a message here..." style="margin-top: 10px;"></textarea>
-            <div class="cs-flex-container cs-tester-actions">
-                <button id="cs-regex-test-button" class="menu_button interactable">Test Pattern</button>
-                <button id="cs-regex-test-copy" class="menu_button interactable" disabled title="Copy the latest live tester report to your clipboard.">Copy Report</button>
+        <section class="cs-card">
+          <header class="cs-card-header">
+            <div class="cs-card-title">
+              <i class="fa-solid fa-vial"></i>
+              <div>
+                <h3>Live Pattern Tester</h3>
+                <p>Paste text to see detections with your current settings.</p>
+              </div>
             </div>
-
-            <div class="cs-flex-container">
-                <b>Veto Status:</b> <span id="cs-test-veto-result" class="cs-tester-list-placeholder">N/A</span>
+          </header>
+          <div class="cs-card-body cs-card-body--stacked">
+            <textarea id="cs-regex-test-input" class="text_pole" rows="4" placeholder="Paste a message here…"></textarea>
+            <div class="cs-toolbar cs-toolbar--wrap">
+              <button id="cs-regex-test-button" class="menu_button interactable">Test Pattern</button>
+              <button id="cs-regex-test-copy" class="menu_button interactable" disabled title="Copy the latest live tester report to your clipboard.">Copy Report</button>
             </div>
-
+            <div class="cs-tester-meta">
+              <span class="cs-meta-label">Veto Status:</span>
+              <span id="cs-test-veto-result" class="cs-tester-list-placeholder">N/A</span>
+            </div>
             <div id="cs-regex-test-output-container" class="text_pole cs-tester-output-container">
               <div class="cs-tester-col cs-tester-col--divider">
-                <div class="cs-tester-title">All Detections (in order):</div>
+                <div class="cs-tester-title">All Detections (in order)</div>
                 <ul id="cs-test-all-detections" class="cs-tester-list">
                   <li class="cs-tester-list-placeholder">Results will appear here.</li>
                 </ul>
               </div>
               <div class="cs-tester-col">
-                <div class="cs-tester-title">Live Switch Decisions:</div>
+                <div class="cs-tester-title">Live Switch Decisions</div>
                 <ul id="cs-test-winner-list" class="cs-tester-list">
                   <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
                 </ul>
               </div>
             </div>
           </div>
-          
-          <div class="cs-block">
-            <input id="cs-debug" type="checkbox" title="Logs detailed decision-making to the browser console (F12) for troubleshooting."/>
-            <label for="cs-debug"><b>Enable Debug Logging</b></label>
-          </div>
+        </section>
 
-        </div>
+        <section class="cs-card cs-card--compact">
+          <label class="cs-toggle cs-toggle--inline" title="Logs detailed decision-making to the browser console (F12) for troubleshooting.">
+            <input id="cs-debug" type="checkbox" />
+            <span class="cs-toggle-indicator"></span>
+            <span><strong>Enable Debug Logging</strong></span>
+          </label>
+        </section>
       </div>
+    </div>
 
-      <div class="cs-flex-container">
-        <button id="cs-save" class="menu_button interactable">Save Current Profile</button>
+    <div class="cs-footer">
+      <div class="cs-toolbar cs-toolbar--wrap">
+        <button id="cs-save" class="menu_button interactable cs-button-primary">Save Current Profile</button>
         <button id="cs-reset" class="menu_button interactable" title="Switch back to your default costume, or the main avatar if none is set.">Manual Reset</button>
       </div>
-
       <div id="cs-status" class="cs-status-message" aria-live="polite">
         <i class="fa-solid fa-circle-info"></i>
         <span class="cs-status-text">Ready</span>

--- a/style.css
+++ b/style.css
@@ -11,16 +11,27 @@
   --surface-contrast: var(--bg0);
   --text-muted: var(--text-color-soft);
   --text-subtle: var(--text-color-soft-extra, rgba(255, 255, 255, 0.6));
+}
+
+#costume-switcher-settings.cs-theme .inline-drawer {
+  margin: 0;
+}
+
+#costume-switcher-settings.cs-theme .inline-drawer-content {
   padding: 18px;
   border-radius: 20px;
   background: linear-gradient(165deg, rgba(108, 92, 231, 0.12), rgba(46, 213, 115, 0.08)) var(--surface);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
-  display: block;
   color: var(--text-color);
   font-family: "Inter", "Roboto", sans-serif;
+  margin-top: 10px;
 }
 
-.cs-shell {
+#costume-switcher-settings.cs-theme .inline-drawer-toggle {
+  border-bottom: none;
+}
+
+#costume-switcher-settings.cs-theme .cs-shell {
   display: flex;
   flex-direction: column;
   gap: 22px;
@@ -28,7 +39,7 @@
   margin: 0 auto;
 }
 
-.cs-card {
+#costume-switcher-settings.cs-theme .cs-card {
   background: rgba(0, 0, 0, 0.18);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.18));
   border-radius: var(--card-radius);
@@ -42,7 +53,7 @@
   overflow: hidden;
 }
 
-.cs-card::before {
+#costume-switcher-settings.cs-theme .cs-card::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -51,51 +62,51 @@
   pointer-events: none;
 }
 
-.cs-card-header {
+#costume-switcher-settings.cs-theme .cs-card-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
 }
 
-.cs-card-title {
+#costume-switcher-settings.cs-theme .cs-card-title {
   display: flex;
   align-items: flex-start;
   gap: 14px;
 }
 
-.cs-card-title i {
+#costume-switcher-settings.cs-theme .cs-card-title i {
   font-size: 1.4em;
   color: var(--accent);
   margin-top: 2px;
 }
 
-.cs-card-title h3 {
+#costume-switcher-settings.cs-theme .cs-card-title h3 {
   font-size: 1.15rem;
   margin: 0;
 }
 
-.cs-card-title p {
+#costume-switcher-settings.cs-theme .cs-card-title p {
   margin: 4px 0 0 0;
   color: var(--text-muted);
   font-size: 0.92rem;
   line-height: 1.4;
 }
 
-.cs-card-body {
+#costume-switcher-settings.cs-theme .cs-card-body {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.cs-card-body--stacked {
+#costume-switcher-settings.cs-theme .cs-card-body--stacked {
   gap: 20px;
 }
 
-.cs-card--compact {
+#costume-switcher-settings.cs-theme .cs-card--compact {
   padding: 16px 22px;
 }
 
-.cs-header-card {
+#costume-switcher-settings.cs-theme .cs-header-card {
   flex-direction: row;
   align-items: center;
   gap: 28px;
@@ -103,37 +114,37 @@
   color: #fff;
 }
 
-.cs-header-card::before {
+#costume-switcher-settings.cs-theme .cs-header-card::before {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-.cs-header-intro {
+#costume-switcher-settings.cs-theme .cs-header-intro {
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.cs-title {
+#costume-switcher-settings.cs-theme .cs-title {
   margin: 0;
   font-size: 1.8rem;
   font-weight: 700;
 }
 
-.cs-subtitle {
+#costume-switcher-settings.cs-theme .cs-subtitle {
   margin: 0;
   font-size: 1rem;
   line-height: 1.5;
   color: rgba(255, 255, 255, 0.75);
 }
 
-.cs-pill-row {
+#costume-switcher-settings.cs-theme .cs-pill-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.cs-pill {
+#costume-switcher-settings.cs-theme .cs-pill {
   display: inline-flex;
   align-items: center;
   padding: 4px 12px;
@@ -145,7 +156,7 @@
   color: rgba(255, 255, 255, 0.65);
 }
 
-.cs-master-toggle {
+#costume-switcher-settings.cs-theme .cs-master-toggle {
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
@@ -157,7 +168,7 @@
   cursor: pointer;
 }
 
-.cs-master-toggle input {
+#costume-switcher-settings.cs-theme .cs-master-toggle input {
   appearance: none;
   width: 46px;
   height: 26px;
@@ -168,7 +179,7 @@
   border: 1px solid rgba(255, 255, 255, 0.4);
 }
 
-.cs-master-toggle input::after {
+#costume-switcher-settings.cs-theme .cs-master-toggle input::after {
   content: "";
   position: absolute;
   inset: 3px;
@@ -181,95 +192,95 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
 }
 
-.cs-master-toggle input:checked {
+#costume-switcher-settings.cs-theme .cs-master-toggle input:checked {
   background: var(--accent);
   border-color: var(--accent);
 }
 
-.cs-master-toggle input:checked::after {
+#costume-switcher-settings.cs-theme .cs-master-toggle input:checked::after {
   transform: translateX(20px);
 }
 
-.cs-master-toggle .cs-switch-copy strong {
+#costume-switcher-settings.cs-theme .cs-master-toggle .cs-switch-copy strong {
   font-size: 1rem;
   display: block;
   margin-bottom: 2px;
 }
 
-.cs-master-toggle .cs-switch-copy small {
+#costume-switcher-settings.cs-theme .cs-master-toggle .cs-switch-copy small {
   color: rgba(255, 255, 255, 0.7);
   display: block;
   line-height: 1.4;
 }
 
-.cs-layout {
+#costume-switcher-settings.cs-theme .cs-layout {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   gap: 22px;
 }
 
-.cs-toolbar {
+#costume-switcher-settings.cs-theme .cs-toolbar {
   display: flex;
   gap: 12px;
   align-items: center;
 }
 
-.cs-toolbar--wrap {
+#costume-switcher-settings.cs-theme .cs-toolbar--wrap {
   flex-wrap: wrap;
 }
 
-.cs-helper-text,
-.cs-card small {
+#costume-switcher-settings.cs-theme .cs-helper-text,
+#costume-switcher-settings.cs-theme .cs-card small {
   color: var(--text-muted);
   font-size: 0.85rem;
   line-height: 1.5;
 }
 
-.cs-field,
-.cs-field-group {
+#costume-switcher-settings.cs-theme .cs-field,
+#costume-switcher-settings.cs-theme .cs-field-group {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.cs-inline-label {
+#costume-switcher-settings.cs-theme .cs-inline-label {
   font-weight: 600;
 }
 
-.cs-grid {
+#costume-switcher-settings.cs-theme .cs-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 14px 18px;
   align-items: center;
 }
 
-.cs-grid > label {
+#costume-switcher-settings.cs-theme .cs-grid > label {
   font-weight: 600;
   color: var(--text-muted);
 }
 
-.cs-slider-field {
+#costume-switcher-settings.cs-theme .cs-slider-field {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.cs-slider-field label {
+#costume-switcher-settings.cs-theme .cs-slider-field label {
   font-weight: 600;
   color: var(--text-muted);
 }
 
-.cs-slider {
+#costume-switcher-settings.cs-theme .cs-slider {
   width: 100%;
 }
 
-.cs-detection-grid {
+#costume-switcher-settings.cs-theme .cs-detection-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 12px;
 }
 
-.cs-toggle {
+#costume-switcher-settings.cs-theme .cs-toggle {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -282,12 +293,12 @@
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
-.cs-toggle:hover {
+#costume-switcher-settings.cs-theme .cs-toggle:hover {
   border-color: var(--accent);
   background: rgba(255, 255, 255, 0.07);
 }
 
-.cs-toggle input {
+#costume-switcher-settings.cs-theme .cs-toggle input {
   appearance: none;
   width: 18px;
   height: 18px;
@@ -298,7 +309,7 @@
   transition: all 0.2s ease;
 }
 
-.cs-toggle input::after {
+#costume-switcher-settings.cs-theme .cs-toggle input::after {
   content: "";
   width: 8px;
   height: 8px;
@@ -308,33 +319,33 @@
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
-.cs-toggle input:checked {
+#costume-switcher-settings.cs-theme .cs-toggle input:checked {
   border-color: var(--accent);
   background: var(--accent);
 }
 
-.cs-toggle input:checked::after {
+#costume-switcher-settings.cs-theme .cs-toggle input:checked::after {
   transform: scale(1);
   background: #fff;
 }
 
-.cs-toggle span i {
+#costume-switcher-settings.cs-theme .cs-toggle span i {
   color: var(--accent);
   margin-right: 6px;
 }
 
-.cs-toggle--inline {
+#costume-switcher-settings.cs-theme .cs-toggle--inline {
   padding: 8px 12px;
 }
 
-.cs-number-field {
+#costume-switcher-settings.cs-theme .cs-number-field {
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding-top: 4px;
 }
 
-.cs-tester-meta {
+#costume-switcher-settings.cs-theme .cs-tester-meta {
   display: flex;
   gap: 8px;
   font-size: 0.9rem;
@@ -342,12 +353,12 @@
   align-items: center;
 }
 
-.cs-meta-label {
+#costume-switcher-settings.cs-theme .cs-meta-label {
   font-weight: 600;
   color: var(--text-color);
 }
 
-.cs-tester-output-container {
+#costume-switcher-settings.cs-theme .cs-tester-output-container {
   margin-top: 6px;
   border-radius: 14px;
   background: rgba(0, 0, 0, 0.3);
@@ -357,23 +368,23 @@
   overflow: hidden;
 }
 
-.cs-tester-col {
+#costume-switcher-settings.cs-theme .cs-tester-col {
   padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.cs-tester-col--divider {
+#costume-switcher-settings.cs-theme .cs-tester-col--divider {
   border-right: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.cs-tester-title {
+#costume-switcher-settings.cs-theme .cs-tester-title {
   font-weight: 600;
   font-size: 0.95rem;
 }
 
-.cs-tester-list {
+#costume-switcher-settings.cs-theme .cs-tester-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -384,7 +395,7 @@
   overflow-y: auto;
 }
 
-.cs-tester-list li {
+#costume-switcher-settings.cs-theme .cs-tester-list li {
   padding: 6px 10px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
@@ -392,12 +403,12 @@
   font-size: 0.9rem;
 }
 
-.cs-tester-list-placeholder {
+#costume-switcher-settings.cs-theme .cs-tester-list-placeholder {
   color: var(--text-muted);
   font-style: italic;
 }
 
-#cs-mappings {
+#costume-switcher-settings.cs-theme #cs-mappings {
   width: 100%;
   border-collapse: collapse;
   background: rgba(255, 255, 255, 0.02);
@@ -405,30 +416,30 @@
   overflow: hidden;
 }
 
-#cs-mappings thead {
+#costume-switcher-settings.cs-theme #cs-mappings thead {
   background: rgba(255, 255, 255, 0.06);
   color: var(--text-color);
 }
 
-#cs-mappings th,
-#cs-mappings td {
+#costume-switcher-settings.cs-theme #cs-mappings th,
+#costume-switcher-settings.cs-theme #cs-mappings td {
   padding: 10px 12px;
   text-align: left;
   font-size: 0.92rem;
 }
 
-#cs-mappings tbody tr:nth-child(even) {
+#costume-switcher-settings.cs-theme #cs-mappings tbody tr:nth-child(even) {
   background: rgba(255, 255, 255, 0.03);
 }
 
-#cs-mappings .map-name,
-#cs-mappings .map-folder {
+#costume-switcher-settings.cs-theme #cs-mappings .map-name,
+#costume-switcher-settings.cs-theme #cs-mappings .map-folder {
   width: 100%;
   padding: 6px 8px;
 }
 
-.menu_button,
-.text_pole {
+#costume-switcher-settings.cs-theme .menu_button,
+#costume-switcher-settings.cs-theme .text_pole {
   border-radius: 10px !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   background: rgba(0, 0, 0, 0.35);
@@ -436,51 +447,51 @@
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
-.text_pole:focus {
+#costume-switcher-settings.cs-theme .text_pole:focus {
   border-color: var(--accent) !important;
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-.menu_button:hover,
-.text_pole:hover {
+#costume-switcher-settings.cs-theme .menu_button:hover,
+#costume-switcher-settings.cs-theme .text_pole:hover {
   border-color: var(--accent) !important;
 }
 
-.menu_button {
+#costume-switcher-settings.cs-theme .menu_button {
   padding: 8px 16px;
   font-weight: 600;
   background: rgba(255, 255, 255, 0.08);
 }
 
-.menu_button:hover {
+#costume-switcher-settings.cs-theme .menu_button:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
 }
 
-.cs-button-primary {
+#costume-switcher-settings.cs-theme .cs-button-primary {
   background: var(--accent) !important;
   color: #fff !important;
   border-color: transparent !important;
 }
 
-.cs-button-primary:hover {
+#costume-switcher-settings.cs-theme .cs-button-primary:hover {
   box-shadow: 0 10px 22px var(--accent-strong);
 }
 
-.cs-button-danger {
+#costume-switcher-settings.cs-theme .cs-button-danger {
   background: var(--danger) !important;
   color: #fff !important;
   border-color: transparent !important;
 }
 
-.cs-footer {
+#costume-switcher-settings.cs-theme .cs-footer {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.cs-status-message,
-.cs-error-message {
+#costume-switcher-settings.cs-theme .cs-status-message,
+#costume-switcher-settings.cs-theme .cs-error-message {
   margin: 0;
   padding: 14px 16px;
   border-radius: 12px;
@@ -492,61 +503,61 @@
   background: rgba(255, 255, 255, 0.04);
 }
 
-.cs-status-message i,
-.cs-error-message i {
+#costume-switcher-settings.cs-theme .cs-status-message i,
+#costume-switcher-settings.cs-theme .cs-error-message i {
   font-size: 1.1rem;
 }
 
-.cs-status-text {
+#costume-switcher-settings.cs-theme .cs-status-text {
   flex: 1;
 }
 
-.cs-error-message {
+#costume-switcher-settings.cs-theme .cs-error-message {
   border-color: rgba(231, 76, 60, 0.6);
   background: rgba(231, 76, 60, 0.15);
   color: #ffd7d2;
 }
 
-.cs-error-message[hidden] {
+#costume-switcher-settings.cs-theme .cs-error-message[hidden] {
   display: none;
 }
 
 @media (max-width: 768px) {
-  #costume-switcher-settings.cs-theme {
+  #costume-switcher-settings.cs-theme .inline-drawer-content {
     padding: 14px;
   }
 
-  .cs-card {
+  #costume-switcher-settings.cs-theme .cs-card {
     padding: 18px;
   }
 
-  .cs-master-toggle {
+  #costume-switcher-settings.cs-theme .cs-master-toggle {
     grid-template-columns: 1fr;
   }
 
-  .cs-master-toggle input {
+  #costume-switcher-settings.cs-theme .cs-master-toggle input {
     justify-self: flex-start;
   }
 }
 
-.cs-toggle-indicator {
+#costume-switcher-settings.cs-theme .cs-toggle-indicator {
   display: none;
 }
-.cs-switch-thumb { display: none; }
+#costume-switcher-settings.cs-theme .cs-switch-thumb { display: none; }
 
-.cs-status-message.is-success {
+#costume-switcher-settings.cs-theme .cs-status-message.is-success {
   border-color: rgba(46, 213, 115, 0.6);
   background: rgba(46, 213, 115, 0.16);
   color: #d4ffe5;
 }
 
-.cs-status-message.is-error {
+#costume-switcher-settings.cs-theme .cs-status-message.is-error {
   border-color: rgba(231, 76, 60, 0.6);
   background: rgba(231, 76, 60, 0.18);
   color: #ffd7d2;
 }
 
-#cs-regex-test-copy[disabled] {
+#costume-switcher-settings.cs-theme #cs-regex-test-copy[disabled] {
   opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;

--- a/style.css
+++ b/style.css
@@ -1,260 +1,554 @@
-/* --- Global & Theme --- */
-#costume-switcher-settings {
-  padding: 10px;
+#costume-switcher-settings.cs-theme {
+  --card-radius: 14px;
+  --card-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  --card-shadow-soft: 0 6px 18px rgba(0, 0, 0, 0.12);
+  --accent: var(--primary-color, #6c5ce7);
+  --accent-soft: rgba(108, 92, 231, 0.15);
+  --accent-strong: rgba(108, 92, 231, 0.35);
+  --danger: var(--red, #e74c3c);
+  --surface: var(--bg1);
+  --surface-soft: var(--bg2);
+  --surface-contrast: var(--bg0);
+  --text-muted: var(--text-color-soft);
+  --text-subtle: var(--text-color-soft-extra, rgba(255, 255, 255, 0.6));
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(165deg, rgba(108, 92, 231, 0.12), rgba(46, 213, 115, 0.08)) var(--surface);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  display: block;
+  color: var(--text-color);
+  font-family: "Inter", "Roboto", sans-serif;
+}
+
+.cs-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.cs-card {
+  background: rgba(0, 0, 0, 0.18);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.18));
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--card-shadow-soft);
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.cs-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  pointer-events: none;
+}
+
+.cs-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.cs-card-title {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.cs-card-title i {
+  font-size: 1.4em;
+  color: var(--accent);
+  margin-top: 2px;
+}
+
+.cs-card-title h3 {
+  font-size: 1.15rem;
+  margin: 0;
+}
+
+.cs-card-title p {
+  margin: 4px 0 0 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.cs-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cs-card-body--stacked {
+  gap: 20px;
+}
+
+.cs-card--compact {
+  padding: 16px 22px;
+}
+
+.cs-header-card {
+  flex-direction: row;
+  align-items: center;
+  gap: 28px;
+  background: linear-gradient(135deg, rgba(108, 92, 231, 0.26), rgba(46, 213, 115, 0.18));
+  color: #fff;
+}
+
+.cs-header-card::before {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.cs-header-intro {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cs-title {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.cs-subtitle {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.cs-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cs-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.cs-master-toggle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+}
+
+.cs-master-toggle input {
+  appearance: none;
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  position: relative;
+  transition: background 0.25s ease;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.cs-master-toggle input::after {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transform: translateX(0);
+  transition: transform 0.25s ease;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+}
+
+.cs-master-toggle input:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.cs-master-toggle input:checked::after {
+  transform: translateX(20px);
+}
+
+.cs-master-toggle .cs-switch-copy strong {
+  font-size: 1rem;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.cs-master-toggle .cs-switch-copy small {
+  color: rgba(255, 255, 255, 0.7);
+  display: block;
+  line-height: 1.4;
+}
+
+.cs-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 22px;
+}
+
+.cs-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.cs-toolbar--wrap {
+  flex-wrap: wrap;
+}
+
+.cs-helper-text,
+.cs-card small {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.cs-field,
+.cs-field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cs-inline-label {
+  font-weight: 600;
+}
+
+.cs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px 18px;
+  align-items: center;
+}
+
+.cs-grid > label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.cs-slider-field {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cs-slider-field label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.cs-slider {
+  width: 100%;
+}
+
+.cs-detection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.cs-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.cs-toggle:hover {
+  border-color: var(--accent);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.cs-toggle input {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  display: grid;
+  place-items: center;
+  transition: all 0.2s ease;
+}
+
+.cs-toggle input::after {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: transparent;
+  transform: scale(0);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.cs-toggle input:checked {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.cs-toggle input:checked::after {
+  transform: scale(1);
+  background: #fff;
+}
+
+.cs-toggle span i {
+  color: var(--accent);
+  margin-right: 6px;
+}
+
+.cs-toggle--inline {
+  padding: 8px 12px;
+}
+
+.cs-number-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.cs-tester-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  align-items: center;
+}
+
+.cs-meta-label {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.cs-tester-output-container {
+  margin-top: 6px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  overflow: hidden;
+}
+
+.cs-tester-col {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cs-tester-col--divider {
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cs-tester-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.cs-tester-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.cs-tester-list li {
+  padding: 6px 10px;
   border-radius: 8px;
-  background-color: var(--bg1);
-  font-family: 'Roboto', sans-serif;
-  --green: #4CAF50;
-  --cs-slider-thumb-color: #51a0de;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+.cs-tester-list-placeholder {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+#cs-mappings {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+#cs-mappings thead {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-color);
+}
+
+#cs-mappings th,
+#cs-mappings td {
+  padding: 10px 12px;
+  text-align: left;
+  font-size: 0.92rem;
+}
+
+#cs-mappings tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+#cs-mappings .map-name,
+#cs-mappings .map-folder {
+  width: 100%;
+  padding: 6px 8px;
+}
+
+.menu_button,
+.text_pole {
+  border-radius: 10px !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text-color);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.text_pole:focus {
+  border-color: var(--accent) !important;
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.menu_button:hover,
+.text_pole:hover {
+  border-color: var(--accent) !important;
+}
+
+.menu_button {
+  padding: 8px 16px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.menu_button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+}
+
+.cs-button-primary {
+  background: var(--accent) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
+
+.cs-button-primary:hover {
+  box-shadow: 0 10px 22px var(--accent-strong);
+}
+
+.cs-button-danger {
+  background: var(--danger) !important;
+  color: #fff !important;
+  border-color: transparent !important;
+}
+
+.cs-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .cs-status-message,
 .cs-error-message {
-  margin-top: 12px;
-  padding: 10px 12px;
-  border-radius: 6px;
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 12px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 0.9em;
-  border: 1px solid var(--border);
-  background-color: var(--bg2);
-  color: var(--text-color);
-}
-
-.cs-status-message.is-error {
-  border-color: var(--red, #dc3545);
-  background-color: rgba(220, 53, 69, 0.12);
-  color: var(--red, #dc3545);
-}
-
-.cs-status-message.is-success {
-  border-color: var(--green, #4CAF50);
-  background-color: rgba(76, 175, 80, 0.12);
-  color: var(--green, #4CAF50);
-}
-
-.cs-error-message {
-  border-color: var(--red, #dc3545);
-  background-color: rgba(220, 53, 69, 0.12);
-  color: var(--red, #dc3545);
-  margin-top: 8px;
+  gap: 12px;
+  font-size: 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .cs-status-message i,
 .cs-error-message i {
-  color: inherit;
+  font-size: 1.1rem;
 }
 
 .cs-status-text {
   flex: 1;
 }
 
+.cs-error-message {
+  border-color: rgba(231, 76, 60, 0.6);
+  background: rgba(231, 76, 60, 0.15);
+  color: #ffd7d2;
+}
+
 .cs-error-message[hidden] {
   display: none;
 }
 
-/* --- Section Blocks --- */
-.cs-block {
-  margin-bottom: 20px;
-  padding: 15px;
-  border-radius: 8px;
-  background-color: var(--bg2);
-  border: 1px solid var(--border);
-  transition: all 0.2s ease-in-out;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-.cs-block:hover {
-  border-color: var(--primary-color-faded);
-}
-.cs-block .cs-block { /* Nested blocks */
-  margin-top: 15px;
-  margin-bottom: 0;
-  padding: 10px;
-  background-color: var(--bg1);
+@media (max-width: 768px) {
+  #costume-switcher-settings.cs-theme {
+    padding: 14px;
+  }
+
+  .cs-card {
+    padding: 18px;
+  }
+
+  .cs-master-toggle {
+    grid-template-columns: 1fr;
+  }
+
+  .cs-master-toggle input {
+    justify-self: flex-start;
+  }
 }
 
+.cs-toggle-indicator {
+  display: none;
+}
+.cs-switch-thumb { display: none; }
 
-/* --- Typography & Icons --- */
-.cs-label-with-icon {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.cs-label-with-icon .fa-solid {
-  color: var(--text-color-soft);
-  width: 1.2em; /* Ensure consistent alignment */
-  text-align: center;
-}
-#costume-switcher-settings small {
-  display: block;
-  margin-top: 5px;
-  color: var(--text-color-soft);
-  font-size: 0.85em;
-  line-height: 1.4;
-}
-#costume-switcher-settings .cs-tip {
-  margin-top: 10px;
-  padding: 8px;
-  background-color: var(--bg0);
-  border-radius: 4px;
-  border-left: 3px solid var(--green);
-  color: var(--text-color-soft-extra);
+.cs-status-message.is-success {
+  border-color: rgba(46, 213, 115, 0.6);
+  background: rgba(46, 213, 115, 0.16);
+  color: #d4ffe5;
 }
 
-/* --- Layout --- */
-.cs-flex-container {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  margin-top: 10px;
-  flex-wrap: wrap;
-}
-.cs-flex-container > * {
-  flex: 1 1 160px;
-}
-.cs-flex-container > .menu_button,
-.cs-flex-container > button {
-  flex: 0 0 auto;
-}
-.inline-group {
-    margin-top: 10px;
-}
-.inline-group.cs-flex-container label {
-    flex-shrink: 0; /* Prevent label from shrinking */
-}
-.inline-group.cs-flex-container input {
-    flex-grow: 1;
+.cs-status-message.is-error {
+  border-color: rgba(231, 76, 60, 0.6);
+  background: rgba(231, 76, 60, 0.18);
+  color: #ffd7d2;
 }
 
-/* --- Form Elements --- */
-.text_pole, .menu_button {
-  transition: all 0.2s ease-in-out;
-}
-.text_pole:focus {
-  border-color: var(--primary-color);
-  box-shadow: 0 0 5px var(--primary-color-faded);
-}
-
-/* --- Buttons --- */
-.cs-button-primary {
-    background-color: var(--primary-color, #007bff);
-    color: white;
-    border: 1px solid transparent;
-}
-.cs-button-primary:hover {
-    background-color: var(--primary-color-hover, #0056b3);
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.15);
-}
-.cs-button-danger {
-    background-color: var(--red, #dc3545);
-    color: white;
-    border: 1px solid transparent;
-}
-.cs-button-danger:hover {
-    background-color: var(--red-hover, #c82333);
-}
-
-/* --- Detection Methods Layout --- */
-.cs-detection-methods {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 15px;
-  margin-top: 15px;
-}
-.cs-detection-method {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.cs-detection-method > div { /* Label and checkbox container */
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-#cs-mappings {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9em;
-}
-
-#cs-mappings th,
-#cs-mappings td {
-  padding: 6px 8px;
-  text-align: left;
-}
-
-#cs-mappings tbody tr:nth-child(even) {
-  background-color: var(--bg1);
-}
-
-#cs-mappings thead {
-  background-color: var(--bg0);
-  border-bottom: 1px solid var(--border);
-}
-
-#cs-mappings .map-name,
-#cs-mappings .map-folder {
-  width: 100%;
-}
-
-/* --- Modern Range Slider --- */
-input[type="range"].cs-slider {
-  -webkit-appearance: none; appearance: none;
-  width: 100%; height: 6px;
-  background: transparent; cursor: pointer;
-  outline: none;
-}
-input[type="range"].cs-slider::-webkit-slider-runnable-track { height: 6px; background: var(--bg0); border-radius: 5px; }
-input[type="range"].cs-slider::-moz-range-track { height: 6px; background: var(--bg0); border-radius: 5px; }
-input[type="range"].cs-slider::-webkit-slider-thumb {
-  -webkit-appearance: none; appearance: none;
-  margin-top: -6px;
-  height: 18px; width: 18px;
-  background-color: var(--cs-slider-thumb-color);
-  border-radius: 50%;
-  border: 2px solid var(--bg2);
-  transition: transform 0.2s ease;
-}
-input[type="range"].cs-slider::-moz-range-thumb {
-  height: 18px; width: 18px;
-  background-color: var(--cs-slider-thumb-color);
-  border-radius: 50%; border: none;
-  box-shadow: 0 0 0 2px var(--bg2); 
-  transition: transform 0.2s ease;
-}
-input[type="range"].cs-slider:hover::-webkit-slider-thumb,
-input[type="range"].cs-slider:hover::-moz-range-thumb { transform: scale(1.1); }
-input[type="range"].cs-slider:focus::-webkit-slider-thumb { box-shadow: 0 0 0 4px var(--primary-color-faded); }
-input[type="range"].cs-slider:focus::-moz-range-thumb { box-shadow: 0 0 0 2px var(--bg2), 0 0 0 4px var(--primary-color-faded); }
-
-
-/* --- Live Tester --- */
-.cs-tester-output-container {
-    display: flex; gap: 10px; padding: 10px; min-height: 100px;
-    margin-top: 10px; background-color: var(--bg0);
-}
-.cs-tester-actions {
-    justify-content: flex-start;
-}
-.cs-tester-actions > .menu_button {
-    min-width: 140px;
-}
-.cs-tester-col { flex: 1; font-size: 0.9em; }
-.cs-tester-col--divider { border-right: 1px solid var(--border); padding-right: 10px; }
-.cs-tester-list { list-style-position: inside; padding: 0; margin: 0; overflow-wrap: break-word; max-height: 220px; overflow-y: auto; }
-.cs-tester-list-placeholder { color: var(--text-color-soft); }
-.cs-tester-title { font-weight: bold; margin-bottom: 5px; }
-.cs-tester-log-switch { color: var(--green); }
-.cs-tester-log-switch small { color: var(--text-color); margin-left: 6px; }
-.cs-tester-log-skip { color: var(--text-color-soft); font-style: italic; }
-.cs-tester-log-skip span { font-weight: 600; color: var(--text-color); font-style: normal; }
-.cs-tester-log-skip small { margin-left: 6px; }
-.cs-tester-log-veto { color: var(--red); font-weight: 600; }
-.cs-tester-log-veto small { color: var(--text-color); margin-left: 6px; font-weight: normal; }
 #cs-regex-test-copy[disabled] {
-    opacity: 0.6;
-    cursor: not-allowed;
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }


### PR DESCRIPTION
## Summary
- reorganize the costume switcher settings into card-based sections with a new header layout and streamlined control groupings
- refresh the extension styling with a cohesive gradient theme, modern toggles, and polished tester and mapping components

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa9d449a608325955de612677e969b