### PR TITLE
Ensure /cs-top returns comma-separated character names

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ All commands are session-scoped—they modify the active profile until you reloa
 | `/cs-ignore <name>` | Adds a character or regex to the ignore list for the current session. |
 | `/cs-map <alias> to <folder>` | Creates a temporary mapping from `alias` to the specified costume folder. |
 | `/cs-stats` | Logs a breakdown of detected character mentions for the most recent AI message to the browser console. |
-| `/cs-top [count]` | Returns a comma-separated list of the top detected characters from the last AI message. Accepts `1`–`4`; defaults to four names. |
+| `/cs-top [count]` | Logs the same mention statistics as `/cs-stats`, then returns a comma-separated list of the top detected characters from the last AI message. Accepts `1`–`4`; defaults to four names. |
 | `/cs-top1` – `/cs-top4` | Shortcuts for pulling exactly the top 1–4 characters without specifying an argument. |
 
 ---

--- a/index.js
+++ b/index.js
@@ -528,10 +528,30 @@ function clearSessionTopCharacters() {
     };
 }
 
+function clampTopCount(count = 4) {
+    return Math.min(Math.max(Number(count) || 4, 1), 4);
+}
+
+function getLastStatsMessageKey() {
+    if (!(state.messageStats instanceof Map) || state.messageStats.size === 0) {
+        return null;
+    }
+    const lastKey = Array.from(state.messageStats.keys()).pop();
+    return normalizeMessageKey(lastKey);
+}
+
 function getLastTopCharacters(count = 4) {
-    const limit = Math.min(Math.max(Number(count) || 4, 1), 4);
+    const limit = clampTopCount(count);
     if (Array.isArray(state.latestTopRanking?.ranking) && state.latestTopRanking.ranking.length) {
         return state.latestTopRanking.ranking.slice(0, limit);
+    }
+
+    const lastMessageKey = getLastStatsMessageKey();
+    if (lastMessageKey && state.topSceneRanking instanceof Map) {
+        const rankingForKey = state.topSceneRanking.get(lastMessageKey);
+        if (Array.isArray(rankingForKey) && rankingForKey.length) {
+            return rankingForKey.slice(0, limit);
+        }
     }
 
     if (state.topSceneRanking instanceof Map && state.topSceneRanking.size > 0) {
@@ -1738,7 +1758,7 @@ async function manualReset() {
 }
 
 function logLastMessageStats() {
-    let lastMessageKey = normalizeMessageKey(Array.from(state.messageStats.keys()).pop());
+    let lastMessageKey = getLastStatsMessageKey();
 
     if (!lastMessageKey) {
         const sessionKey = ensureSessionData()?.lastMessageKey;
@@ -1976,31 +1996,14 @@ function calculateFinalMessageStats(reference) {
 // SLASH COMMANDS
 // ======================================================================
 function registerCommands() {
-    const formatTopCharacterList = (ranking) => {
-        return ranking.map((entry, idx) => {
-            const mentionLabel = entry.count === 1 ? 'mention' : 'mentions';
-            const countInfo = Number.isFinite(entry.count) && entry.count > 0
-                ? ` — ${entry.count} ${mentionLabel}`
-                : '';
-            return `${idx + 1}. ${entry.name}${countInfo}`;
-        }).join('\n');
-    };
+    const emptyTopCharactersMessage = 'No character detections available for the last message.';
 
-    const emitTopCharacters = (count, { silent } = {}) => {
+    const getTopCharacterNamesString = (count = 4) => {
         const ranking = getLastTopCharacters(count);
         if (!ranking.length) {
-            const emptyMessage = 'No character detections available for the last message.';
-            if (!silent) {
-                showStatus(emptyMessage, 'info');
-            }
-            return emptyMessage;
+            return '';
         }
-
-        const formatted = formatTopCharacterList(ranking);
-        if (!silent) {
-            showStatus(`Top detections:<br>${escapeHtml(formatted).replace(/\n/g, '<br>')}`, 'success', 5000);
-        }
-        return formatted;
+        return ranking.map(entry => entry.name).join(', ');
     };
 
     registerSlashCommand("cs-addchar", (args) => {
@@ -2052,13 +2055,22 @@ function registerCommands() {
 
     registerSlashCommand("cs-top", (args) => {
         const desired = Number(args?.[0]);
-        const count = Number.isFinite(desired) ? desired : 4;
-        return emitTopCharacters(count);
-    }, ["count?"], "Returns a comma-separated list of the top detected characters from the last message (1-4).", true);
+        const count = clampTopCount(Number.isFinite(desired) ? desired : 4);
+        const statsMessage = logLastMessageStats();
+        const names = getTopCharacterNamesString(count);
+        if (names) {
+            return names;
+        }
+        if (typeof statsMessage === 'string' && !statsMessage.includes('Top Ranked Characters:')) {
+            return statsMessage;
+        }
+        return emptyTopCharactersMessage;
+    }, ["count?"], "Logs mention stats and returns a comma-separated list of the top detected characters from the last message (1-4).", true);
 
     [1, 2, 3, 4].forEach((num) => {
         registerSlashCommand(`cs-top${num}`, () => {
-            return emitTopCharacters(num, { silent: true });
+            const names = getTopCharacterNamesString(num);
+            return names || emptyTopCharactersMessage;
         }, [], `Shortcut for the top ${num} detected character${num > 1 ? 's' : ''} from the last message.`, true);
     });
 }


### PR DESCRIPTION
## Summary
- add helpers to clamp the requested top count and locate the latest stats entry when retrieving rankings
- ensure `/cs-top` uses the shared helpers so it always returns only the comma-separated names while still logging stats for the last message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbb7fca8a88325a64ae0d312a07351