### PR TITLE
Log /cs-top results to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ All commands are session-scoped—they modify the active profile until you reloa
 | `/cs-ignore <name>` | Adds a character or regex to the ignore list for the current session. |
 | `/cs-map <alias> to <folder>` | Creates a temporary mapping from `alias` to the specified costume folder. |
 | `/cs-stats` | Logs a breakdown of detected character mentions for the most recent AI message to the browser console. |
-| `/cs-top [count]` | Logs the same mention statistics as `/cs-stats`, then returns a comma-separated list of the top detected characters from the last AI message. Accepts `1`–`4`; defaults to four names. |
+| `/cs-top [count]` | Returns a comma-separated list of the top detected characters from the last AI message and logs the result to the browser console. Accepts `1`–`4`; defaults to four names. |
 | `/cs-top1` – `/cs-top4` | Shortcuts for pulling exactly the top 1–4 characters without specifying an argument. |
 
 ---

--- a/index.js
+++ b/index.js
@@ -2056,16 +2056,11 @@ function registerCommands() {
     registerSlashCommand("cs-top", (args) => {
         const desired = Number(args?.[0]);
         const count = clampTopCount(Number.isFinite(desired) ? desired : 4);
-        const statsMessage = logLastMessageStats();
         const names = getTopCharacterNamesString(count);
-        if (names) {
-            return names;
-        }
-        if (typeof statsMessage === 'string' && !statsMessage.includes('Top Ranked Characters:')) {
-            return statsMessage;
-        }
-        return emptyTopCharactersMessage;
-    }, ["count?"], "Logs mention stats and returns a comma-separated list of the top detected characters from the last message (1-4).", true);
+        const message = names || emptyTopCharactersMessage;
+        console.log(`${logPrefix} ${message}`);
+        return names || message;
+    }, ["count?"], "Returns a comma-separated list of the top detected characters from the last message (1-4) and logs the result to the console.", true);
 
     [1, 2, 3, 4].forEach((num) => {
         registerSlashCommand(`cs-top${num}`, () => {


### PR DESCRIPTION
## Summary
- log the `/cs-top` slash command output to the browser console while still returning the comma-separated list
- document the updated behavior for `/cs-top` in the README command table

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc321a184c8325b406f07d70727499