### PR TITLE
Enhance detection vocabulary and mapping performance

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -257,6 +257,11 @@
                   <small>Comma-separated list used by the action detector.</small>
                   <textarea id="cs-action-verbs" class="text_pole" rows="3"></textarea>
                 </div>
+                <div class="cs-field-group">
+                  <label for="cs-pronoun-vocabulary">Pronoun Vocabulary</label>
+                  <small>Comma-separated list of pronouns the pronoun detector should recognize. Supports custom neopronouns.</small>
+                  <textarea id="cs-pronoun-vocabulary" class="text_pole" rows="2"></textarea>
+                </div>
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- add a configurable pronoun vocabulary and wire it into the pronoun detector UI
- broaden dialogue quote detection to additional Unicode glyphs while avoiding apostrophes
- precompute character-to-costume mappings and adopt Unicode-aware action matching for faster lookups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc3e0dbfdc8325be376d624f8ededa