### PR TITLE
Add scoring controls, slash command persistence, and cache pruning

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -297,6 +297,64 @@
                 </div>
               </div>
             </section>
+            <section class="cs-card">
+              <header class="cs-card-header">
+                <div class="cs-card-title">
+                  <i class="fa-solid fa-ranking-star"></i>
+                  <div>
+                    <h3>Scoring Weights</h3>
+                    <p>Fine-tune how detections are ranked and how strongly recency matters.</p>
+                  </div>
+                </div>
+              </header>
+              <div class="cs-card-body cs-card-body--stacked">
+                <small>Increase a priority to make that detection type more influential when breaking ties.</small>
+                <div class="cs-grid">
+                  <div class="cs-field-group">
+                    <label for="cs-priority-speaker">Speaker Priority</label>
+                    <input id="cs-priority-speaker" class="text_pole" type="number" step="0.1" min="0" title="Weight for explicit speaker labels such as Name: &quot;Dialogue&quot;." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-attribution">Attribution Priority</label>
+                    <input id="cs-priority-attribution" class="text_pole" type="number" step="0.1" min="0" title="Weight for narration like '...,' she said." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-action">Action Priority</label>
+                    <input id="cs-priority-action" class="text_pole" type="number" step="0.1" min="0" title="Weight for action detections such as He nodded." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-pronoun">Pronoun Priority</label>
+                    <input id="cs-priority-pronoun" class="text_pole" type="number" step="0.1" min="0" title="Weight applied when resolving pronouns to the last subject." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-vocative">Vocative Priority</label>
+                    <input id="cs-priority-vocative" class="text_pole" type="number" step="0.1" min="0" title="Weight for names called out inside dialogue." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-possessive">Possessive Priority</label>
+                    <input id="cs-priority-possessive" class="text_pole" type="number" step="0.1" min="0" title="Weight for possessive mentions like Merlin's staff." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-priority-name">General Name Priority</label>
+                    <input id="cs-priority-name" class="text_pole" type="number" step="0.1" min="0" title="Weight for general name detections when enabled." />
+                  </div>
+                </div>
+                <div class="cs-grid">
+                  <div class="cs-field-group">
+                    <label for="cs-roster-bonus">Roster Bonus</label>
+                    <input id="cs-roster-bonus" class="text_pole" type="number" step="1" min="0" title="Bonus score applied when the character is already in the scene roster." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-roster-dropoff">Roster Priority Drop-off</label>
+                    <input id="cs-roster-dropoff" class="text_pole" type="number" step="0.1" min="0" title="How quickly the roster bonus decays for lower-priority detections." />
+                  </div>
+                  <div class="cs-field-group">
+                    <label for="cs-distance-penalty">Distance Penalty Weight</label>
+                    <input id="cs-distance-penalty" class="text_pole" type="number" step="0.1" min="0" title="Penalty per character of distance from the end of the message." />
+                  </div>
+                </div>
+              </div>
+            </section>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add configurable scoring weights to the detection UI and apply them throughout ranking logic
- sync slash-command updates with the settings panel and support an optional --persist flag that saves immediately
- prune cached message buffers/stats after each generation to cap memory usage

## Testing
- Not run (not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68fd183fe9d88325bd4e5bfcc7906e59