### PR TITLE
Improve preset guidance and tester layout

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,34 @@ const LEXICON_PACKS = {
         attributionVerbs: ["muttered", "rasped", "drawled", "grumbled"],
         actionVerbs: ["lurched", "leaned", "nursed", "shadowed", "tailed", "poured"],
     },
+    romance: {
+        name: "Romance Studio",
+        description: "Highlights soft pronouns and affectionate beats for relationship-driven scenes.",
+        pronouns: ["she", "her", "he", "him", "they", "them", "zie", "zir"],
+        attributionVerbs: ["whispered", "murmured", "breathed", "confessed", "promised", "sighed"],
+        actionVerbs: ["caressed", "embraced", "kissed", "lingered", "blushed", "cradled"],
+    },
+    horror: {
+        name: "Midnight Horror",
+        description: "Adds unsettling verbs and ominous pronouns for creeping dread.",
+        pronouns: ["it", "its", "they", "them", "someone", "something"],
+        attributionVerbs: ["hissed", "croaked", "whimpered", "rasped", "moaned"],
+        actionVerbs: ["slithered", "crept", "lurched", "stalked", "screeched", "shuddered"],
+    },
+    western: {
+        name: "Frontier Drawl",
+        description: "Adds twangy vernacular and trail verbs for western adventures.",
+        pronouns: ["ya", "y'all", "yer", "yourselves"],
+        attributionVerbs: ["spat", "drawled", "barked", "hollered", "whooped"],
+        actionVerbs: ["lassoed", "saddled", "spurred", "tilted", "spat", "squared"],
+    },
+    anime: {
+        name: "Anime Drama",
+        description: "Injects energetic verbs and honorific-friendly pronouns for high-energy scenes.",
+        pronouns: ["watashi", "boku", "ore", "anata", "kanojo", "kare"],
+        attributionVerbs: ["shouted", "declared", "pleaded", "exclaimed", "yelled"],
+        actionVerbs: ["transformed", "charged", "sparked", "posed", "teleported", "radiated"],
+    },
 };
 
 const DEFAULT_PRONOUNS = ['he', 'she', 'they'];
@@ -1424,9 +1452,9 @@ function renderScorePresetPreview(presetName) {
     const currentWeights = collectScoreWeights();
 
     if (!preset) {
-        previewContainer.html('<p class="cs-helper-text">Pick a preset to compare scoring weights.</p>');
+        previewContainer.html('<p class="cs-helper-text">Pick a preset to compare how it leans against your current weights.</p>');
         if (messageEl.length) {
-            messageEl.text('Select a preset to preview its scoring emphasis against the active profile.');
+            messageEl.text('Select a preset to preview its scoring emphasis against what you have configured right now.');
         }
         return;
     }
@@ -1439,6 +1467,13 @@ function renderScorePresetPreview(presetName) {
     }, 1);
 
     const table = $('<table>').addClass('cs-score-preview-table');
+    const head = $('<thead>');
+    head.append($('<tr>')
+        .append($('<th>').text('Signal'))
+        .append($('<th>').text('Preset Focus'))
+        .append($('<th>').text('Your Profile'))
+        .append($('<th>').text('Change')));
+    table.append(head);
     const tbody = $('<tbody>');
     SCORE_WEIGHT_KEYS.forEach((key) => {
         const label = SCORE_WEIGHT_LABELS[key] || key;
@@ -1467,6 +1502,7 @@ function renderScorePresetPreview(presetName) {
         const parts = [];
         if (preset.description) parts.push(preset.description);
         parts.push(preset.builtIn ? 'Built-in preset' : 'Custom preset');
+        parts.push('Bars show preset weight; numbers show your current setup.');
         messageEl.text(parts.join(' • '));
     }
 }

--- a/settings.html
+++ b/settings.html
@@ -365,6 +365,13 @@
                     <h4>Scoring Presets</h4>
                     <p class="cs-helper-text">Save and compare weight profiles for different scenes.</p>
                   </div>
+                  <div class="cs-score-presets-guide" aria-live="polite">
+                    <ol>
+                      <li><strong>Preview:</strong> Pick a preset to see how its priorities compare with yours.</li>
+                      <li><strong>Inspect:</strong> Bars show the preset emphasis; the middle column shows your live values.</li>
+                      <li><strong>Apply or Tweak:</strong> Apply the preset or adjust individual weights before saving.</li>
+                    </ol>
+                  </div>
                   <div class="cs-toolbar">
                     <select id="cs-score-preset-select" class="text_pole" style="flex: 1 1 auto;" title="Select a saved scoring preset to preview its weights.">
                       <option value="">Select a scoring preset…</option>
@@ -378,13 +385,13 @@
                     <button id="cs-score-preset-rename" class="menu_button interactable" title="Rename the selected custom preset.">Rename</button>
                     <button id="cs-score-preset-delete" class="menu_button interactable cs-button-danger" title="Delete the selected custom preset.">Delete</button>
                   </div>
-                  <p id="cs-score-preset-message" class="cs-helper-text">Select a preset to preview its weights against the active profile.</p>
+                  <p id="cs-score-preset-message" class="cs-helper-text">Select a preset to preview how it stacks against your active profile.</p>
                   <div id="cs-score-preset-preview" class="cs-score-preview">
-                    <table class="cs-score-preview-table">
-                      <tbody>
-                        <tr><td colspan="3" class="cs-tester-list-placeholder">Select a preset to see weight comparisons.</td></tr>
-                      </tbody>
-                    </table>
+                      <table class="cs-score-preview-table">
+                        <tbody>
+                          <tr><td colspan="4" class="cs-tester-list-placeholder">Select a preset to see weight comparisons.</td></tr>
+                        </tbody>
+                      </table>
                   </div>
                 </div>
               </div>
@@ -412,53 +419,71 @@
                   <button id="cs-regex-test-button" class="menu_button interactable">Test Pattern</button>
                   <button id="cs-regex-test-copy" class="menu_button interactable" disabled title="Copy the latest live tester report to your clipboard.">Copy Report</button>
                 </div>
-                <div class="cs-tester-meta">
-                  <span class="cs-meta-label">Veto Status:</span>
-                  <span id="cs-test-veto-result" class="cs-tester-list-placeholder">N/A</span>
-                </div>
-                <div class="cs-tester-meta">
-                  <span class="cs-meta-label">Top Characters:</span>
-                  <span id="cs-test-top-characters" class="cs-tester-list-placeholder">N/A</span>
+                <div class="cs-tester-guide">
+                  <h4>Live Tester Walkthrough</h4>
+                  <ol>
+                    <li>Paste a recent chat message or narration chunk, then run <strong>Test Pattern</strong>.</li>
+                    <li>Check the summary cards to see which characters ranked highest and whether a switch fired.</li>
+                    <li>Drill into the panels below to inspect detections, winners, roster health, and vocabulary tips.</li>
+                  </ol>
                 </div>
                 <div id="cs-regex-test-output-container" class="text_pole cs-tester-output-container">
-                  <div class="cs-tester-col cs-tester-col--divider">
-                    <div class="cs-tester-title">All Detections (in order)</div>
-                    <ul id="cs-test-all-detections" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Results will appear here.</li>
-                    </ul>
+                  <div class="cs-tester-summary-grid">
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Top Characters</span>
+                      <div id="cs-test-top-characters" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                      <p>Highest scoring matches from the last run.</p>
+                    </div>
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Veto Status</span>
+                      <div id="cs-test-veto-result" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                      <p>Explains whether a cooldown or lock blocked the switch.</p>
+                    </div>
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Need a Hint?</span>
+                      <p class="cs-summary-help">Use the coverage suggestions to pad your verb lists or pronouns if detections feel thin.</p>
+                    </div>
                   </div>
-                  <div class="cs-tester-col cs-tester-col--divider">
-                    <div class="cs-tester-title">Live Switch Decisions</div>
-                    <ul id="cs-test-winner-list" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
-                    </ul>
-                  </div>
-                  <div class="cs-tester-col cs-tester-col--insights">
-                    <div class="cs-tester-title">Scene Roster Timeline</div>
-                    <ul id="cs-test-roster-timeline" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
-                    </ul>
-                    <div class="cs-tester-title">Roster Health</div>
-                    <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
-                    <div class="cs-tester-title">Score Breakdown</div>
-                    <table id="cs-test-score-breakdown" class="cs-score-table">
-                      <tbody>
-                        <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
-                      </tbody>
-                    </table>
-                    <div class="cs-tester-title">Coverage Suggestions</div>
-                    <div class="cs-coverage-panel">
-                      <div>
-                        <h5>Pronouns</h5>
-                        <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                      </div>
-                      <div>
-                        <h5>Attribution Verbs</h5>
-                        <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                      </div>
-                      <div>
-                        <h5>Action Verbs</h5>
-                        <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                  <div class="cs-tester-columns">
+                    <div class="cs-tester-col">
+                      <div class="cs-tester-title">All Detections (in order)</div>
+                      <ul id="cs-test-all-detections" class="cs-tester-list">
+                        <li class="cs-tester-list-placeholder">Results will appear here.</li>
+                      </ul>
+                    </div>
+                    <div class="cs-tester-col">
+                      <div class="cs-tester-title">Live Switch Decisions</div>
+                      <ul id="cs-test-winner-list" class="cs-tester-list">
+                        <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
+                      </ul>
+                    </div>
+                    <div class="cs-tester-col cs-tester-col--insights">
+                      <div class="cs-tester-title">Scene Roster Timeline</div>
+                      <ul id="cs-test-roster-timeline" class="cs-tester-list">
+                        <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
+                      </ul>
+                      <div class="cs-tester-title">Roster Health</div>
+                      <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
+                      <div class="cs-tester-title">Score Breakdown</div>
+                      <table id="cs-test-score-breakdown" class="cs-score-table">
+                        <tbody>
+                          <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
+                        </tbody>
+                      </table>
+                      <div class="cs-tester-title">Coverage Suggestions</div>
+                      <div class="cs-coverage-panel">
+                        <div>
+                          <h5>Pronouns</h5>
+                          <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                        </div>
+                        <div>
+                          <h5>Attribution Verbs</h5>
+                          <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                        </div>
+                        <div>
+                          <h5>Action Verbs</h5>
+                          <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/style.css
+++ b/style.css
@@ -442,27 +442,21 @@
   padding-top: 4px;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-meta {
-  display: flex;
-  gap: 8px;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-  align-items: center;
-}
-
-#costume-switcher-settings.cs-theme .cs-meta-label {
-  font-weight: 600;
-  color: var(--text-color);
-}
-
 #costume-switcher-settings.cs-theme .cs-tester-output-container {
   margin-top: 6px;
-  border-radius: 14px;
-  background: rgba(0, 0, 0, 0.3);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  overflow: hidden;
+  gap: 16px;
 }
 
 #costume-switcher-settings.cs-theme .cs-tester-col {
@@ -470,10 +464,10 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-#costume-switcher-settings.cs-theme .cs-tester-col--divider {
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  min-height: 0;
 }
 
 #costume-switcher-settings.cs-theme .cs-tester-col--insights {
@@ -514,6 +508,69 @@
   max-height: 140px;
 }
 
+#costume-switcher-settings.cs-theme .cs-tester-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 110px;
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-help {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide ol {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-muted);
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide strong {
+  color: var(--text-color);
+}
+
 #costume-switcher-settings.cs-theme .cs-roster-warning {
   padding: 10px 12px;
   border-radius: 10px;
@@ -533,6 +590,27 @@
   gap: 12px;
 }
 
+#costume-switcher-settings.cs-theme .cs-score-presets-guide {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  border-left: 3px solid var(--accent);
+  padding: 10px 14px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-presets-guide ol {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-presets-guide strong {
+  color: var(--text-color);
+}
+
 #costume-switcher-settings.cs-theme .cs-score-presets-header h4 {
   margin: 0;
   font-size: 1rem;
@@ -542,6 +620,17 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.88rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-preview-table thead {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+#costume-switcher-settings.cs-theme .cs-score-preview-table thead th {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 
 #costume-switcher-settings.cs-theme .cs-score-preview-table th,
@@ -842,6 +931,10 @@
 
   #costume-switcher-settings.cs-theme .cs-master-toggle input {
     justify-self: flex-start;
+  }
+
+  #costume-switcher-settings.cs-theme .cs-tester-output-container {
+    padding: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add four new lexicon packs covering romance, horror, western, and anime styles
- clarify scoring preset previews with an instructional guide and clearer comparison table
- reorganize the live tester into summary cards and structured panels to aid new users

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_690140134de88325ad974e3e32c7e9b7