### PR TITLE
Streamline live tester layout and remove lexicon packs

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,31 +149,35 @@ const DEFAULT_SCORE_PRESETS = {
 
 const BUILTIN_SCORE_PRESET_KEYS = new Set(Object.keys(DEFAULT_SCORE_PRESETS));
 
-const LEXICON_PACKS = {
-    fantasy: {
-        name: "Fantasy Field Notes",
-        description: "Adds archaic pronouns and common bard/warrior verbs.",
-        pronouns: ["thee", "thou", "thy", "thine", "yon", "ye"],
-        attributionVerbs: ["intoned", "proclaimed", "recited", "declared", "pronounced"],
-        actionVerbs: ["brandished", "summoned", "conjured", "smote", "unsheathed", "teleported"],
-    },
-    scifi: {
-        name: "Sci-Fi Ops",
-        description: "Bolsters technobabble verbs and synthetic pronouns.",
-        pronouns: ["xe", "xem", "xyr", "ze", "zir", "theyre"],
-        attributionVerbs: ["transmitted", "pinged", "reported", "uploaded"],
-        actionVerbs: ["calibrated", "recalibrated", "synced", "overclocked", "hacked", "booted"],
-    },
-    noir: {
-        name: "Noir Desk",
-        description: "Adds smoky narration staples for detective stories.",
-        pronouns: ["ya", "ya'll"],
-        attributionVerbs: ["muttered", "rasped", "drawled", "grumbled"],
-        actionVerbs: ["lurched", "leaned", "nursed", "shadowed", "tailed", "poured"],
-    },
-};
-
 const DEFAULT_PRONOUNS = ['he', 'she', 'they'];
+
+const EXTENDED_PRONOUNS = [
+    'thee', 'thou', 'thy', 'thine', 'yon', 'ye',
+    'xe', 'xem', 'xyr', 'ze', 'zir', 'theyre',
+    'ya', "ya'll", 'y\'all', 'yer', 'yourselves',
+    'watashi', 'boku', 'ore', 'anata', 'kanojo', 'kare',
+    'zie', 'zir', 'it', 'its', 'someone', 'something',
+];
+
+const EXTENDED_ATTRIBUTION_VERBS = [
+    'intoned', 'proclaimed', 'recited', 'declared', 'pronounced',
+    'transmitted', 'pinged', 'reported', 'uploaded',
+    'muttered', 'rasped', 'drawled', 'grumbled',
+    'whispered', 'murmured', 'breathed', 'confessed', 'promised', 'sighed',
+    'hissed', 'croaked', 'whimpered', 'moaned',
+    'spat', 'barked', 'hollered', 'whooped',
+    'shouted', 'pleaded', 'exclaimed', 'yelled',
+];
+
+const EXTENDED_ACTION_VERBS = [
+    'brandished', 'summoned', 'conjured', 'smote', 'unsheathed', 'teleported',
+    'calibrated', 'recalibrated', 'synced', 'overclocked', 'hacked', 'booted',
+    'lurched', 'leaned', 'nursed', 'shadowed', 'tailed', 'poured',
+    'caressed', 'embraced', 'kissed', 'lingered', 'blushed', 'cradled',
+    'slithered', 'crept', 'stalked', 'screeched', 'shuddered',
+    'lassoed', 'saddled', 'spurred', 'tilted', 'spat', 'squared',
+    'transformed', 'charged', 'sparked', 'posed', 'radiated',
+];
 
 const COVERAGE_TOKEN_REGEX = /[\p{L}\p{M}']+/gu;
 
@@ -264,18 +268,18 @@ const PROFILE_DEFAULTS = {
 
 const KNOWN_PRONOUNS = new Set([
     ...DEFAULT_PRONOUNS,
-    ...Object.values(LEXICON_PACKS).flatMap(pack => pack.pronouns || []),
+    ...EXTENDED_PRONOUNS,
     ...PROFILE_DEFAULTS.pronounVocabulary,
 ].map(value => String(value).toLowerCase()));
 
 const KNOWN_ATTRIBUTION_VERBS = new Set([
     ...PROFILE_DEFAULTS.attributionVerbs,
-    ...Object.values(LEXICON_PACKS).flatMap(pack => pack.attributionVerbs || []),
+    ...EXTENDED_ATTRIBUTION_VERBS,
 ].map(value => String(value).toLowerCase()));
 
 const KNOWN_ACTION_VERBS = new Set([
     ...PROFILE_DEFAULTS.actionVerbs,
-    ...Object.values(LEXICON_PACKS).flatMap(pack => pack.actionVerbs || []),
+    ...EXTENDED_ACTION_VERBS,
 ].map(value => String(value).toLowerCase()));
 
 const DEFAULTS = {
@@ -1424,9 +1428,9 @@ function renderScorePresetPreview(presetName) {
     const currentWeights = collectScoreWeights();
 
     if (!preset) {
-        previewContainer.html('<p class="cs-helper-text">Pick a preset to compare scoring weights.</p>');
+        previewContainer.html('<p class="cs-helper-text">Pick a preset to compare how it leans against your current weights.</p>');
         if (messageEl.length) {
-            messageEl.text('Select a preset to preview its scoring emphasis against the active profile.');
+            messageEl.text('Select a preset to preview its scoring emphasis against what you have configured right now.');
         }
         return;
     }
@@ -1439,6 +1443,13 @@ function renderScorePresetPreview(presetName) {
     }, 1);
 
     const table = $('<table>').addClass('cs-score-preview-table');
+    const head = $('<thead>');
+    head.append($('<tr>')
+        .append($('<th>').text('Signal'))
+        .append($('<th>').text('Preset Focus'))
+        .append($('<th>').text('Your Profile'))
+        .append($('<th>').text('Change')));
+    table.append(head);
     const tbody = $('<tbody>');
     SCORE_WEIGHT_KEYS.forEach((key) => {
         const label = SCORE_WEIGHT_LABELS[key] || key;
@@ -1467,6 +1478,7 @@ function renderScorePresetPreview(presetName) {
         const parts = [];
         if (preset.description) parts.push(preset.description);
         parts.push(preset.builtIn ? 'Built-in preset' : 'Custom preset');
+        parts.push('Bars show preset weight; numbers show your current setup.');
         messageEl.text(parts.join(' • '));
     }
 }
@@ -2019,7 +2031,7 @@ function refreshCoverageFromLastReport() {
     }
 }
 
-function mergeLexiconList(target = [], additions = []) {
+function mergeUniqueList(target = [], additions = []) {
     const list = Array.isArray(target) ? [...target] : [];
     const seen = new Set(list.map(item => String(item).toLowerCase()));
     (additions || []).forEach((item) => {
@@ -2032,37 +2044,6 @@ function mergeLexiconList(target = [], additions = []) {
         }
     });
     return list;
-}
-
-function applyLexiconPack(packKey) {
-    const pack = LEXICON_PACKS?.[packKey];
-    const profile = getActiveProfile();
-    if (!pack || !profile) {
-        return false;
-    }
-
-    profile.pronounVocabulary = mergeLexiconList(profile.pronounVocabulary, pack.pronouns);
-    profile.attributionVerbs = mergeLexiconList(profile.attributionVerbs, pack.attributionVerbs);
-    profile.actionVerbs = mergeLexiconList(profile.actionVerbs, pack.actionVerbs);
-    syncProfileFieldsToUI(profile, ['pronounVocabulary', 'attributionVerbs', 'actionVerbs']);
-    recompileRegexes();
-    refreshCoverageFromLastReport();
-    return true;
-}
-
-function populateLexiconPackButtons() {
-    const container = $('#cs-lexicon-pack-buttons');
-    if (!container.length) return;
-    container.empty();
-    Object.entries(LEXICON_PACKS).forEach(([key, pack]) => {
-        const button = $('<button>')
-            .addClass('menu_button interactable cs-lexicon-pack')
-            .attr('type', 'button')
-            .attr('data-pack', key)
-            .attr('title', pack.description || '')
-            .text(pack.name);
-        container.append(button);
-    });
 }
 
 function copyTextToClipboard(text) {
@@ -3028,13 +3009,13 @@ function wireUI() {
         if (!value) return;
         let field = null;
         if (type === 'pronoun') {
-            profile.pronounVocabulary = mergeLexiconList(profile.pronounVocabulary, [value]);
+            profile.pronounVocabulary = mergeUniqueList(profile.pronounVocabulary, [value]);
             field = 'pronounVocabulary';
         } else if (type === 'attribution') {
-            profile.attributionVerbs = mergeLexiconList(profile.attributionVerbs, [value]);
+            profile.attributionVerbs = mergeUniqueList(profile.attributionVerbs, [value]);
             field = 'attributionVerbs';
         } else if (type === 'action') {
-            profile.actionVerbs = mergeLexiconList(profile.actionVerbs, [value]);
+            profile.actionVerbs = mergeUniqueList(profile.actionVerbs, [value]);
             field = 'actionVerbs';
         }
         if (field) {
@@ -3042,15 +3023,6 @@ function wireUI() {
             recompileRegexes();
             refreshCoverageFromLastReport();
             showStatus(`Added "${escapeHtml(value)}" to ${field.replace(/([A-Z])/g, ' $1').toLowerCase()}.`, 'success');
-        }
-    });
-    $(document).on('click', '.cs-lexicon-pack', function() {
-        const key = $(this).data('pack');
-        if (applyLexiconPack(key)) {
-            const packName = LEXICON_PACKS?.[key]?.name || 'Lexicon pack';
-            showStatus(`Imported ${escapeHtml(packName)}.`, 'success');
-        } else {
-            showStatus('Unable to apply lexicon pack.', 'error');
         }
     });
     $(document).on('click', '#cs-focus-lock-toggle', async () => {
@@ -3788,7 +3760,6 @@ jQuery(async () => {
         populateProfileDropdown();
         populatePresetDropdown();
         populateScorePresetDropdown();
-        populateLexiconPackButtons();
         loadProfile(getSettings().activeProfile);
         wireUI();
         registerCommands();

--- a/settings.html
+++ b/settings.html
@@ -433,79 +433,95 @@
                       <p>Explains whether a cooldown or lock blocked the switch.</p>
                     </div>
                     <div class="cs-summary-card">
-                      <span class="cs-summary-label">Need a Hint?</span>
-                      <p class="cs-summary-help">Use the coverage suggestions to pad your verb lists or pronouns if detections feel thin.</p>
+                      <span class="cs-summary-label">Quick Tip</span>
+                      <p class="cs-summary-help">Use the score, roster, and coverage panes below to focus your next tweaks.</p>
                     </div>
                   </div>
                   <div class="cs-tester-panels">
-                    <div class="cs-tester-primary">
-                      <section class="cs-tester-panel">
-                        <div class="cs-tester-title">All Detections (in order)</div>
-                        <p class="cs-helper-text">Timeline of every match we spotted.</p>
-                        <ul id="cs-test-all-detections" class="cs-tester-list">
-                          <li class="cs-tester-list-placeholder">Results will appear here.</li>
-                        </ul>
-                      </section>
-                      <section class="cs-tester-panel">
-                        <div class="cs-tester-title">Live Switch Decisions</div>
-                        <p class="cs-helper-text">Shows who would have received the costume change.</p>
-                        <ul id="cs-test-winner-list" class="cs-tester-list">
-                          <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
-                        </ul>
-                      </section>
-                      <section class="cs-tester-panel">
-                        <div class="cs-tester-title">Scene Roster Timeline</div>
-                        <p class="cs-helper-text">Track roster joins, refreshes, and drops.</p>
+                    <section class="cs-tester-panel cs-tester-panel--flow">
+                      <header class="cs-tester-panel-header">
+                        <h4>Match Flow</h4>
+                        <p>Follow detections through to the costume decision.</p>
+                      </header>
+                      <div class="cs-tester-split">
+                        <div class="cs-tester-pane">
+                          <div class="cs-tester-title">All Detections</div>
+                          <p class="cs-helper-text">Every detection we spotted, in order.</p>
+                          <ul id="cs-test-all-detections" class="cs-tester-list">
+                            <li class="cs-tester-list-placeholder">Results will appear here.</li>
+                          </ul>
+                        </div>
+                        <div class="cs-tester-pane">
+                          <div class="cs-tester-title">Live Switch Decisions</div>
+                          <p class="cs-helper-text">Who would have received the costume change.</p>
+                          <ul id="cs-test-winner-list" class="cs-tester-list">
+                            <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
+                          </ul>
+                        </div>
+                      </div>
+                    </section>
+                    <section class="cs-tester-panel cs-tester-panel--roster">
+                      <header class="cs-tester-panel-header">
+                        <h4>Scene Roster</h4>
+                        <p>Check for churn or TTL gaps that could impact switching.</p>
+                      </header>
+                      <div class="cs-tester-stack">
                         <ul id="cs-test-roster-timeline" class="cs-tester-list">
                           <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
                         </ul>
-                        <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
-                        <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
-                      </section>
-                    </div>
-                    <aside class="cs-tester-sidebar">
-                      <section class="cs-tester-panel cs-tester-panel--score">
-                        <div class="cs-tester-title">Score Breakdown</div>
-                        <p class="cs-helper-text">Scroll to compare how each detection contributed.</p>
-                        <div class="cs-score-scroll">
-                          <table id="cs-test-score-breakdown" class="cs-score-table">
-                            <tbody>
-                              <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
-                            </tbody>
-                          </table>
+                        <div class="cs-roster-health">
+                          <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
+                          <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
                         </div>
-                      </section>
-                      <section class="cs-tester-panel">
-                        <div class="cs-tester-title">Coverage Suggestions</div>
-                        <p class="cs-helper-text">Click a suggestion to add it to your vocabulary.</p>
-                        <div class="cs-coverage-panel">
-                          <div>
-                            <h5>Pronouns</h5>
-                            <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                          </div>
-                          <div>
-                            <h5>Attribution Verbs</h5>
-                            <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                          </div>
-                          <div>
-                            <h5>Action Verbs</h5>
-                            <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                          </div>
+                      </div>
+                    </section>
+                    <section class="cs-tester-panel cs-tester-panel--score">
+                      <header class="cs-tester-panel-header">
+                        <h4>Score Breakdown</h4>
+                        <p>Scroll to compare how each detection contributed.</p>
+                      </header>
+                      <div class="cs-score-scroll">
+                        <table id="cs-test-score-breakdown" class="cs-score-table">
+                          <tbody>
+                            <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </section>
+                    <section class="cs-tester-panel cs-tester-panel--coverage">
+                      <header class="cs-tester-panel-header">
+                        <h4>Coverage Suggestions</h4>
+                        <p>Click to add helpful pronouns or verbs to your lists.</p>
+                      </header>
+                      <div class="cs-coverage-panel">
+                        <div>
+                          <h5>Pronouns</h5>
+                          <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
                         </div>
-                      </section>
-                    </aside>
+                        <div>
+                          <h5>Attribution Verbs</h5>
+                          <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                        </div>
+                        <div>
+                          <h5>Action Verbs</h5>
+                          <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                        </div>
+                      </div>
+                    </section>
+                    <section class="cs-tester-panel cs-tester-panel--logs">
+                      <header class="cs-tester-panel-header">
+                        <h4>Debug Tools</h4>
+                        <p>Mirror the tester output to the browser console.</p>
+                      </header>
+                      <label class="cs-toggle cs-toggle--inline" title="Logs detailed decision-making to the browser console (F12) for troubleshooting.">
+                        <input id="cs-debug" type="checkbox" />
+                        <span class="cs-toggle-indicator"></span>
+                        <span><strong>Enable Debug Logging</strong></span>
+                      </label>
+                    </section>
                   </div>
                 </div>
               </div>
-            </section>
-          </div>
-          <div class="cs-column">
-            <section class="cs-card cs-card--compact">
-              <label class="cs-toggle cs-toggle--inline" title="Logs detailed decision-making to the browser console (F12) for troubleshooting.">
-                <input id="cs-debug" type="checkbox" />
-                <span class="cs-toggle-indicator"></span>
-                <span><strong>Enable Debug Logging</strong></span>
-              </label>
             </section>
           </div>
         </div>

--- a/settings.html
+++ b/settings.html
@@ -262,13 +262,6 @@
                   <small>Comma-separated list of pronouns the pronoun detector should recognize. Supports custom neopronouns.</small>
                   <textarea id="cs-pronoun-vocabulary" class="text_pole" rows="2"></textarea>
                 </div>
-                <div class="cs-lexicon-tools">
-                  <h4>Lexicon Packs</h4>
-                  <p class="cs-helper-text">Import curated verb and pronoun lists to jump-start new genres.</p>
-                  <div id="cs-lexicon-pack-buttons" class="cs-pack-buttons">
-                    <span class="cs-tester-list-placeholder">Loading packs…</span>
-                  </div>
-                </div>
               </div>
             </section>
           </div>
@@ -365,6 +358,13 @@
                     <h4>Scoring Presets</h4>
                     <p class="cs-helper-text">Save and compare weight profiles for different scenes.</p>
                   </div>
+                  <div class="cs-score-presets-guide" aria-live="polite">
+                    <ol>
+                      <li><strong>Preview:</strong> Pick a preset to see how its priorities compare with yours.</li>
+                      <li><strong>Inspect:</strong> Bars show the preset emphasis; the middle column shows your live values.</li>
+                      <li><strong>Apply or Tweak:</strong> Apply the preset or adjust individual weights before saving.</li>
+                    </ol>
+                  </div>
                   <div class="cs-toolbar">
                     <select id="cs-score-preset-select" class="text_pole" style="flex: 1 1 auto;" title="Select a saved scoring preset to preview its weights.">
                       <option value="">Select a scoring preset…</option>
@@ -378,13 +378,13 @@
                     <button id="cs-score-preset-rename" class="menu_button interactable" title="Rename the selected custom preset.">Rename</button>
                     <button id="cs-score-preset-delete" class="menu_button interactable cs-button-danger" title="Delete the selected custom preset.">Delete</button>
                   </div>
-                  <p id="cs-score-preset-message" class="cs-helper-text">Select a preset to preview its weights against the active profile.</p>
+                  <p id="cs-score-preset-message" class="cs-helper-text">Select a preset to preview how it stacks against your active profile.</p>
                   <div id="cs-score-preset-preview" class="cs-score-preview">
-                    <table class="cs-score-preview-table">
-                      <tbody>
-                        <tr><td colspan="3" class="cs-tester-list-placeholder">Select a preset to see weight comparisons.</td></tr>
-                      </tbody>
-                    </table>
+                      <table class="cs-score-preview-table">
+                        <tbody>
+                          <tr><td colspan="4" class="cs-tester-list-placeholder">Select a preset to see weight comparisons.</td></tr>
+                        </tbody>
+                      </table>
                   </div>
                 </div>
               </div>
@@ -412,55 +412,88 @@
                   <button id="cs-regex-test-button" class="menu_button interactable">Test Pattern</button>
                   <button id="cs-regex-test-copy" class="menu_button interactable" disabled title="Copy the latest live tester report to your clipboard.">Copy Report</button>
                 </div>
-                <div class="cs-tester-meta">
-                  <span class="cs-meta-label">Veto Status:</span>
-                  <span id="cs-test-veto-result" class="cs-tester-list-placeholder">N/A</span>
-                </div>
-                <div class="cs-tester-meta">
-                  <span class="cs-meta-label">Top Characters:</span>
-                  <span id="cs-test-top-characters" class="cs-tester-list-placeholder">N/A</span>
+                <div class="cs-tester-guide">
+                  <h4>Live Tester Walkthrough</h4>
+                  <ol>
+                    <li>Paste a recent chat message or narration chunk, then run <strong>Test Pattern</strong>.</li>
+                    <li>Check the summary cards to see which characters ranked highest and whether a switch fired.</li>
+                    <li>Drill into the panels below to inspect detections, winners, roster health, and vocabulary tips.</li>
+                  </ol>
                 </div>
                 <div id="cs-regex-test-output-container" class="text_pole cs-tester-output-container">
-                  <div class="cs-tester-col cs-tester-col--divider">
-                    <div class="cs-tester-title">All Detections (in order)</div>
-                    <ul id="cs-test-all-detections" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Results will appear here.</li>
-                    </ul>
-                  </div>
-                  <div class="cs-tester-col cs-tester-col--divider">
-                    <div class="cs-tester-title">Live Switch Decisions</div>
-                    <ul id="cs-test-winner-list" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
-                    </ul>
-                  </div>
-                  <div class="cs-tester-col cs-tester-col--insights">
-                    <div class="cs-tester-title">Scene Roster Timeline</div>
-                    <ul id="cs-test-roster-timeline" class="cs-tester-list">
-                      <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
-                    </ul>
-                    <div class="cs-tester-title">Roster Health</div>
-                    <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
-                    <div class="cs-tester-title">Score Breakdown</div>
-                    <table id="cs-test-score-breakdown" class="cs-score-table">
-                      <tbody>
-                        <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
-                      </tbody>
-                    </table>
-                    <div class="cs-tester-title">Coverage Suggestions</div>
-                    <div class="cs-coverage-panel">
-                      <div>
-                        <h5>Pronouns</h5>
-                        <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                      </div>
-                      <div>
-                        <h5>Attribution Verbs</h5>
-                        <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                      </div>
-                      <div>
-                        <h5>Action Verbs</h5>
-                        <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
-                      </div>
+                  <div class="cs-tester-summary-grid">
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Top Characters</span>
+                      <div id="cs-test-top-characters" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                      <p>Highest scoring matches from the last run.</p>
                     </div>
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Veto Status</span>
+                      <div id="cs-test-veto-result" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                      <p>Explains whether a cooldown or lock blocked the switch.</p>
+                    </div>
+                    <div class="cs-summary-card">
+                      <span class="cs-summary-label">Need a Hint?</span>
+                      <p class="cs-summary-help">Use the coverage suggestions to pad your verb lists or pronouns if detections feel thin.</p>
+                    </div>
+                  </div>
+                  <div class="cs-tester-panels">
+                    <div class="cs-tester-primary">
+                      <section class="cs-tester-panel">
+                        <div class="cs-tester-title">All Detections (in order)</div>
+                        <p class="cs-helper-text">Timeline of every match we spotted.</p>
+                        <ul id="cs-test-all-detections" class="cs-tester-list">
+                          <li class="cs-tester-list-placeholder">Results will appear here.</li>
+                        </ul>
+                      </section>
+                      <section class="cs-tester-panel">
+                        <div class="cs-tester-title">Live Switch Decisions</div>
+                        <p class="cs-helper-text">Shows who would have received the costume change.</p>
+                        <ul id="cs-test-winner-list" class="cs-tester-list">
+                          <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
+                        </ul>
+                      </section>
+                      <section class="cs-tester-panel">
+                        <div class="cs-tester-title">Scene Roster Timeline</div>
+                        <p class="cs-helper-text">Track roster joins, refreshes, and drops.</p>
+                        <ul id="cs-test-roster-timeline" class="cs-tester-list">
+                          <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
+                        </ul>
+                        <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
+                        <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
+                      </section>
+                    </div>
+                    <aside class="cs-tester-sidebar">
+                      <section class="cs-tester-panel cs-tester-panel--score">
+                        <div class="cs-tester-title">Score Breakdown</div>
+                        <p class="cs-helper-text">Scroll to compare how each detection contributed.</p>
+                        <div class="cs-score-scroll">
+                          <table id="cs-test-score-breakdown" class="cs-score-table">
+                            <tbody>
+                              <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </section>
+                      <section class="cs-tester-panel">
+                        <div class="cs-tester-title">Coverage Suggestions</div>
+                        <p class="cs-helper-text">Click a suggestion to add it to your vocabulary.</p>
+                        <div class="cs-coverage-panel">
+                          <div>
+                            <h5>Pronouns</h5>
+                            <div id="cs-coverage-pronouns" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                          </div>
+                          <div>
+                            <h5>Attribution Verbs</h5>
+                            <div id="cs-coverage-attribution" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                          </div>
+                          <div>
+                            <h5>Action Verbs</h5>
+                            <div id="cs-coverage-action" class="cs-coverage-list"><span class="cs-tester-list-placeholder">Run the tester to see suggestions.</span></div>
+                          </div>
+                        </div>
+                      </section>
+                    </aside>
                   </div>
                 </div>
               </div>

--- a/style.css
+++ b/style.css
@@ -455,16 +455,10 @@
 
 #costume-switcher-settings.cs-theme .cs-tester-panels {
   display: grid;
-  grid-template-columns: minmax(0, 2.1fr) minmax(0, 1fr);
-  gap: 18px;
-  align-items: start;
-}
-
-#costume-switcher-settings.cs-theme .cs-tester-primary,
-#costume-switcher-settings.cs-theme .cs-tester-sidebar {
-  display: flex;
-  flex-direction: column;
   gap: 16px;
+  align-items: stretch;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-auto-flow: dense;
 }
 
 #costume-switcher-settings.cs-theme .cs-tester-panel {
@@ -478,12 +472,69 @@
   min-height: 0;
 }
 
+#costume-switcher-settings.cs-theme .cs-tester-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-panel-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-panel-header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-panel--flow,
+#costume-switcher-settings.cs-theme .cs-tester-panel--coverage {
+  gap: 16px;
+}
+
 #costume-switcher-settings.cs-theme .cs-tester-panel--score {
+  gap: 12px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 14px;
 }
 
+#costume-switcher-settings.cs-theme .cs-tester-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#costume-switcher-settings.cs-theme .cs-roster-health {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-title--sub {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 #costume-switcher-settings.cs-theme .cs-score-scroll {
-  max-height: 260px;
+  max-height: 220px;
   overflow: auto;
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.04);
@@ -495,21 +546,24 @@
   margin: 0;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-title--sub {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+#costume-switcher-settings.cs-theme .cs-tester-panel--logs {
+  align-self: stretch;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-sidebar .cs-helper-text {
-  margin: 0;
+#costume-switcher-settings.cs-theme .cs-tester-panel--logs .cs-toggle {
+  margin-top: 4px;
 }
 
-@media (max-width: 1080px) {
-  #costume-switcher-settings.cs-theme .cs-tester-panels {
-    grid-template-columns: 1fr;
+@media (min-width: 1180px) {
+  #costume-switcher-settings.cs-theme .cs-tester-panel--flow,
+  #costume-switcher-settings.cs-theme .cs-tester-panel--coverage {
+    grid-column: span 2;
+  }
+
+  #costume-switcher-settings.cs-theme .cs-tester-panel--score,
+  #costume-switcher-settings.cs-theme .cs-tester-panel--roster,
+  #costume-switcher-settings.cs-theme .cs-tester-panel--logs {
+    grid-column: span 1;
   }
 }
 
@@ -525,7 +579,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 220px;
+  max-height: 180px;
   overflow-y: auto;
 }
 
@@ -560,7 +614,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-height: 110px;
+  min-height: 96px;
 }
 
 #costume-switcher-settings.cs-theme .cs-summary-label {
@@ -780,7 +834,7 @@
 #costume-switcher-settings.cs-theme .cs-coverage-panel {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 #costume-switcher-settings.cs-theme .cs-coverage-panel h5 {

--- a/style.css
+++ b/style.css
@@ -442,43 +442,75 @@
   padding-top: 4px;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-meta {
-  display: flex;
-  gap: 8px;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-  align-items: center;
-}
-
-#costume-switcher-settings.cs-theme .cs-meta-label {
-  font-weight: 600;
-  color: var(--text-color);
-}
-
 #costume-switcher-settings.cs-theme .cs-tester-output-container {
   margin-top: 6px;
-  border-radius: 14px;
-  background: rgba(0, 0, 0, 0.3);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-col {
+#costume-switcher-settings.cs-theme .cs-tester-panels {
+  display: grid;
+  grid-template-columns: minmax(0, 2.1fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-primary,
+#costume-switcher-settings.cs-theme .cs-tester-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-panel {
   padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  min-height: 0;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-col--divider {
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
+#costume-switcher-settings.cs-theme .cs-tester-panel--score {
+  gap: 14px;
 }
 
-#costume-switcher-settings.cs-theme .cs-tester-col--insights {
-  gap: 16px;
-  min-width: 260px;
+#costume-switcher-settings.cs-theme .cs-score-scroll {
+  max-height: 260px;
+  overflow: auto;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.01);
+  padding: 8px 4px;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-scroll table {
+  margin: 0;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-title--sub {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-sidebar .cs-helper-text {
+  margin: 0;
+}
+
+@media (max-width: 1080px) {
+  #costume-switcher-settings.cs-theme .cs-tester-panels {
+    grid-template-columns: 1fr;
+  }
 }
 
 #costume-switcher-settings.cs-theme .cs-tester-title {
@@ -514,6 +546,69 @@
   max-height: 140px;
 }
 
+#costume-switcher-settings.cs-theme .cs-tester-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 110px;
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+#costume-switcher-settings.cs-theme .cs-summary-help {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide ol {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-muted);
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-guide strong {
+  color: var(--text-color);
+}
+
 #costume-switcher-settings.cs-theme .cs-roster-warning {
   padding: 10px 12px;
   border-radius: 10px;
@@ -533,6 +628,27 @@
   gap: 12px;
 }
 
+#costume-switcher-settings.cs-theme .cs-score-presets-guide {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  border-left: 3px solid var(--accent);
+  padding: 10px 14px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-presets-guide ol {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-presets-guide strong {
+  color: var(--text-color);
+}
+
 #costume-switcher-settings.cs-theme .cs-score-presets-header h4 {
   margin: 0;
   font-size: 1rem;
@@ -542,6 +658,17 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.88rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-score-preview-table thead {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+#costume-switcher-settings.cs-theme .cs-score-preview-table thead th {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 
 #costume-switcher-settings.cs-theme .cs-score-preview-table th,
@@ -681,22 +808,6 @@
 #costume-switcher-settings.cs-theme .cs-coverage-pill:hover {
   background: color-mix(in srgb, var(--accent) 30%, transparent);
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-}
-
-#costume-switcher-settings.cs-theme .cs-lexicon-tools {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  padding: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-#costume-switcher-settings.cs-theme .cs-pack-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
 }
 
 #costume-switcher-settings.cs-theme #cs-mappings {
@@ -842,6 +953,10 @@
 
   #costume-switcher-settings.cs-theme .cs-master-toggle input {
     justify-self: flex-start;
+  }
+
+  #costume-switcher-settings.cs-theme .cs-tester-output-container {
+    padding: 14px;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the lexicon pack UI and supporting code while keeping coverage suggestions available for quick additions
- restructure the live tester into focused panels with helper text so key diagnostics are easier to scan
- confine the score breakdown to a scrollable container to reduce the vertical footprint of reports

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_690140134de88325ad974e3e32c7e9b7