### PR TITLE
Fix duplicate helper declarations in extension script

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -221,19 +221,6 @@ function getUniqueProfileName(baseName = 'Profile') {
     return `${attempt} (${counter})`;
 }
 
-function resolveMaxBufferChars(profile) {
-    const raw = Number(profile?.maxBufferChars);
-    if (Number.isFinite(raw) && raw > 0) {
-        return raw;
-    }
-    return PROFILE_DEFAULTS.maxBufferChars;
-}
-
-function resolveNumericSetting(value, fallback) {
-    const num = Number(value);
-    return Number.isFinite(num) ? num : fallback;
-}
-
 function populateProfileDropdown() {
     const select = $("#cs-profile-select");
     const settings = getSettings();


### PR DESCRIPTION
## Summary
- remove redundant resolveMaxBufferChars and resolveNumericSetting definitions from `src/extension.js`
- rely on shared utility exports to avoid runtime redeclaration errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69015b84811c832597d0ce839073897c