### PR TITLE
Fix escaping of user patterns before regex compilation

### DIFF
--- a/src/regex.js
+++ b/src/regex.js
@@ -87,8 +87,8 @@ export function parsePatternEntry(entry) {
         const trimmed = entry.trim();
         if (!trimmed) return null;
         const body = trimmed
-            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            .replace(/\s+/g, '\\s+');
+            .replace(/[.*+?^${}()|[\]\\]/g, (match) => `\\${match}`)
+            .replace(/\s+/g, () => '\\s+');
         return { body, raw: trimmed };
     }
     if (entry instanceof RegExp) {


### PR DESCRIPTION
## Summary
- escape regex metacharacters in pattern strings using a functional replacer so literal brackets compile under unicode flags
- ensure whitespace replacement emits proper `\s+` tokens when building pattern bodies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6901699b5a348325b4bf8db45821a78c