### PR TITLE
Support outfit-aware profile mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sillytavern-costumeswitch-testing",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/profile-utils.js
+++ b/profile-utils.js
@@ -1,0 +1,113 @@
+function safeClone(value) {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(value);
+        } catch (err) {
+            // Fall back to manual cloning below
+        }
+    }
+
+    try {
+        const json = JSON.stringify(value);
+        return json === undefined ? undefined : JSON.parse(json);
+    } catch (err) {
+        if (Array.isArray(value)) {
+            return value.map((item) => safeClone(item));
+        }
+        if (value && typeof value === 'object') {
+            return Object.keys(value).reduce((acc, key) => {
+                acc[key] = safeClone(value[key]);
+                return acc;
+            }, {});
+        }
+        return value;
+    }
+}
+
+function cloneOutfits(outfits) {
+    if (!Array.isArray(outfits)) {
+        return [];
+    }
+
+    const result = [];
+    outfits.forEach((item) => {
+        if (item == null) {
+            return;
+        }
+        if (typeof item === 'string') {
+            const trimmed = item.trim();
+            if (trimmed) {
+                result.push(trimmed);
+            }
+            return;
+        }
+        if (typeof item === 'object') {
+            const cloned = safeClone(item);
+            if (cloned && typeof cloned === 'object') {
+                result.push(cloned);
+            }
+        }
+    });
+    return result;
+}
+
+export function normalizeMappingEntry(entry = {}) {
+    const source = entry && typeof entry === 'object' ? entry : {};
+    const cloned = safeClone(source) || {};
+    const name = typeof cloned.name === 'string' ? cloned.name.trim() : '';
+
+    let defaultFolder = typeof cloned.defaultFolder === 'string' ? cloned.defaultFolder.trim() : '';
+    if (!defaultFolder && typeof cloned.folder === 'string') {
+        defaultFolder = cloned.folder.trim();
+    }
+    const outfits = cloneOutfits(cloned.outfits);
+
+    const normalized = {
+        ...cloned,
+        name,
+        defaultFolder,
+        outfits,
+    };
+
+    if (defaultFolder) {
+        normalized.folder = defaultFolder;
+    } else if (typeof normalized.folder === 'string') {
+        normalized.folder = normalized.folder.trim();
+        if (!normalized.defaultFolder && normalized.folder) {
+            normalized.defaultFolder = normalized.folder;
+        }
+    }
+
+    return normalized;
+}
+
+export function normalizeProfile(profile = {}, defaults = {}) {
+    const base = defaults && typeof defaults === 'object' ? (safeClone(defaults) || {}) : {};
+    const source = profile && typeof profile === 'object' ? (safeClone(profile) || {}) : {};
+    const merged = Object.assign(base, source);
+
+    if (Array.isArray(source.mappings)) {
+        merged.mappings = source.mappings.map((mapping) => normalizeMappingEntry(mapping));
+    } else {
+        merged.mappings = [];
+    }
+
+    return merged;
+}
+
+export function loadProfiles(rawProfiles = {}, defaults = {}) {
+    const normalized = {};
+    if (!rawProfiles || typeof rawProfiles !== 'object') {
+        return normalized;
+    }
+
+    for (const [name, profile] of Object.entries(rawProfiles)) {
+        normalized[name] = normalizeProfile(profile, defaults);
+    }
+
+    return normalized;
+}

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { loadProfiles, normalizeProfile } from '../profile-utils.js';
+
+const PROFILE_DEFAULTS = {
+    mappings: [],
+    enableOutfits: false,
+};
+
+test('loadProfiles wraps legacy mapping entries with default folder', () => {
+    const legacyProfiles = {
+        Legacy: {
+            mappings: [
+                { name: 'Alice', folder: 'alice-main' },
+            ],
+        },
+    };
+
+    const loaded = loadProfiles(legacyProfiles, PROFILE_DEFAULTS);
+
+    assert.ok(loaded.Legacy, 'profile should exist after load');
+    assert.equal(loaded.Legacy.enableOutfits, false, 'legacy profile should adopt default enableOutfits flag');
+    assert.equal(loaded.Legacy.mappings.length, 1, 'legacy mapping should be preserved');
+
+    const mapping = loaded.Legacy.mappings[0];
+    assert.equal(mapping.name, 'Alice');
+    assert.equal(mapping.defaultFolder, 'alice-main');
+    assert.equal(mapping.folder, 'alice-main', 'folder alias should match defaultFolder for compatibility');
+    assert.deepEqual(mapping.outfits, [], 'legacy mappings should expose an empty outfits array');
+
+    const serialized = JSON.parse(JSON.stringify(loaded.Legacy));
+    const rehydrated = normalizeProfile(serialized, PROFILE_DEFAULTS);
+    assert.deepEqual(rehydrated.mappings, loaded.Legacy.mappings, 'legacy mapping should round-trip through serialization');
+});
+
+test('loadProfiles preserves enableOutfits flag and outfit arrays', () => {
+    const modernProfiles = {
+        Modern: {
+            enableOutfits: true,
+            mappings: [
+                {
+                    name: 'Bob',
+                    defaultFolder: 'bob/base',
+                    outfits: ['bob/casual', { slot: 'formal', folder: 'bob/formal' }],
+                },
+            ],
+        },
+    };
+
+    const loaded = loadProfiles(modernProfiles, PROFILE_DEFAULTS);
+
+    assert.ok(loaded.Modern, 'profile should exist after load');
+    assert.equal(loaded.Modern.enableOutfits, true, 'enableOutfits flag should persist');
+    assert.equal(loaded.Modern.mappings.length, 1, 'mapping entry should be retained');
+
+    const mapping = loaded.Modern.mappings[0];
+    assert.equal(mapping.defaultFolder, 'bob/base');
+    assert.equal(mapping.folder, 'bob/base');
+    assert.deepEqual(mapping.outfits, ['bob/casual', { slot: 'formal', folder: 'bob/formal' }]);
+    assert.notStrictEqual(mapping.outfits[1], modernProfiles.Modern.mappings[0].outfits[1], 'outfits should be cloned');
+
+    const serialized = JSON.parse(JSON.stringify(loaded.Modern));
+    const rehydrated = normalizeProfile(serialized, PROFILE_DEFAULTS);
+    assert.deepEqual(rehydrated.mappings, loaded.Modern.mappings, 'modern mapping should round-trip through serialization');
+    assert.equal(rehydrated.enableOutfits, true, 'modern profile should preserve enableOutfits flag');
+});


### PR DESCRIPTION
## Summary
- add utilities for normalizing profile mappings and loading profile data
- update profile save/load paths to preserve default folders, outfits, and outfit flags
- add automated tests covering legacy and modern profile round-trips

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6901b5a1a76083258d0f5aab435be90a