### PR TITLE
Fix syntax error in mapping row button creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1703,7 +1703,7 @@ function renderMappings(profile) {
         row.data('outfits', outfits);
         row.append($("<td>").append($("<input>").addClass("map-name text_pole").val(normalized.name || "")));
         row.append($("<td>").append($("<input>").addClass("map-folder text_pole").val(normalized.defaultFolder || normalized.folder || "")));
-        row.append($("<td>").append($("<button>").addClass("map-remove menu_button interactable").html('<i class="fa-solid fa-trash-can"></i>'))));
+        row.append($("<td>").append($("<button>").addClass("map-remove menu_button interactable").html('<i class="fa-solid fa-trash-can"></i>')));
         tbody.append(row);
     });
 }


### PR DESCRIPTION
## Summary
- remove the extra closing parenthesis when rendering the mapping remove button
- ensure the mappings table renders without a syntax error

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6901b93b7b2483259dc63685a1de617f