### PR TITLE
feat: make outfit character slots collapsible

### DIFF
--- a/style.css
+++ b/style.css
@@ -244,12 +244,25 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
+#costume-switcher-settings.cs-theme .cs-outfit-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 #costume-switcher-settings.cs-theme .cs-outfit-card-header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+#costume-switcher-settings.cs-theme .cs-outfit-card-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
 }
 
 #costume-switcher-settings.cs-theme .cs-outfit-card-title {
@@ -262,6 +275,25 @@
   font-size: 1.3rem;
   color: var(--accent);
   margin-top: 4px;
+}
+
+#costume-switcher-settings.cs-theme .cs-outfit-card-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+
+#costume-switcher-settings.cs-theme .cs-outfit-card-toggle i {
+  transition: transform 0.2s ease;
+}
+
+#costume-switcher-settings.cs-theme .cs-outfit-card.is-collapsed .cs-outfit-card-toggle i {
+  transform: rotate(-90deg);
+}
+
+#costume-switcher-settings.cs-theme .cs-outfit-card.is-collapsed {
+  gap: 12px;
 }
 
 #costume-switcher-settings.cs-theme .cs-outfit-card .cs-field label {


### PR DESCRIPTION
## Summary
- add collapse toggles to outfit character cards and persist their state
- keep collapse preferences in sync when mappings are removed
- style the card headers and toggles for the collapsible layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6902d859213c8325a20e6193e9bfa586