### PR TITLE
Fix browser import for verb catalog data

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,18 @@ import { saveSettingsDebounced, event_types, eventSource } from "../../../../scr
 import { executeSlashCommandsOnChatInput, registerSlashCommand } from "../../../slash-commands.js";
 import {
     DEFAULT_ACTION_VERBS,
+    DEFAULT_ACTION_VERBS_PRESENT,
+    DEFAULT_ACTION_VERBS_THIRD_PERSON,
     DEFAULT_ATTRIBUTION_VERBS,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT,
+    DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
     EXTENDED_ACTION_VERBS,
+    EXTENDED_ACTION_VERBS_PRESENT,
+    EXTENDED_ACTION_VERBS_THIRD_PERSON,
     EXTENDED_ATTRIBUTION_VERBS,
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT,
+    EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+    buildVerbSlices,
 } from "./verbs.js";
 import { loadProfiles, normalizeProfile, normalizeMappingEntry } from "./profile-utils.js";
 
@@ -266,13 +275,25 @@ const KNOWN_PRONOUNS = new Set([
 
 const KNOWN_ATTRIBUTION_VERBS = new Set([
     ...PROFILE_DEFAULTS.attributionVerbs,
+    ...DEFAULT_ATTRIBUTION_VERBS_PRESENT,
+    ...DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
     ...EXTENDED_ATTRIBUTION_VERBS,
+    ...EXTENDED_ATTRIBUTION_VERBS_PRESENT,
+    ...EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
 ].map(value => String(value).toLowerCase()));
 
 const KNOWN_ACTION_VERBS = new Set([
     ...PROFILE_DEFAULTS.actionVerbs,
+    ...DEFAULT_ACTION_VERBS_PRESENT,
+    ...DEFAULT_ACTION_VERBS_THIRD_PERSON,
     ...EXTENDED_ACTION_VERBS,
+    ...EXTENDED_ACTION_VERBS_PRESENT,
+    ...EXTENDED_ACTION_VERBS_THIRD_PERSON,
 ].map(value => String(value).toLowerCase()));
+
+function getVerbInflections(category = "attribution", edition = "default") {
+    return buildVerbSlices({ category, edition });
+}
 
 const DEFAULTS = {
     enabled: true,
@@ -5048,6 +5069,7 @@ export {
     summarizeOutfitDecision,
     state,
     extensionName,
+    getVerbInflections,
 };
 
 function load() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "sillytavern-costumeswitch-testing",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sillytavern-costumeswitch-testing",
+      "version": "0.0.0",
+      "dependencies": {
+        "en-inflectors": "^1.0.12",
+        "wink-lemmatizer": "^3.0.4"
+      }
+    },
+    "node_modules/en-inflectors": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/en-inflectors/-/en-inflectors-1.0.12.tgz",
+      "integrity": "sha512-G9wwJMx9DQQzwom8J8e8ErVpI6h/Z5BpYusJCE2Q/2NfgBNYCesyNaCOOskZAhOrw2nmR4D8nYAv4Xv/INIbzw==",
+      "license": "MIT",
+      "dependencies": {
+        "en-stemmer": "^1.0.2"
+      }
+    },
+    "node_modules/en-stemmer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/en-stemmer/-/en-stemmer-1.0.3.tgz",
+      "integrity": "sha512-sBeYsHLqZWACn/mTRLAMdYb/A53s55r4/nCB2UjKK96EBuRQ4t4GKl4V1pW/0hvzdncfYlZRT+JSIRxCtoYqbA==",
+      "license": "MIT"
+    },
+    "node_modules/wink-lemmatizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/wink-lemmatizer/-/wink-lemmatizer-3.0.4.tgz",
+      "integrity": "sha512-EdLJfy1xLF2ze2cp9Z3qiEWjiq+V8ZVRWiWooCXTXR0AyPxY8ezm4E0puJ0yIj5szzED9tcXV2U7RboaGvboFw==",
+      "license": "MIT",
+      "dependencies": {
+        "wink-lexicon": "^2.2.0",
+        "wink-porter2-stemmer": "^2.0.0"
+      }
+    },
+    "node_modules/wink-lexicon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/wink-lexicon/-/wink-lexicon-2.2.0.tgz",
+      "integrity": "sha512-QIuHS9r/HV6q3PCCz6pymg4gbsryW9wDk8CHdU+sDn0kJcHpECNDIcdY0Q/mZpqxtFLp9dzIw7pjcStLBbGZGg==",
+      "license": "MIT"
+    },
+    "node_modules/wink-porter2-stemmer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wink-porter2-stemmer/-/wink-porter2-stemmer-2.0.1.tgz",
+      "integrity": "sha512-0g+RkkqhRXFmSpJQStVXW5N/WsshWpJXsoDRW7DwVkGI2uDT6IBCoq3xdH5p6IHLaC6ygk7RWUsUx4alKxoagQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "type": "module",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "en-inflectors": "^1.0.12",
+    "wink-lemmatizer": "^3.0.4"
   }
 }

--- a/src/data/verbCatalog.js
+++ b/src/data/verbCatalog.js
@@ -1,0 +1,79 @@
+import verbCatalog from "./verbCatalogData.js";
+
+const CATEGORY_KEYS = new Set(["attribution", "action"]);
+const EDITION_KEYS = new Set(["default", "extended"]);
+
+export const VERB_CATALOG = verbCatalog;
+
+function normalizeOptions(options = {}) {
+    const category = options.category || "attribution";
+    const edition = options.edition || "default";
+    if (!CATEGORY_KEYS.has(category)) {
+        throw new Error(`Unknown verb category: ${category}`);
+    }
+    if (!EDITION_KEYS.has(edition)) {
+        throw new Error(`Unknown verb edition: ${edition}`);
+    }
+    return { category, edition };
+}
+
+function getEntries(options = {}) {
+    const { category, edition } = normalizeOptions(options);
+    return VERB_CATALOG
+        .filter(entry => Boolean(entry?.categories?.[category]?.[edition]))
+        .sort((a, b) => a.base.localeCompare(b.base));
+}
+
+function buildUniqueList(entries, selector) {
+    const seen = new Set();
+    const list = [];
+    for (const entry of entries) {
+        const value = selector(entry);
+        if (!value || seen.has(value)) {
+            continue;
+        }
+        seen.add(value);
+        list.push(value);
+    }
+    return list;
+}
+
+export function buildVerbSlices(options = {}) {
+    const entries = getEntries(options);
+    return {
+        base: buildUniqueList(entries, entry => entry.forms.base),
+        thirdPerson: buildUniqueList(entries, entry => entry.forms.thirdPerson),
+        past: buildUniqueList(entries, entry => entry.forms.past),
+        pastParticiple: buildUniqueList(entries, entry => entry.forms.pastParticiple),
+        presentParticiple: buildUniqueList(entries, entry => entry.forms.presentParticiple),
+    };
+}
+
+export function buildLegacyVerbList(options = {}) {
+    const { category, edition } = normalizeOptions(options);
+    const entries = getEntries({ category, edition });
+
+    if (category === "action") {
+        if (edition === "default") {
+            const legacy = [];
+            for (const entry of entries) {
+                const baseForm = entry.forms.base;
+                const pastForm = entry.forms.past;
+                if (baseForm) {
+                    legacy.push(baseForm);
+                }
+                if (pastForm && pastForm !== baseForm) {
+                    legacy.push(pastForm);
+                }
+            }
+            return legacy;
+        }
+        return buildUniqueList(entries, entry => entry.forms.past);
+    }
+
+    return buildUniqueList(entries, entry => entry.forms.past);
+}
+
+export function getVerbEntries(options = {}) {
+    return getEntries(options);
+}

--- a/src/data/verbCatalogData.js
+++ b/src/data/verbCatalogData.js
@@ -1,0 +1,13442 @@
+export default [
+    {
+        "base": "accelerate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "accelerate",
+            "thirdPerson": "accelerates",
+            "past": "accelerated",
+            "pastParticiple": "accelerated",
+            "presentParticiple": "accelerating"
+        }
+    },
+    {
+        "base": "acknowledge",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "acknowledge",
+            "thirdPerson": "acknowledges",
+            "past": "acknowledged",
+            "pastParticiple": "acknowledged",
+            "presentParticiple": "acknowledging"
+        }
+    },
+    {
+        "base": "add",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "add",
+            "thirdPerson": "adds",
+            "past": "added",
+            "pastParticiple": "added",
+            "presentParticiple": "adding"
+        }
+    },
+    {
+        "base": "address",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "address",
+            "thirdPerson": "addresses",
+            "past": "addressed",
+            "pastParticiple": "addressed",
+            "presentParticiple": "addressing"
+        }
+    },
+    {
+        "base": "adjudge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "adjudge",
+            "thirdPerson": "adjudges",
+            "past": "adjudged",
+            "pastParticiple": "adjudged",
+            "presentParticiple": "adjudging"
+        }
+    },
+    {
+        "base": "adjust",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "adjust",
+            "thirdPerson": "adjusts",
+            "past": "adjusted",
+            "pastParticiple": "adjusted",
+            "presentParticiple": "adjusting"
+        }
+    },
+    {
+        "base": "admit",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "admit",
+            "thirdPerson": "admits",
+            "past": "admitted",
+            "pastParticiple": "admitted",
+            "presentParticiple": "admitting"
+        }
+    },
+    {
+        "base": "advise",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "advise",
+            "thirdPerson": "advises",
+            "past": "advised",
+            "pastParticiple": "advised",
+            "presentParticiple": "advising"
+        }
+    },
+    {
+        "base": "affirm",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "affirm",
+            "thirdPerson": "affirms",
+            "past": "affirmed",
+            "pastParticiple": "affirmed",
+            "presentParticiple": "affirming"
+        }
+    },
+    {
+        "base": "agree",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "agree",
+            "thirdPerson": "agrees",
+            "past": "agreed",
+            "pastParticiple": "agreed",
+            "presentParticiple": "agreeing"
+        }
+    },
+    {
+        "base": "allege",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "allege",
+            "thirdPerson": "alleges",
+            "past": "alleged",
+            "pastParticiple": "alleged",
+            "presentParticiple": "alleging"
+        }
+    },
+    {
+        "base": "amble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "amble",
+            "thirdPerson": "ambles",
+            "past": "ambled",
+            "pastParticiple": "ambled",
+            "presentParticiple": "ambling"
+        }
+    },
+    {
+        "base": "angle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "angle",
+            "thirdPerson": "angles",
+            "past": "angled",
+            "pastParticiple": "angled",
+            "presentParticiple": "angling"
+        }
+    },
+    {
+        "base": "announce",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "announce",
+            "thirdPerson": "announces",
+            "past": "announced",
+            "pastParticiple": "announced",
+            "presentParticiple": "announcing"
+        }
+    },
+    {
+        "base": "answer",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "answer",
+            "thirdPerson": "answers",
+            "past": "answered",
+            "pastParticiple": "answered",
+            "presentParticiple": "answering"
+        }
+    },
+    {
+        "base": "appeal",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "appeal",
+            "thirdPerson": "appeals",
+            "past": "appealed",
+            "pastParticiple": "appealed",
+            "presentParticiple": "appealing"
+        }
+    },
+    {
+        "base": "appear",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "appear",
+            "thirdPerson": "appears",
+            "past": "appeared",
+            "pastParticiple": "appeared",
+            "presentParticiple": "appearing"
+        }
+    },
+    {
+        "base": "applaud",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "applaud",
+            "thirdPerson": "applauds",
+            "past": "applauded",
+            "pastParticiple": "applauded",
+            "presentParticiple": "applauding"
+        }
+    },
+    {
+        "base": "approach",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "approach",
+            "thirdPerson": "approaches",
+            "past": "approached",
+            "pastParticiple": "approached",
+            "presentParticiple": "approaching"
+        }
+    },
+    {
+        "base": "arc",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "arc",
+            "thirdPerson": "arcs",
+            "past": "arced",
+            "pastParticiple": "arced",
+            "presentParticiple": "arcing"
+        }
+    },
+    {
+        "base": "arch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "arch",
+            "thirdPerson": "arches",
+            "past": "arched",
+            "pastParticiple": "arched",
+            "presentParticiple": "arching"
+        }
+    },
+    {
+        "base": "argue",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "argue",
+            "thirdPerson": "argues",
+            "past": "argued",
+            "pastParticiple": "argued",
+            "presentParticiple": "arguing"
+        }
+    },
+    {
+        "base": "arrive",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "arrive",
+            "thirdPerson": "arrives",
+            "past": "arrived",
+            "pastParticiple": "arrived",
+            "presentParticiple": "arriving"
+        }
+    },
+    {
+        "base": "articulate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "articulate",
+            "thirdPerson": "articulates",
+            "past": "articulated",
+            "pastParticiple": "articulated",
+            "presentParticiple": "articulating"
+        }
+    },
+    {
+        "base": "ascend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "ascend",
+            "thirdPerson": "ascends",
+            "past": "ascended",
+            "pastParticiple": "ascended",
+            "presentParticiple": "ascending"
+        }
+    },
+    {
+        "base": "ask",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "ask",
+            "thirdPerson": "asks",
+            "past": "asked",
+            "pastParticiple": "asked",
+            "presentParticiple": "asking"
+        }
+    },
+    {
+        "base": "assemble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "assemble",
+            "thirdPerson": "assembles",
+            "past": "assembled",
+            "pastParticiple": "assembled",
+            "presentParticiple": "assembling"
+        }
+    },
+    {
+        "base": "assert",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "assert",
+            "thirdPerson": "asserts",
+            "past": "asserted",
+            "pastParticiple": "asserted",
+            "presentParticiple": "asserting"
+        }
+    },
+    {
+        "base": "assure",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "assure",
+            "thirdPerson": "assures",
+            "past": "assured",
+            "pastParticiple": "assured",
+            "presentParticiple": "assuring"
+        }
+    },
+    {
+        "base": "attack",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "attack",
+            "thirdPerson": "attacks",
+            "past": "attacked",
+            "pastParticiple": "attacked",
+            "presentParticiple": "attacking"
+        }
+    },
+    {
+        "base": "aver",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "aver",
+            "thirdPerson": "avers",
+            "past": "averred",
+            "pastParticiple": "averred",
+            "presentParticiple": "averring"
+        }
+    },
+    {
+        "base": "avow",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "avow",
+            "thirdPerson": "avows",
+            "past": "avowed",
+            "pastParticiple": "avowed",
+            "presentParticiple": "avowing"
+        }
+    },
+    {
+        "base": "babble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "babble",
+            "thirdPerson": "babbles",
+            "past": "babbled",
+            "pastParticiple": "babbled",
+            "presentParticiple": "babbling"
+        }
+    },
+    {
+        "base": "backpedal",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "backpedal",
+            "thirdPerson": "backpedals",
+            "past": "backpedaled",
+            "pastParticiple": "backpedaled",
+            "presentParticiple": "backpedaling"
+        }
+    },
+    {
+        "base": "balance",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "balance",
+            "thirdPerson": "balances",
+            "past": "balanced",
+            "pastParticiple": "balanced",
+            "presentParticiple": "balancing"
+        }
+    },
+    {
+        "base": "banter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "banter",
+            "thirdPerson": "banters",
+            "past": "bantered",
+            "pastParticiple": "bantered",
+            "presentParticiple": "bantering"
+        }
+    },
+    {
+        "base": "barge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "barge",
+            "thirdPerson": "barges",
+            "past": "barged",
+            "pastParticiple": "barged",
+            "presentParticiple": "barging"
+        }
+    },
+    {
+        "base": "bark",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bark",
+            "thirdPerson": "barks",
+            "past": "barked",
+            "pastParticiple": "barked",
+            "presentParticiple": "barking"
+        }
+    },
+    {
+        "base": "bawl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bawl",
+            "thirdPerson": "bawls",
+            "past": "bawled",
+            "pastParticiple": "bawled",
+            "presentParticiple": "bawling"
+        }
+    },
+    {
+        "base": "be",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "be",
+            "thirdPerson": "is",
+            "past": "was",
+            "pastParticiple": "been",
+            "presentParticiple": "being"
+        }
+    },
+    {
+        "base": "beckon",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "beckon",
+            "thirdPerson": "beckons",
+            "past": "beckonned",
+            "pastParticiple": "beckonned",
+            "presentParticiple": "beckonning"
+        }
+    },
+    {
+        "base": "beg",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "beg",
+            "thirdPerson": "begs",
+            "past": "begged",
+            "pastParticiple": "begged",
+            "presentParticiple": "begging"
+        }
+    },
+    {
+        "base": "begin",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "begin",
+            "thirdPerson": "begins",
+            "past": "began",
+            "pastParticiple": "begun",
+            "presentParticiple": "beginning"
+        }
+    },
+    {
+        "base": "bellow",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bellow",
+            "thirdPerson": "bellows",
+            "past": "bellowed",
+            "pastParticiple": "bellowed",
+            "presentParticiple": "bellowing"
+        }
+    },
+    {
+        "base": "bend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bend",
+            "thirdPerson": "bends",
+            "past": "bent",
+            "pastParticiple": "bent",
+            "presentParticiple": "bending"
+        }
+    },
+    {
+        "base": "bind",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bind",
+            "thirdPerson": "binds",
+            "past": "bound",
+            "pastParticiple": "bound",
+            "presentParticiple": "binding"
+        }
+    },
+    {
+        "base": "blather",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "blather",
+            "thirdPerson": "blathers",
+            "past": "blathered",
+            "pastParticiple": "blathered",
+            "presentParticiple": "blathering"
+        }
+    },
+    {
+        "base": "bleat",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bleat",
+            "thirdPerson": "bleats",
+            "past": "bleated",
+            "pastParticiple": "bleated",
+            "presentParticiple": "bleating"
+        }
+    },
+    {
+        "base": "blink",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "blink",
+            "thirdPerson": "blinks",
+            "past": "blinked",
+            "pastParticiple": "blinked",
+            "presentParticiple": "blinking"
+        }
+    },
+    {
+        "base": "blubber",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "blubber",
+            "thirdPerson": "blubbers",
+            "past": "blubbered",
+            "pastParticiple": "blubbered",
+            "presentParticiple": "blubbering"
+        }
+    },
+    {
+        "base": "blurt",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "blurt",
+            "thirdPerson": "blurts",
+            "past": "blurted",
+            "pastParticiple": "blurted",
+            "presentParticiple": "blurting"
+        }
+    },
+    {
+        "base": "boast",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "boast",
+            "thirdPerson": "boasts",
+            "past": "boasted",
+            "pastParticiple": "boasted",
+            "presentParticiple": "boasting"
+        }
+    },
+    {
+        "base": "bolt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "bolt",
+            "thirdPerson": "bolts",
+            "past": "bolted",
+            "pastParticiple": "bolted",
+            "presentParticiple": "bolting"
+        }
+    },
+    {
+        "base": "bound",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "bind",
+            "thirdPerson": "binds",
+            "past": "bound",
+            "pastParticiple": "bound",
+            "presentParticiple": "binding"
+        }
+    },
+    {
+        "base": "bow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bow",
+            "thirdPerson": "bows",
+            "past": "bowed",
+            "pastParticiple": "bowed",
+            "presentParticiple": "bowing"
+        }
+    },
+    {
+        "base": "brace",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "brace",
+            "thirdPerson": "braces",
+            "past": "braced",
+            "pastParticiple": "braced",
+            "presentParticiple": "bracing"
+        }
+    },
+    {
+        "base": "brag",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "brag",
+            "thirdPerson": "brags",
+            "past": "bragged",
+            "pastParticiple": "bragged",
+            "presentParticiple": "bragging"
+        }
+    },
+    {
+        "base": "brandish",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "brandish",
+            "thirdPerson": "brandishes",
+            "past": "brandished",
+            "pastParticiple": "brandished",
+            "presentParticiple": "brandishing"
+        }
+    },
+    {
+        "base": "breach",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "breach",
+            "thirdPerson": "breaches",
+            "past": "breached",
+            "pastParticiple": "breached",
+            "presentParticiple": "breaching"
+        }
+    },
+    {
+        "base": "breathe",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "breathe",
+            "thirdPerson": "breathes",
+            "past": "breathed",
+            "pastParticiple": "breathed",
+            "presentParticiple": "breathing"
+        }
+    },
+    {
+        "base": "breeze",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "breeze",
+            "thirdPerson": "breezes",
+            "past": "breezed",
+            "pastParticiple": "breezed",
+            "presentParticiple": "breezing"
+        }
+    },
+    {
+        "base": "bring",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "bring",
+            "thirdPerson": "brings",
+            "past": "brought",
+            "pastParticiple": "brought",
+            "presentParticiple": "bringing"
+        }
+    },
+    {
+        "base": "bristle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "bristle",
+            "thirdPerson": "bristles",
+            "past": "bristled",
+            "pastParticiple": "bristled",
+            "presentParticiple": "bristling"
+        }
+    },
+    {
+        "base": "brood",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "brood",
+            "thirdPerson": "broods",
+            "past": "brooded",
+            "pastParticiple": "brooded",
+            "presentParticiple": "brooding"
+        }
+    },
+    {
+        "base": "brush",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "brush",
+            "thirdPerson": "brushes",
+            "past": "brushed",
+            "pastParticiple": "brushed",
+            "presentParticiple": "brushing"
+        }
+    },
+    {
+        "base": "bubble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "bubble",
+            "thirdPerson": "bubbles",
+            "past": "bubbled",
+            "pastParticiple": "bubbled",
+            "presentParticiple": "bubbling"
+        }
+    },
+    {
+        "base": "burrow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "burrow",
+            "thirdPerson": "burrows",
+            "past": "burrowed",
+            "pastParticiple": "burrowed",
+            "presentParticiple": "burrowing"
+        }
+    },
+    {
+        "base": "bustle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "bustle",
+            "thirdPerson": "bustles",
+            "past": "bustled",
+            "pastParticiple": "bustled",
+            "presentParticiple": "bustling"
+        }
+    },
+    {
+        "base": "butt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "butt",
+            "thirdPerson": "butts",
+            "past": "butted",
+            "pastParticiple": "butted",
+            "presentParticiple": "butting"
+        }
+    },
+    {
+        "base": "cackle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "cackle",
+            "thirdPerson": "cackles",
+            "past": "cackled",
+            "pastParticiple": "cackled",
+            "presentParticiple": "cackling"
+        }
+    },
+    {
+        "base": "cajole",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "cajole",
+            "thirdPerson": "cajoles",
+            "past": "cajoled",
+            "pastParticiple": "cajoled",
+            "presentParticiple": "cajoling"
+        }
+    },
+    {
+        "base": "calibrate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "calibrate",
+            "thirdPerson": "calibrates",
+            "past": "calibrated",
+            "pastParticiple": "calibrated",
+            "presentParticiple": "calibrating"
+        }
+    },
+    {
+        "base": "call",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "call",
+            "thirdPerson": "calls",
+            "past": "called",
+            "pastParticiple": "called",
+            "presentParticiple": "calling"
+        }
+    },
+    {
+        "base": "careen",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "careen",
+            "thirdPerson": "careens",
+            "past": "careened",
+            "pastParticiple": "careened",
+            "presentParticiple": "careening"
+        }
+    },
+    {
+        "base": "carve",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "carve",
+            "thirdPerson": "carves",
+            "past": "carved",
+            "pastParticiple": "carved",
+            "presentParticiple": "carving"
+        }
+    },
+    {
+        "base": "cast",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "cast",
+            "thirdPerson": "casts",
+            "past": "cast",
+            "pastParticiple": "cast",
+            "presentParticiple": "casting"
+        }
+    },
+    {
+        "base": "caution",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "caution",
+            "thirdPerson": "cautions",
+            "past": "cautioned",
+            "pastParticiple": "cautioned",
+            "presentParticiple": "cautioning"
+        }
+    },
+    {
+        "base": "celebrate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "celebrate",
+            "thirdPerson": "celebrates",
+            "past": "celebrated",
+            "pastParticiple": "celebrated",
+            "presentParticiple": "celebrating"
+        }
+    },
+    {
+        "base": "chant",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chant",
+            "thirdPerson": "chants",
+            "past": "chanted",
+            "pastParticiple": "chanted",
+            "presentParticiple": "chanting"
+        }
+    },
+    {
+        "base": "charge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "charge",
+            "thirdPerson": "charges",
+            "past": "charged",
+            "pastParticiple": "charged",
+            "presentParticiple": "charging"
+        }
+    },
+    {
+        "base": "chase",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "chase",
+            "thirdPerson": "chases",
+            "past": "chased",
+            "pastParticiple": "chased",
+            "presentParticiple": "chasing"
+        }
+    },
+    {
+        "base": "chat",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chat",
+            "thirdPerson": "chats",
+            "past": "chatted",
+            "pastParticiple": "chatted",
+            "presentParticiple": "chatting"
+        }
+    },
+    {
+        "base": "cheer",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "cheer",
+            "thirdPerson": "cheers",
+            "past": "cheered",
+            "pastParticiple": "cheered",
+            "presentParticiple": "cheering"
+        }
+    },
+    {
+        "base": "chime",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chime",
+            "thirdPerson": "chimes",
+            "past": "chimed",
+            "pastParticiple": "chimed",
+            "presentParticiple": "chiming"
+        }
+    },
+    {
+        "base": "chirp",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chirp",
+            "thirdPerson": "chirps",
+            "past": "chirped",
+            "pastParticiple": "chirped",
+            "presentParticiple": "chirping"
+        }
+    },
+    {
+        "base": "chortle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chortle",
+            "thirdPerson": "chortles",
+            "past": "chortled",
+            "pastParticiple": "chortled",
+            "presentParticiple": "chortling"
+        }
+    },
+    {
+        "base": "chuckle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "chuckle",
+            "thirdPerson": "chuckles",
+            "past": "chuckled",
+            "pastParticiple": "chuckled",
+            "presentParticiple": "chuckling"
+        }
+    },
+    {
+        "base": "circle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "circle",
+            "thirdPerson": "circles",
+            "past": "circled",
+            "pastParticiple": "circled",
+            "presentParticiple": "circling"
+        }
+    },
+    {
+        "base": "clamber",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "clamber",
+            "thirdPerson": "clambers",
+            "past": "clambered",
+            "pastParticiple": "clambered",
+            "presentParticiple": "clambering"
+        }
+    },
+    {
+        "base": "clamor",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "clamor",
+            "thirdPerson": "clamors",
+            "past": "clamored",
+            "pastParticiple": "clamored",
+            "presentParticiple": "clamoring"
+        }
+    },
+    {
+        "base": "clap",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "clap",
+            "thirdPerson": "claps",
+            "past": "clapped",
+            "pastParticiple": "clapped",
+            "presentParticiple": "clapping"
+        }
+    },
+    {
+        "base": "clarify",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "clarify",
+            "thirdPerson": "clarifies",
+            "past": "clarified",
+            "pastParticiple": "clarified",
+            "presentParticiple": "clarifying"
+        }
+    },
+    {
+        "base": "clash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "clash",
+            "thirdPerson": "clashes",
+            "past": "clashed",
+            "pastParticiple": "clashed",
+            "presentParticiple": "clashing"
+        }
+    },
+    {
+        "base": "claw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "claw",
+            "thirdPerson": "claws",
+            "past": "clawed",
+            "pastParticiple": "clawed",
+            "presentParticiple": "clawing"
+        }
+    },
+    {
+        "base": "clench",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "clench",
+            "thirdPerson": "clenches",
+            "past": "clenched",
+            "pastParticiple": "clenched",
+            "presentParticiple": "clenching"
+        }
+    },
+    {
+        "base": "climb",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "climb",
+            "thirdPerson": "climbs",
+            "past": "climbed",
+            "pastParticiple": "climbed",
+            "presentParticiple": "climbing"
+        }
+    },
+    {
+        "base": "cling",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "cling",
+            "thirdPerson": "clings",
+            "past": "clung",
+            "pastParticiple": "clung",
+            "presentParticiple": "clinging"
+        }
+    },
+    {
+        "base": "clutch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "clutch",
+            "thirdPerson": "clutches",
+            "past": "clutched",
+            "pastParticiple": "clutched",
+            "presentParticiple": "clutching"
+        }
+    },
+    {
+        "base": "coil",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "coil",
+            "thirdPerson": "coils",
+            "past": "coiled",
+            "pastParticiple": "coiled",
+            "presentParticiple": "coiling"
+        }
+    },
+    {
+        "base": "collapse",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "collapse",
+            "thirdPerson": "collapses",
+            "past": "collapsed",
+            "pastParticiple": "collapsed",
+            "presentParticiple": "collapsing"
+        }
+    },
+    {
+        "base": "collide",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "collide",
+            "thirdPerson": "collides",
+            "past": "collided",
+            "pastParticiple": "collided",
+            "presentParticiple": "colliding"
+        }
+    },
+    {
+        "base": "come",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "come",
+            "thirdPerson": "comes",
+            "past": "came",
+            "pastParticiple": "come",
+            "presentParticiple": "coming"
+        }
+    },
+    {
+        "base": "command",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "command",
+            "thirdPerson": "commands",
+            "past": "commanded",
+            "pastParticiple": "commanded",
+            "presentParticiple": "commanding"
+        }
+    },
+    {
+        "base": "commandeer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "commandeer",
+            "thirdPerson": "commandeers",
+            "past": "commandeered",
+            "pastParticiple": "commandeered",
+            "presentParticiple": "commandeering"
+        }
+    },
+    {
+        "base": "comment",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "comment",
+            "thirdPerson": "comments",
+            "past": "commented",
+            "pastParticiple": "commented",
+            "presentParticiple": "commenting"
+        }
+    },
+    {
+        "base": "complain",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "complain",
+            "thirdPerson": "complains",
+            "past": "complained",
+            "pastParticiple": "complained",
+            "presentParticiple": "complaining"
+        }
+    },
+    {
+        "base": "concede",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "concede",
+            "thirdPerson": "concedes",
+            "past": "conceded",
+            "pastParticiple": "conceded",
+            "presentParticiple": "conceding"
+        }
+    },
+    {
+        "base": "conclude",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "conclude",
+            "thirdPerson": "concludes",
+            "past": "concluded",
+            "pastParticiple": "concluded",
+            "presentParticiple": "concluding"
+        }
+    },
+    {
+        "base": "confess",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "confess",
+            "thirdPerson": "confesses",
+            "past": "confessed",
+            "pastParticiple": "confessed",
+            "presentParticiple": "confessing"
+        }
+    },
+    {
+        "base": "confide",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "confide",
+            "thirdPerson": "confides",
+            "past": "confided",
+            "pastParticiple": "confided",
+            "presentParticiple": "confiding"
+        }
+    },
+    {
+        "base": "confirm",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "confirm",
+            "thirdPerson": "confirms",
+            "past": "confirmed",
+            "pastParticiple": "confirmed",
+            "presentParticiple": "confirming"
+        }
+    },
+    {
+        "base": "congratulate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "congratulate",
+            "thirdPerson": "congratulates",
+            "past": "congratulated",
+            "pastParticiple": "congratulated",
+            "presentParticiple": "congratulating"
+        }
+    },
+    {
+        "base": "conjure",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "conjure",
+            "thirdPerson": "conjures",
+            "past": "conjured",
+            "pastParticiple": "conjured",
+            "presentParticiple": "conjuring"
+        }
+    },
+    {
+        "base": "console",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "console",
+            "thirdPerson": "consoles",
+            "past": "consoled",
+            "pastParticiple": "consoled",
+            "presentParticiple": "consoling"
+        }
+    },
+    {
+        "base": "contemplate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "contemplate",
+            "thirdPerson": "contemplates",
+            "past": "contemplated",
+            "pastParticiple": "contemplated",
+            "presentParticiple": "contemplating"
+        }
+    },
+    {
+        "base": "contend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "contend",
+            "thirdPerson": "contends",
+            "past": "contended",
+            "pastParticiple": "contended",
+            "presentParticiple": "contending"
+        }
+    },
+    {
+        "base": "continue",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "continue",
+            "thirdPerson": "continues",
+            "past": "continued",
+            "pastParticiple": "continued",
+            "presentParticiple": "continuing"
+        }
+    },
+    {
+        "base": "contort",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "contort",
+            "thirdPerson": "contorts",
+            "past": "contorted",
+            "pastParticiple": "contorted",
+            "presentParticiple": "contorting"
+        }
+    },
+    {
+        "base": "corkscrew",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "corkscrew",
+            "thirdPerson": "corkscrews",
+            "past": "corkscrewed",
+            "pastParticiple": "corkscrewed",
+            "presentParticiple": "corkscrewing"
+        }
+    },
+    {
+        "base": "counter",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "counter",
+            "thirdPerson": "counters",
+            "past": "countered",
+            "pastParticiple": "countered",
+            "presentParticiple": "countering"
+        }
+    },
+    {
+        "base": "cower",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "cower",
+            "thirdPerson": "cowers",
+            "past": "cowered",
+            "pastParticiple": "cowered",
+            "presentParticiple": "cowering"
+        }
+    },
+    {
+        "base": "cradle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "cradle",
+            "thirdPerson": "cradles",
+            "past": "cradled",
+            "pastParticiple": "cradled",
+            "presentParticiple": "cradling"
+        }
+    },
+    {
+        "base": "crash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "crash",
+            "thirdPerson": "crashes",
+            "past": "crashed",
+            "pastParticiple": "crashed",
+            "presentParticiple": "crashing"
+        }
+    },
+    {
+        "base": "crawl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "crawl",
+            "thirdPerson": "crawls",
+            "past": "crawled",
+            "pastParticiple": "crawled",
+            "presentParticiple": "crawling"
+        }
+    },
+    {
+        "base": "creak",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "creak",
+            "thirdPerson": "creaks",
+            "past": "creaked",
+            "pastParticiple": "creaked",
+            "presentParticiple": "creaking"
+        }
+    },
+    {
+        "base": "creep",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "creep",
+            "thirdPerson": "creeps",
+            "past": "crept",
+            "pastParticiple": "crept",
+            "presentParticiple": "creeping"
+        }
+    },
+    {
+        "base": "crinkle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "crinkle",
+            "thirdPerson": "crinkles",
+            "past": "crinkled",
+            "pastParticiple": "crinkled",
+            "presentParticiple": "crinkling"
+        }
+    },
+    {
+        "base": "croak",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "croak",
+            "thirdPerson": "croaks",
+            "past": "croaked",
+            "pastParticiple": "croaked",
+            "presentParticiple": "croaking"
+        }
+    },
+    {
+        "base": "croon",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "croon",
+            "thirdPerson": "croons",
+            "past": "crooned",
+            "pastParticiple": "crooned",
+            "presentParticiple": "crooning"
+        }
+    },
+    {
+        "base": "crouch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "crouch",
+            "thirdPerson": "crouches",
+            "past": "crouched",
+            "pastParticiple": "crouched",
+            "presentParticiple": "crouching"
+        }
+    },
+    {
+        "base": "crow",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "crow",
+            "thirdPerson": "crows",
+            "past": "crowed",
+            "pastParticiple": "crowed",
+            "presentParticiple": "crowing"
+        }
+    },
+    {
+        "base": "crumple",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "crumple",
+            "thirdPerson": "crumples",
+            "past": "crumpled",
+            "pastParticiple": "crumpled",
+            "presentParticiple": "crumpling"
+        }
+    },
+    {
+        "base": "crush",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "crush",
+            "thirdPerson": "crushes",
+            "past": "crushed",
+            "pastParticiple": "crushed",
+            "presentParticiple": "crushing"
+        }
+    },
+    {
+        "base": "cry",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "cry",
+            "thirdPerson": "cries",
+            "past": "cried",
+            "pastParticiple": "cried",
+            "presentParticiple": "crying"
+        }
+    },
+    {
+        "base": "curl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "curl",
+            "thirdPerson": "curls",
+            "past": "curled",
+            "pastParticiple": "curled",
+            "presentParticiple": "curling"
+        }
+    },
+    {
+        "base": "dance",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "dance",
+            "thirdPerson": "dances",
+            "past": "danced",
+            "pastParticiple": "danced",
+            "presentParticiple": "dancing"
+        }
+    },
+    {
+        "base": "dart",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "dart",
+            "thirdPerson": "darts",
+            "past": "darted",
+            "pastParticiple": "darted",
+            "presentParticiple": "darting"
+        }
+    },
+    {
+        "base": "dash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "dash",
+            "thirdPerson": "dashes",
+            "past": "dashed",
+            "pastParticiple": "dashed",
+            "presentParticiple": "dashing"
+        }
+    },
+    {
+        "base": "debate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "debate",
+            "thirdPerson": "debates",
+            "past": "debated",
+            "pastParticiple": "debated",
+            "presentParticiple": "debating"
+        }
+    },
+    {
+        "base": "declare",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "declare",
+            "thirdPerson": "declares",
+            "past": "declared",
+            "pastParticiple": "declared",
+            "presentParticiple": "declaring"
+        }
+    },
+    {
+        "base": "decree",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "decree",
+            "thirdPerson": "decrees",
+            "past": "decreed",
+            "pastParticiple": "decreed",
+            "presentParticiple": "decreeing"
+        }
+    },
+    {
+        "base": "defend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "defend",
+            "thirdPerson": "defends",
+            "past": "defended",
+            "pastParticiple": "defended",
+            "presentParticiple": "defending"
+        }
+    },
+    {
+        "base": "deflect",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "deflect",
+            "thirdPerson": "deflects",
+            "past": "deflected",
+            "pastParticiple": "deflected",
+            "presentParticiple": "deflecting"
+        }
+    },
+    {
+        "base": "demand",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "demand",
+            "thirdPerson": "demands",
+            "past": "demanded",
+            "pastParticiple": "demanded",
+            "presentParticiple": "demanding"
+        }
+    },
+    {
+        "base": "deny",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "deny",
+            "thirdPerson": "denies",
+            "past": "denied",
+            "pastParticiple": "denied",
+            "presentParticiple": "denying"
+        }
+    },
+    {
+        "base": "depart",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "depart",
+            "thirdPerson": "departs",
+            "past": "departed",
+            "pastParticiple": "departed",
+            "presentParticiple": "departing"
+        }
+    },
+    {
+        "base": "descend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "descend",
+            "thirdPerson": "descends",
+            "past": "descended",
+            "pastParticiple": "descended",
+            "presentParticiple": "descending"
+        }
+    },
+    {
+        "base": "describe",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "describe",
+            "thirdPerson": "describes",
+            "past": "described",
+            "pastParticiple": "described",
+            "presentParticiple": "describing"
+        }
+    },
+    {
+        "base": "detail",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "detail",
+            "thirdPerson": "details",
+            "past": "detailed",
+            "pastParticiple": "detailed",
+            "presentParticiple": "detailing"
+        }
+    },
+    {
+        "base": "detour",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "detour",
+            "thirdPerson": "detours",
+            "past": "detoured",
+            "pastParticiple": "detoured",
+            "presentParticiple": "detouring"
+        }
+    },
+    {
+        "base": "dictate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "dictate",
+            "thirdPerson": "dictates",
+            "past": "dictated",
+            "pastParticiple": "dictated",
+            "presentParticiple": "dictating"
+        }
+    },
+    {
+        "base": "dip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "dip",
+            "thirdPerson": "dips",
+            "past": "dipped",
+            "pastParticiple": "dipped",
+            "presentParticiple": "dipping"
+        }
+    },
+    {
+        "base": "direct",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "direct",
+            "thirdPerson": "directs",
+            "past": "directed",
+            "pastParticiple": "directed",
+            "presentParticiple": "directing"
+        }
+    },
+    {
+        "base": "dive",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "dive",
+            "thirdPerson": "dives",
+            "past": "dived",
+            "pastParticiple": "dived",
+            "presentParticiple": "diving"
+        }
+    },
+    {
+        "base": "do",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "do",
+            "thirdPerson": "does",
+            "past": "did",
+            "pastParticiple": "done",
+            "presentParticiple": "doing"
+        }
+    },
+    {
+        "base": "dodge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "dodge",
+            "thirdPerson": "dodges",
+            "past": "dodged",
+            "pastParticiple": "dodged",
+            "presentParticiple": "dodging"
+        }
+    },
+    {
+        "base": "drag",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "drag",
+            "thirdPerson": "drags",
+            "past": "dragged",
+            "pastParticiple": "dragged",
+            "presentParticiple": "dragging"
+        }
+    },
+    {
+        "base": "drain",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drain",
+            "thirdPerson": "drains",
+            "past": "drained",
+            "pastParticiple": "drained",
+            "presentParticiple": "draining"
+        }
+    },
+    {
+        "base": "drape",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drape",
+            "thirdPerson": "drapes",
+            "past": "draped",
+            "pastParticiple": "draped",
+            "presentParticiple": "draping"
+        }
+    },
+    {
+        "base": "drawl",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "drawl",
+            "thirdPerson": "drawls",
+            "past": "drawled",
+            "pastParticiple": "drawled",
+            "presentParticiple": "drawling"
+        }
+    },
+    {
+        "base": "drift",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drift",
+            "thirdPerson": "drifts",
+            "past": "drifted",
+            "pastParticiple": "drifted",
+            "presentParticiple": "drifting"
+        }
+    },
+    {
+        "base": "drill",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drill",
+            "thirdPerson": "drills",
+            "past": "drilled",
+            "pastParticiple": "drilled",
+            "presentParticiple": "drilling"
+        }
+    },
+    {
+        "base": "drip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drip",
+            "thirdPerson": "drips",
+            "past": "dripped",
+            "pastParticiple": "dripped",
+            "presentParticiple": "dripping"
+        }
+    },
+    {
+        "base": "drizzle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drizzle",
+            "thirdPerson": "drizzles",
+            "past": "drizzled",
+            "pastParticiple": "drizzled",
+            "presentParticiple": "drizzling"
+        }
+    },
+    {
+        "base": "drone",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "drone",
+            "thirdPerson": "drones",
+            "past": "droned",
+            "pastParticiple": "droned",
+            "presentParticiple": "droning"
+        }
+    },
+    {
+        "base": "drop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "drop",
+            "thirdPerson": "drops",
+            "past": "dropped",
+            "pastParticiple": "dropped",
+            "presentParticiple": "dropping"
+        }
+    },
+    {
+        "base": "drum",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "drum",
+            "thirdPerson": "drums",
+            "past": "drummed",
+            "pastParticiple": "drummed",
+            "presentParticiple": "drumming"
+        }
+    },
+    {
+        "base": "duck",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "duck",
+            "thirdPerson": "ducks",
+            "past": "ducked",
+            "pastParticiple": "ducked",
+            "presentParticiple": "ducking"
+        }
+    },
+    {
+        "base": "echo",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "echo",
+            "thirdPerson": "echos",
+            "past": "echoed",
+            "pastParticiple": "echoed",
+            "presentParticiple": "echoing"
+        }
+    },
+    {
+        "base": "emerge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "emerge",
+            "thirdPerson": "emerges",
+            "past": "emerged",
+            "pastParticiple": "emerged",
+            "presentParticiple": "emerging"
+        }
+    },
+    {
+        "base": "emphasize",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "emphasize",
+            "thirdPerson": "emphasizes",
+            "past": "emphasized",
+            "pastParticiple": "emphasized",
+            "presentParticiple": "emphasizing"
+        }
+    },
+    {
+        "base": "encourage",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "encourage",
+            "thirdPerson": "encourages",
+            "past": "encouraged",
+            "pastParticiple": "encouraged",
+            "presentParticiple": "encouraging"
+        }
+    },
+    {
+        "base": "enquire",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "enquire",
+            "thirdPerson": "enquires",
+            "past": "enquired",
+            "pastParticiple": "enquired",
+            "presentParticiple": "enquiring"
+        }
+    },
+    {
+        "base": "enter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "enter",
+            "thirdPerson": "enters",
+            "past": "entered",
+            "pastParticiple": "entered",
+            "presentParticiple": "entering"
+        }
+    },
+    {
+        "base": "enthuse",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "enthuse",
+            "thirdPerson": "enthuses",
+            "past": "enthused",
+            "pastParticiple": "enthused",
+            "presentParticiple": "enthusing"
+        }
+    },
+    {
+        "base": "entreat",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "entreat",
+            "thirdPerson": "entreats",
+            "past": "entreated",
+            "pastParticiple": "entreated",
+            "presentParticiple": "entreating"
+        }
+    },
+    {
+        "base": "enumerate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "enumerate",
+            "thirdPerson": "enumerates",
+            "past": "enumerated",
+            "pastParticiple": "enumerated",
+            "presentParticiple": "enumerating"
+        }
+    },
+    {
+        "base": "epitomize",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "epitomize",
+            "thirdPerson": "epitomizes",
+            "past": "epitomized",
+            "pastParticiple": "epitomized",
+            "presentParticiple": "epitomizing"
+        }
+    },
+    {
+        "base": "equivocate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "equivoceat",
+            "thirdPerson": "equivoceats",
+            "past": "equivocate",
+            "pastParticiple": "equivoceaten",
+            "presentParticiple": "equivoceating"
+        }
+    },
+    {
+        "base": "escape",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "escape",
+            "thirdPerson": "escapes",
+            "past": "escaped",
+            "pastParticiple": "escaped",
+            "presentParticiple": "escaping"
+        }
+    },
+    {
+        "base": "estimate",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "estimate",
+            "thirdPerson": "estimates",
+            "past": "estimated",
+            "pastParticiple": "estimated",
+            "presentParticiple": "estimating"
+        }
+    },
+    {
+        "base": "exclaim",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "exclaim",
+            "thirdPerson": "exclaims",
+            "past": "exclaimed",
+            "pastParticiple": "exclaimed",
+            "presentParticiple": "exclaiming"
+        }
+    },
+    {
+        "base": "exhort",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "exhort",
+            "thirdPerson": "exhorts",
+            "past": "exhorted",
+            "pastParticiple": "exhorted",
+            "presentParticiple": "exhorting"
+        }
+    },
+    {
+        "base": "exit",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "exit",
+            "thirdPerson": "exits",
+            "past": "exited",
+            "pastParticiple": "exited",
+            "presentParticiple": "exiting"
+        }
+    },
+    {
+        "base": "exonerate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "exonerate",
+            "thirdPerson": "exonerates",
+            "past": "exonerated",
+            "pastParticiple": "exonerated",
+            "presentParticiple": "exonerating"
+        }
+    },
+    {
+        "base": "explain",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "explain",
+            "thirdPerson": "explains",
+            "past": "explained",
+            "pastParticiple": "explained",
+            "presentParticiple": "explaining"
+        }
+    },
+    {
+        "base": "expostulate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "expostulate",
+            "thirdPerson": "expostulates",
+            "past": "expostulated",
+            "pastParticiple": "expostulated",
+            "presentParticiple": "expostulating"
+        }
+    },
+    {
+        "base": "expound",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "expound",
+            "thirdPerson": "expounds",
+            "past": "expounded",
+            "pastParticiple": "expounded",
+            "presentParticiple": "expounding"
+        }
+    },
+    {
+        "base": "express",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "express",
+            "thirdPerson": "expresses",
+            "past": "expressed",
+            "pastParticiple": "expressed",
+            "presentParticiple": "expressing"
+        }
+    },
+    {
+        "base": "fall",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "fall",
+            "thirdPerson": "falls",
+            "past": "fell",
+            "pastParticiple": "fallen",
+            "presentParticiple": "falling"
+        }
+    },
+    {
+        "base": "falter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "falter",
+            "thirdPerson": "falters",
+            "past": "faltered",
+            "pastParticiple": "faltered",
+            "presentParticiple": "faltering"
+        }
+    },
+    {
+        "base": "fidget",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "fidget",
+            "thirdPerson": "fidgets",
+            "past": "fidgot",
+            "pastParticiple": "fidgot",
+            "presentParticiple": "fidgetting"
+        }
+    },
+    {
+        "base": "flare",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flare",
+            "thirdPerson": "flares",
+            "past": "flared",
+            "pastParticiple": "flared",
+            "presentParticiple": "flaring"
+        }
+    },
+    {
+        "base": "flee",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flee",
+            "thirdPerson": "flees",
+            "past": "fled",
+            "pastParticiple": "fled",
+            "presentParticiple": "fleeing"
+        }
+    },
+    {
+        "base": "flinch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flinch",
+            "thirdPerson": "flinches",
+            "past": "flinched",
+            "pastParticiple": "flinched",
+            "presentParticiple": "flinching"
+        }
+    },
+    {
+        "base": "flit",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flit",
+            "thirdPerson": "flits",
+            "past": "flitted",
+            "pastParticiple": "flitted",
+            "presentParticiple": "flitting"
+        }
+    },
+    {
+        "base": "float",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "float",
+            "thirdPerson": "floats",
+            "past": "floated",
+            "pastParticiple": "floated",
+            "presentParticiple": "floating"
+        }
+    },
+    {
+        "base": "flop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flop",
+            "thirdPerson": "flops",
+            "past": "flopped",
+            "pastParticiple": "flopped",
+            "presentParticiple": "flopping"
+        }
+    },
+    {
+        "base": "flourish",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flourish",
+            "thirdPerson": "flourishes",
+            "past": "flourished",
+            "pastParticiple": "flourished",
+            "presentParticiple": "flourishing"
+        }
+    },
+    {
+        "base": "flow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "flow",
+            "thirdPerson": "flows",
+            "past": "flowed",
+            "pastParticiple": "flowed",
+            "presentParticiple": "flowing"
+        }
+    },
+    {
+        "base": "flurry",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "flurry",
+            "thirdPerson": "flurries",
+            "past": "flurried",
+            "pastParticiple": "flurried",
+            "presentParticiple": "flurrying"
+        }
+    },
+    {
+        "base": "flutter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "flutter",
+            "thirdPerson": "flutters",
+            "past": "fluttered",
+            "pastParticiple": "fluttered",
+            "presentParticiple": "fluttering"
+        }
+    },
+    {
+        "base": "fly",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "fly",
+            "thirdPerson": "flies",
+            "past": "flew",
+            "pastParticiple": "flown",
+            "presentParticiple": "flying"
+        }
+    },
+    {
+        "base": "focus",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "focus",
+            "thirdPerson": "focuses",
+            "past": "focused",
+            "pastParticiple": "focused",
+            "presentParticiple": "focusing"
+        }
+    },
+    {
+        "base": "follow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "follow",
+            "thirdPerson": "follows",
+            "past": "followed",
+            "pastParticiple": "followed",
+            "presentParticiple": "following"
+        }
+    },
+    {
+        "base": "forge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "forge",
+            "thirdPerson": "forges",
+            "past": "forged",
+            "pastParticiple": "forged",
+            "presentParticiple": "forging"
+        }
+    },
+    {
+        "base": "fracture",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "fracture",
+            "thirdPerson": "fractures",
+            "past": "fractured",
+            "pastParticiple": "fractured",
+            "presentParticiple": "fracturing"
+        }
+    },
+    {
+        "base": "freeze",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "freeze",
+            "thirdPerson": "freezes",
+            "past": "froze",
+            "pastParticiple": "frozen",
+            "presentParticiple": "freezing"
+        }
+    },
+    {
+        "base": "frolic",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "frolic",
+            "thirdPerson": "frolics",
+            "past": "froliced",
+            "pastParticiple": "froliced",
+            "presentParticiple": "frolicing"
+        }
+    },
+    {
+        "base": "frown",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "frown",
+            "thirdPerson": "frowns",
+            "past": "frowned",
+            "pastParticiple": "frowned",
+            "presentParticiple": "frowning"
+        }
+    },
+    {
+        "base": "fume",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "fume",
+            "thirdPerson": "fumes",
+            "past": "fumed",
+            "pastParticiple": "fumed",
+            "presentParticiple": "fuming"
+        }
+    },
+    {
+        "base": "gallop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "gallop",
+            "thirdPerson": "gallops",
+            "past": "gallopped",
+            "pastParticiple": "gallopped",
+            "presentParticiple": "gallopping"
+        }
+    },
+    {
+        "base": "gasp",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "gasp",
+            "thirdPerson": "gasps",
+            "past": "gasped",
+            "pastParticiple": "gasped",
+            "presentParticiple": "gasping"
+        }
+    },
+    {
+        "base": "gather",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "gather",
+            "thirdPerson": "gathers",
+            "past": "gathered",
+            "pastParticiple": "gathered",
+            "presentParticiple": "gathering"
+        }
+    },
+    {
+        "base": "gesture",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "gesture",
+            "thirdPerson": "gestures",
+            "past": "gestured",
+            "pastParticiple": "gestured",
+            "presentParticiple": "gesturing"
+        }
+    },
+    {
+        "base": "get",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "get",
+            "thirdPerson": "gets",
+            "past": "got",
+            "pastParticiple": "got",
+            "presentParticiple": "getting"
+        }
+    },
+    {
+        "base": "giggle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "giggle",
+            "thirdPerson": "giggles",
+            "past": "giggled",
+            "pastParticiple": "giggled",
+            "presentParticiple": "giggling"
+        }
+    },
+    {
+        "base": "give",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "give",
+            "thirdPerson": "gives",
+            "past": "gave",
+            "pastParticiple": "given",
+            "presentParticiple": "giving"
+        }
+    },
+    {
+        "base": "glance",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glance",
+            "thirdPerson": "glances",
+            "past": "glanced",
+            "pastParticiple": "glanced",
+            "presentParticiple": "glancing"
+        }
+    },
+    {
+        "base": "glide",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glide",
+            "thirdPerson": "glides",
+            "past": "glided",
+            "pastParticiple": "glided",
+            "presentParticiple": "gliding"
+        }
+    },
+    {
+        "base": "glimmer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glimmer",
+            "thirdPerson": "glimmers",
+            "past": "glimmered",
+            "pastParticiple": "glimmered",
+            "presentParticiple": "glimmering"
+        }
+    },
+    {
+        "base": "glint",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glint",
+            "thirdPerson": "glints",
+            "past": "glinted",
+            "pastParticiple": "glinted",
+            "presentParticiple": "glinting"
+        }
+    },
+    {
+        "base": "glissade",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glissade",
+            "thirdPerson": "glissades",
+            "past": "glissaded",
+            "pastParticiple": "glissaded",
+            "presentParticiple": "glissading"
+        }
+    },
+    {
+        "base": "glower",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "glower",
+            "thirdPerson": "glowers",
+            "past": "glowered",
+            "pastParticiple": "glowered",
+            "presentParticiple": "glowering"
+        }
+    },
+    {
+        "base": "gnash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "gnash",
+            "thirdPerson": "gnashes",
+            "past": "gnashed",
+            "pastParticiple": "gnashed",
+            "presentParticiple": "gnashing"
+        }
+    },
+    {
+        "base": "gnaw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "gnaw",
+            "thirdPerson": "gnaws",
+            "past": "gnawed",
+            "pastParticiple": "gnawed",
+            "presentParticiple": "gnawing"
+        }
+    },
+    {
+        "base": "go",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "go",
+            "thirdPerson": "goes",
+            "past": "went",
+            "pastParticiple": "gone",
+            "presentParticiple": "going"
+        }
+    },
+    {
+        "base": "grab",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "grab",
+            "thirdPerson": "grabs",
+            "past": "grabbed",
+            "pastParticiple": "grabbed",
+            "presentParticiple": "grabbing"
+        }
+    },
+    {
+        "base": "grasp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "grasp",
+            "thirdPerson": "grasps",
+            "past": "grasped",
+            "pastParticiple": "grasped",
+            "presentParticiple": "grasping"
+        }
+    },
+    {
+        "base": "grimace",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "grimace",
+            "thirdPerson": "grimaces",
+            "past": "grimaced",
+            "pastParticiple": "grimaced",
+            "presentParticiple": "grimacing"
+        }
+    },
+    {
+        "base": "grin",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "grin",
+            "thirdPerson": "grins",
+            "past": "grinned",
+            "pastParticiple": "grinned",
+            "presentParticiple": "grinning"
+        }
+    },
+    {
+        "base": "grind",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "grind",
+            "thirdPerson": "grinds",
+            "past": "ground",
+            "pastParticiple": "ground",
+            "presentParticiple": "grinding"
+        }
+    },
+    {
+        "base": "grip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "grip",
+            "thirdPerson": "grips",
+            "past": "gripped",
+            "pastParticiple": "gripped",
+            "presentParticiple": "gripping"
+        }
+    },
+    {
+        "base": "groan",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "groan",
+            "thirdPerson": "groans",
+            "past": "groaned",
+            "pastParticiple": "groaned",
+            "presentParticiple": "groaning"
+        }
+    },
+    {
+        "base": "growl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "growl",
+            "thirdPerson": "growls",
+            "past": "growled",
+            "pastParticiple": "growled",
+            "presentParticiple": "growling"
+        }
+    },
+    {
+        "base": "grumble",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "grumble",
+            "thirdPerson": "grumbles",
+            "past": "grumbled",
+            "pastParticiple": "grumbled",
+            "presentParticiple": "grumbling"
+        }
+    },
+    {
+        "base": "grunt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "grunt",
+            "thirdPerson": "grunts",
+            "past": "grunted",
+            "pastParticiple": "grunted",
+            "presentParticiple": "grunting"
+        }
+    },
+    {
+        "base": "guarantee",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "guarantee",
+            "thirdPerson": "guarantees",
+            "past": "guaranteed",
+            "pastParticiple": "guaranteed",
+            "presentParticiple": "guaranteeing"
+        }
+    },
+    {
+        "base": "guess",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "guess",
+            "thirdPerson": "guesses",
+            "past": "guessed",
+            "pastParticiple": "guessed",
+            "presentParticiple": "guessing"
+        }
+    },
+    {
+        "base": "hack",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hack",
+            "thirdPerson": "hacks",
+            "past": "hacked",
+            "pastParticiple": "hacked",
+            "presentParticiple": "hacking"
+        }
+    },
+    {
+        "base": "halt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "halt",
+            "thirdPerson": "halts",
+            "past": "halted",
+            "pastParticiple": "halted",
+            "presentParticiple": "halting"
+        }
+    },
+    {
+        "base": "hammer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hammer",
+            "thirdPerson": "hammers",
+            "past": "hammered",
+            "pastParticiple": "hammered",
+            "presentParticiple": "hammering"
+        }
+    },
+    {
+        "base": "harangue",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "harangue",
+            "thirdPerson": "harangues",
+            "past": "harangued",
+            "pastParticiple": "harangued",
+            "presentParticiple": "haranguing"
+        }
+    },
+    {
+        "base": "harness",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "harness",
+            "thirdPerson": "harnesses",
+            "past": "harnessed",
+            "pastParticiple": "harnessed",
+            "presentParticiple": "harnessing"
+        }
+    },
+    {
+        "base": "haul",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "haul",
+            "thirdPerson": "hauls",
+            "past": "hauled",
+            "pastParticiple": "hauled",
+            "presentParticiple": "hauling"
+        }
+    },
+    {
+        "base": "have",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "have",
+            "thirdPerson": "has",
+            "past": "had",
+            "pastParticiple": "had",
+            "presentParticiple": "having"
+        }
+    },
+    {
+        "base": "heave",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "heave",
+            "thirdPerson": "heaves",
+            "past": "hove",
+            "pastParticiple": "hove",
+            "presentParticiple": "heaving"
+        }
+    },
+    {
+        "base": "hinge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hinge",
+            "thirdPerson": "hinges",
+            "past": "hinged",
+            "pastParticiple": "hinged",
+            "presentParticiple": "hinging"
+        }
+    },
+    {
+        "base": "hint",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hint",
+            "thirdPerson": "hints",
+            "past": "hinted",
+            "pastParticiple": "hinted",
+            "presentParticiple": "hinting"
+        }
+    },
+    {
+        "base": "hiss",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hiss",
+            "thirdPerson": "hisses",
+            "past": "hissed",
+            "pastParticiple": "hissed",
+            "presentParticiple": "hissing"
+        }
+    },
+    {
+        "base": "hitch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hitch",
+            "thirdPerson": "hitches",
+            "past": "hitched",
+            "pastParticiple": "hitched",
+            "presentParticiple": "hitching"
+        }
+    },
+    {
+        "base": "hobble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hobble",
+            "thirdPerson": "hobbles",
+            "past": "hobbled",
+            "pastParticiple": "hobbled",
+            "presentParticiple": "hobbling"
+        }
+    },
+    {
+        "base": "hold",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hold",
+            "thirdPerson": "holds",
+            "past": "held",
+            "pastParticiple": "held",
+            "presentParticiple": "holding"
+        }
+    },
+    {
+        "base": "holler",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "holler",
+            "thirdPerson": "hollers",
+            "past": "hollered",
+            "pastParticiple": "hollered",
+            "presentParticiple": "hollering"
+        }
+    },
+    {
+        "base": "hop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hop",
+            "thirdPerson": "hops",
+            "past": "hopped",
+            "pastParticiple": "hopped",
+            "presentParticiple": "hopping"
+        }
+    },
+    {
+        "base": "hover",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hover",
+            "thirdPerson": "hovers",
+            "past": "hovered",
+            "pastParticiple": "hovered",
+            "presentParticiple": "hovering"
+        }
+    },
+    {
+        "base": "howl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "howl",
+            "thirdPerson": "howls",
+            "past": "howled",
+            "pastParticiple": "howled",
+            "presentParticiple": "howling"
+        }
+    },
+    {
+        "base": "huddle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "huddle",
+            "thirdPerson": "huddles",
+            "past": "huddled",
+            "pastParticiple": "huddled",
+            "presentParticiple": "huddling"
+        }
+    },
+    {
+        "base": "hunt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hunt",
+            "thirdPerson": "hunts",
+            "past": "hunted",
+            "pastParticiple": "hunted",
+            "presentParticiple": "hunting"
+        }
+    },
+    {
+        "base": "hurry",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hurry",
+            "thirdPerson": "hurries",
+            "past": "hurried",
+            "pastParticiple": "hurried",
+            "presentParticiple": "hurrying"
+        }
+    },
+    {
+        "base": "hustle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "hustle",
+            "thirdPerson": "hustles",
+            "past": "hustled",
+            "pastParticiple": "hustled",
+            "presentParticiple": "hustling"
+        }
+    },
+    {
+        "base": "hypothesize",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "hypothesize",
+            "thirdPerson": "hypothesizes",
+            "past": "hypothesized",
+            "pastParticiple": "hypothesized",
+            "presentParticiple": "hypothesizing"
+        }
+    },
+    {
+        "base": "illuminate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "illuminate",
+            "thirdPerson": "illuminates",
+            "past": "illuminated",
+            "pastParticiple": "illuminated",
+            "presentParticiple": "illuminating"
+        }
+    },
+    {
+        "base": "immerged",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "immerge",
+            "thirdPerson": "immerges",
+            "past": "immerged",
+            "pastParticiple": "immerged",
+            "presentParticiple": "immerging"
+        }
+    },
+    {
+        "base": "implore",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "implore",
+            "thirdPerson": "implores",
+            "past": "implored",
+            "pastParticiple": "implored",
+            "presentParticiple": "imploring"
+        }
+    },
+    {
+        "base": "imply",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "imply",
+            "thirdPerson": "implies",
+            "past": "implied",
+            "pastParticiple": "implied",
+            "presentParticiple": "implying"
+        }
+    },
+    {
+        "base": "improvise",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "improvise",
+            "thirdPerson": "improvises",
+            "past": "improvised",
+            "pastParticiple": "improvised",
+            "presentParticiple": "improvising"
+        }
+    },
+    {
+        "base": "inch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "inch",
+            "thirdPerson": "inches",
+            "past": "inched",
+            "pastParticiple": "inched",
+            "presentParticiple": "inching"
+        }
+    },
+    {
+        "base": "inquire",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "inquire",
+            "thirdPerson": "inquires",
+            "past": "inquired",
+            "pastParticiple": "inquired",
+            "presentParticiple": "inquiring"
+        }
+    },
+    {
+        "base": "insist",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "insist",
+            "thirdPerson": "insists",
+            "past": "insisted",
+            "pastParticiple": "insisted",
+            "presentParticiple": "insisting"
+        }
+    },
+    {
+        "base": "instruct",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "instruct",
+            "thirdPerson": "instructs",
+            "past": "instructed",
+            "pastParticiple": "instructed",
+            "presentParticiple": "instructing"
+        }
+    },
+    {
+        "base": "intercept",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "intercept",
+            "thirdPerson": "intercepts",
+            "past": "intercepted",
+            "pastParticiple": "intercepted",
+            "presentParticiple": "intercepting"
+        }
+    },
+    {
+        "base": "interject",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "interject",
+            "thirdPerson": "interjects",
+            "past": "interjected",
+            "pastParticiple": "interjected",
+            "presentParticiple": "interjecting"
+        }
+    },
+    {
+        "base": "interrogate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "interrogate",
+            "thirdPerson": "interrogates",
+            "past": "interrogated",
+            "pastParticiple": "interrogated",
+            "presentParticiple": "interrogating"
+        }
+    },
+    {
+        "base": "interrupt",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "interrupt",
+            "thirdPerson": "interrupts",
+            "past": "interrupted",
+            "pastParticiple": "interrupted",
+            "presentParticiple": "interrupting"
+        }
+    },
+    {
+        "base": "intimate",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "intimate",
+            "thirdPerson": "intimates",
+            "past": "intimated",
+            "pastParticiple": "intimated",
+            "presentParticiple": "intimating"
+        }
+    },
+    {
+        "base": "intone",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "intone",
+            "thirdPerson": "intones",
+            "past": "intoned",
+            "pastParticiple": "intoned",
+            "presentParticiple": "intoning"
+        }
+    },
+    {
+        "base": "jabber",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "jabber",
+            "thirdPerson": "jabbers",
+            "past": "jabbered",
+            "pastParticiple": "jabbered",
+            "presentParticiple": "jabbering"
+        }
+    },
+    {
+        "base": "jeer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "jeer",
+            "thirdPerson": "jeers",
+            "past": "jeered",
+            "pastParticiple": "jeered",
+            "presentParticiple": "jeering"
+        }
+    },
+    {
+        "base": "jerk",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "jerk",
+            "thirdPerson": "jerks",
+            "past": "jerked",
+            "pastParticiple": "jerked",
+            "presentParticiple": "jerking"
+        }
+    },
+    {
+        "base": "jest",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "jest",
+            "thirdPerson": "jests",
+            "past": "jested",
+            "pastParticiple": "jested",
+            "presentParticiple": "jesting"
+        }
+    },
+    {
+        "base": "jog",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "jog",
+            "thirdPerson": "jogs",
+            "past": "jogged",
+            "pastParticiple": "jogged",
+            "presentParticiple": "jogging"
+        }
+    },
+    {
+        "base": "joke",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "joke",
+            "thirdPerson": "jokes",
+            "past": "joked",
+            "pastParticiple": "joked",
+            "presentParticiple": "joking"
+        }
+    },
+    {
+        "base": "jolt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "jolt",
+            "thirdPerson": "jolts",
+            "past": "jolted",
+            "pastParticiple": "jolted",
+            "presentParticiple": "jolting"
+        }
+    },
+    {
+        "base": "jostle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "jostle",
+            "thirdPerson": "jostles",
+            "past": "jostled",
+            "pastParticiple": "jostled",
+            "presentParticiple": "jostling"
+        }
+    },
+    {
+        "base": "juggle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "juggle",
+            "thirdPerson": "juggles",
+            "past": "juggled",
+            "pastParticiple": "juggled",
+            "presentParticiple": "juggling"
+        }
+    },
+    {
+        "base": "jump",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "jump",
+            "thirdPerson": "jumps",
+            "past": "jumped",
+            "pastParticiple": "jumped",
+            "presentParticiple": "jumping"
+        }
+    },
+    {
+        "base": "jut",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "jut",
+            "thirdPerson": "juts",
+            "past": "jutted",
+            "pastParticiple": "jutted",
+            "presentParticiple": "jutting"
+        }
+    },
+    {
+        "base": "kick",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "kick",
+            "thirdPerson": "kicks",
+            "past": "kicked",
+            "pastParticiple": "kicked",
+            "presentParticiple": "kicking"
+        }
+    },
+    {
+        "base": "kindle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "kindle",
+            "thirdPerson": "kindles",
+            "past": "kindled",
+            "pastParticiple": "kindled",
+            "presentParticiple": "kindling"
+        }
+    },
+    {
+        "base": "kneel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "kneel",
+            "thirdPerson": "kneels",
+            "past": "knelt",
+            "pastParticiple": "knelt",
+            "presentParticiple": "kneeling"
+        }
+    },
+    {
+        "base": "knit",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "knit",
+            "thirdPerson": "knits",
+            "past": "knit",
+            "pastParticiple": "knit",
+            "presentParticiple": "knitting"
+        }
+    },
+    {
+        "base": "knock",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "knock",
+            "thirdPerson": "knocks",
+            "past": "knocked",
+            "pastParticiple": "knocked",
+            "presentParticiple": "knocking"
+        }
+    },
+    {
+        "base": "know",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "know",
+            "thirdPerson": "knows",
+            "past": "knew",
+            "pastParticiple": "known",
+            "presentParticiple": "knowing"
+        }
+    },
+    {
+        "base": "lament",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "lament",
+            "thirdPerson": "laments",
+            "past": "lamented",
+            "pastParticiple": "lamented",
+            "presentParticiple": "lamenting"
+        }
+    },
+    {
+        "base": "lance",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lance",
+            "thirdPerson": "lances",
+            "past": "lanced",
+            "pastParticiple": "lanced",
+            "presentParticiple": "lancing"
+        }
+    },
+    {
+        "base": "lash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lash",
+            "thirdPerson": "lashes",
+            "past": "lashed",
+            "pastParticiple": "lashed",
+            "presentParticiple": "lashing"
+        }
+    },
+    {
+        "base": "laugh",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "laugh",
+            "thirdPerson": "laughs",
+            "past": "laughed",
+            "pastParticiple": "laughed",
+            "presentParticiple": "laughing"
+        }
+    },
+    {
+        "base": "launch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "launch",
+            "thirdPerson": "launches",
+            "past": "launched",
+            "pastParticiple": "launched",
+            "presentParticiple": "launching"
+        }
+    },
+    {
+        "base": "lean",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lean",
+            "thirdPerson": "leans",
+            "past": "leaned",
+            "pastParticiple": "leaned",
+            "presentParticiple": "leaning"
+        }
+    },
+    {
+        "base": "leap",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "leap",
+            "thirdPerson": "leaps",
+            "past": "leaped",
+            "pastParticiple": "leaped",
+            "presentParticiple": "leaping"
+        }
+    },
+    {
+        "base": "leave",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "leave",
+            "thirdPerson": "leaves",
+            "past": "left",
+            "pastParticiple": "left",
+            "presentParticiple": "leaving"
+        }
+    },
+    {
+        "base": "lecture",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "lecture",
+            "thirdPerson": "lectures",
+            "past": "lectured",
+            "pastParticiple": "lectured",
+            "presentParticiple": "lecturing"
+        }
+    },
+    {
+        "base": "lever",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lever",
+            "thirdPerson": "levers",
+            "past": "levered",
+            "pastParticiple": "levered",
+            "presentParticiple": "levering"
+        }
+    },
+    {
+        "base": "lie",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "lie",
+            "thirdPerson": "lies",
+            "past": "lied",
+            "pastParticiple": "lied",
+            "presentParticiple": "lying"
+        }
+    },
+    {
+        "base": "limp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "limp",
+            "thirdPerson": "limps",
+            "past": "limped",
+            "pastParticiple": "limped",
+            "presentParticiple": "limping"
+        }
+    },
+    {
+        "base": "linger",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "linger",
+            "thirdPerson": "lingers",
+            "past": "lingered",
+            "pastParticiple": "lingered",
+            "presentParticiple": "lingering"
+        }
+    },
+    {
+        "base": "look",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "look",
+            "thirdPerson": "looks",
+            "past": "looked",
+            "pastParticiple": "looked",
+            "presentParticiple": "looking"
+        }
+    },
+    {
+        "base": "loom",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "loom",
+            "thirdPerson": "looms",
+            "past": "loomed",
+            "pastParticiple": "loomed",
+            "presentParticiple": "looming"
+        }
+    },
+    {
+        "base": "loosen",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "loosen",
+            "thirdPerson": "loosens",
+            "past": "loosened",
+            "pastParticiple": "loosened",
+            "presentParticiple": "loosening"
+        }
+    },
+    {
+        "base": "lower",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "lower",
+            "thirdPerson": "lowers",
+            "past": "lowered",
+            "pastParticiple": "lowered",
+            "presentParticiple": "lowering"
+        }
+    },
+    {
+        "base": "lunge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lunge",
+            "thirdPerson": "lunges",
+            "past": "lunged",
+            "pastParticiple": "lunged",
+            "presentParticiple": "lunging"
+        }
+    },
+    {
+        "base": "lurch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "lurch",
+            "thirdPerson": "lurches",
+            "past": "lurched",
+            "pastParticiple": "lurched",
+            "presentParticiple": "lurching"
+        }
+    },
+    {
+        "base": "maintain",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "maintain",
+            "thirdPerson": "maintains",
+            "past": "maintained",
+            "pastParticiple": "maintained",
+            "presentParticiple": "maintaining"
+        }
+    },
+    {
+        "base": "make",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "make",
+            "thirdPerson": "makes",
+            "past": "made",
+            "pastParticiple": "made",
+            "presentParticiple": "making"
+        }
+    },
+    {
+        "base": "march",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "march",
+            "thirdPerson": "marches",
+            "past": "marched",
+            "pastParticiple": "marched",
+            "presentParticiple": "marching"
+        }
+    },
+    {
+        "base": "marvel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "marvel",
+            "thirdPerson": "marvels",
+            "past": "marveled",
+            "pastParticiple": "marveled",
+            "presentParticiple": "marveling"
+        }
+    },
+    {
+        "base": "mass",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mass",
+            "thirdPerson": "masses",
+            "past": "massed",
+            "pastParticiple": "massed",
+            "presentParticiple": "massing"
+        }
+    },
+    {
+        "base": "meander",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "meander",
+            "thirdPerson": "meanders",
+            "past": "meandered",
+            "pastParticiple": "meandered",
+            "presentParticiple": "meandering"
+        }
+    },
+    {
+        "base": "melt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "melt",
+            "thirdPerson": "melts",
+            "past": "melted",
+            "pastParticiple": "melted",
+            "presentParticiple": "melting"
+        }
+    },
+    {
+        "base": "mend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mend",
+            "thirdPerson": "mends",
+            "past": "mended",
+            "pastParticiple": "mended",
+            "presentParticiple": "mending"
+        }
+    },
+    {
+        "base": "mention",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "mention",
+            "thirdPerson": "mentions",
+            "past": "mentioned",
+            "pastParticiple": "mentioned",
+            "presentParticiple": "mentioning"
+        }
+    },
+    {
+        "base": "merge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "merge",
+            "thirdPerson": "merges",
+            "past": "merged",
+            "pastParticiple": "merged",
+            "presentParticiple": "merging"
+        }
+    },
+    {
+        "base": "mewl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "mewl",
+            "thirdPerson": "mewls",
+            "past": "mewled",
+            "pastParticiple": "mewled",
+            "presentParticiple": "mewling"
+        }
+    },
+    {
+        "base": "migrate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "migrate",
+            "thirdPerson": "migrates",
+            "past": "migrated",
+            "pastParticiple": "migrated",
+            "presentParticiple": "migrating"
+        }
+    },
+    {
+        "base": "mill",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mill",
+            "thirdPerson": "mills",
+            "past": "milled",
+            "pastParticiple": "milled",
+            "presentParticiple": "milling"
+        }
+    },
+    {
+        "base": "mime",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mime",
+            "thirdPerson": "mimes",
+            "past": "mimed",
+            "pastParticiple": "mimed",
+            "presentParticiple": "miming"
+        }
+    },
+    {
+        "base": "mimic",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "mimic",
+            "thirdPerson": "mimics",
+            "past": "mimiced",
+            "pastParticiple": "mimiced",
+            "presentParticiple": "mimicing"
+        }
+    },
+    {
+        "base": "morph",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "morph",
+            "thirdPerson": "morphs",
+            "past": "morphed",
+            "pastParticiple": "morphed",
+            "presentParticiple": "morphing"
+        }
+    },
+    {
+        "base": "motion",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "motion",
+            "thirdPerson": "motions",
+            "past": "motioned",
+            "pastParticiple": "motioned",
+            "presentParticiple": "motioning"
+        }
+    },
+    {
+        "base": "mount",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mount",
+            "thirdPerson": "mounts",
+            "past": "mounted",
+            "pastParticiple": "mounted",
+            "presentParticiple": "mounting"
+        }
+    },
+    {
+        "base": "move",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "move",
+            "thirdPerson": "moves",
+            "past": "moved",
+            "pastParticiple": "moved",
+            "presentParticiple": "moving"
+        }
+    },
+    {
+        "base": "mumble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "mumble",
+            "thirdPerson": "mumbles",
+            "past": "mumbled",
+            "pastParticiple": "mumbled",
+            "presentParticiple": "mumbling"
+        }
+    },
+    {
+        "base": "murmur",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "murmur",
+            "thirdPerson": "murmurs",
+            "past": "murmured",
+            "pastParticiple": "murmured",
+            "presentParticiple": "murmuring"
+        }
+    },
+    {
+        "base": "muse",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "muse",
+            "thirdPerson": "muses",
+            "past": "mused",
+            "pastParticiple": "mused",
+            "presentParticiple": "musing"
+        }
+    },
+    {
+        "base": "muster",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "muster",
+            "thirdPerson": "musters",
+            "past": "mustered",
+            "pastParticiple": "mustered",
+            "presentParticiple": "mustering"
+        }
+    },
+    {
+        "base": "mutter",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "mutter",
+            "thirdPerson": "mutters",
+            "past": "muttered",
+            "pastParticiple": "muttered",
+            "presentParticiple": "muttering"
+        }
+    },
+    {
+        "base": "nag",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "nag",
+            "thirdPerson": "nags",
+            "past": "nagged",
+            "pastParticiple": "nagged",
+            "presentParticiple": "nagging"
+        }
+    },
+    {
+        "base": "narrate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "narrate",
+            "thirdPerson": "narrates",
+            "past": "narrated",
+            "pastParticiple": "narrated",
+            "presentParticiple": "narrating"
+        }
+    },
+    {
+        "base": "navigate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "navigate",
+            "thirdPerson": "navigates",
+            "past": "navigated",
+            "pastParticiple": "navigated",
+            "presentParticiple": "navigating"
+        }
+    },
+    {
+        "base": "nod",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "nod",
+            "thirdPerson": "nods",
+            "past": "nodded",
+            "pastParticiple": "nodded",
+            "presentParticiple": "nodding"
+        }
+    },
+    {
+        "base": "note",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "note",
+            "thirdPerson": "notes",
+            "past": "noted",
+            "pastParticiple": "noted",
+            "presentParticiple": "noting"
+        }
+    },
+    {
+        "base": "notify",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "notify",
+            "thirdPerson": "notifies",
+            "past": "notified",
+            "pastParticiple": "notified",
+            "presentParticiple": "notifying"
+        }
+    },
+    {
+        "base": "nudge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "nudge",
+            "thirdPerson": "nudges",
+            "past": "nudged",
+            "pastParticiple": "nudged",
+            "presentParticiple": "nudging"
+        }
+    },
+    {
+        "base": "nuzzle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "nuzzle",
+            "thirdPerson": "nuzzles",
+            "past": "nuzzled",
+            "pastParticiple": "nuzzled",
+            "presentParticiple": "nuzzling"
+        }
+    },
+    {
+        "base": "object",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "object",
+            "thirdPerson": "objects",
+            "past": "objected",
+            "pastParticiple": "objected",
+            "presentParticiple": "objecting"
+        }
+    },
+    {
+        "base": "observe",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "observe",
+            "thirdPerson": "observes",
+            "past": "observed",
+            "pastParticiple": "observed",
+            "presentParticiple": "observing"
+        }
+    },
+    {
+        "base": "offer",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "offer",
+            "thirdPerson": "offers",
+            "past": "offered",
+            "pastParticiple": "offered",
+            "presentParticiple": "offering"
+        }
+    },
+    {
+        "base": "opine",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "opine",
+            "thirdPerson": "opines",
+            "past": "opined",
+            "pastParticiple": "opined",
+            "presentParticiple": "opining"
+        }
+    },
+    {
+        "base": "orate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "orate",
+            "thirdPerson": "orates",
+            "past": "orated",
+            "pastParticiple": "orated",
+            "presentParticiple": "orating"
+        }
+    },
+    {
+        "base": "orbit",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "orbit",
+            "thirdPerson": "orbits",
+            "past": "orbited",
+            "pastParticiple": "orbited",
+            "presentParticiple": "orbiting"
+        }
+    },
+    {
+        "base": "order",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "order",
+            "thirdPerson": "orders",
+            "past": "ordered",
+            "pastParticiple": "ordered",
+            "presentParticiple": "ordering"
+        }
+    },
+    {
+        "base": "pace",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pace",
+            "thirdPerson": "paces",
+            "past": "paced",
+            "pastParticiple": "paced",
+            "presentParticiple": "pacing"
+        }
+    },
+    {
+        "base": "paddle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "paddle",
+            "thirdPerson": "paddles",
+            "past": "paddled",
+            "pastParticiple": "paddled",
+            "presentParticiple": "paddling"
+        }
+    },
+    {
+        "base": "parry",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "parry",
+            "thirdPerson": "parries",
+            "past": "parried",
+            "pastParticiple": "parried",
+            "presentParticiple": "parrying"
+        }
+    },
+    {
+        "base": "pause",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pause",
+            "thirdPerson": "pauses",
+            "past": "paused",
+            "pastParticiple": "paused",
+            "presentParticiple": "pausing"
+        }
+    },
+    {
+        "base": "paw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "paw",
+            "thirdPerson": "paws",
+            "past": "pawed",
+            "pastParticiple": "pawed",
+            "presentParticiple": "pawing"
+        }
+    },
+    {
+        "base": "peek",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "peek",
+            "thirdPerson": "peeks",
+            "past": "peeked",
+            "pastParticiple": "peeked",
+            "presentParticiple": "peeking"
+        }
+    },
+    {
+        "base": "peer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "peer",
+            "thirdPerson": "peers",
+            "past": "peered",
+            "pastParticiple": "peered",
+            "presentParticiple": "peering"
+        }
+    },
+    {
+        "base": "perch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "perch",
+            "thirdPerson": "perches",
+            "past": "perched",
+            "pastParticiple": "perched",
+            "presentParticiple": "perching"
+        }
+    },
+    {
+        "base": "perk up",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "perk up",
+            "thirdPerson": "perks up",
+            "past": "perked up",
+            "pastParticiple": "perked up",
+            "presentParticiple": "perking up"
+        }
+    },
+    {
+        "base": "petition",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "petition",
+            "thirdPerson": "petitions",
+            "past": "petitioned",
+            "pastParticiple": "petitioned",
+            "presentParticiple": "petitioning"
+        }
+    },
+    {
+        "base": "phrase",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "phrase",
+            "thirdPerson": "phrases",
+            "past": "phrased",
+            "pastParticiple": "phrased",
+            "presentParticiple": "phrasing"
+        }
+    },
+    {
+        "base": "pivot",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pivot",
+            "thirdPerson": "pivots",
+            "past": "pivotted",
+            "pastParticiple": "pivotted",
+            "presentParticiple": "pivotting"
+        }
+    },
+    {
+        "base": "plant",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "plant",
+            "thirdPerson": "plants",
+            "past": "planted",
+            "pastParticiple": "planted",
+            "presentParticiple": "planting"
+        }
+    },
+    {
+        "base": "plead",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "plead",
+            "thirdPerson": "pleads",
+            "past": "pleaded",
+            "pastParticiple": "pleaded",
+            "presentParticiple": "pleading"
+        }
+    },
+    {
+        "base": "pledge",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "pledge",
+            "thirdPerson": "pledges",
+            "past": "pledged",
+            "pastParticiple": "pledged",
+            "presentParticiple": "pledging"
+        }
+    },
+    {
+        "base": "plod",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "plod",
+            "thirdPerson": "plods",
+            "past": "plodded",
+            "pastParticiple": "plodded",
+            "presentParticiple": "plodding"
+        }
+    },
+    {
+        "base": "plot",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "plot",
+            "thirdPerson": "plots",
+            "past": "plotted",
+            "pastParticiple": "plotted",
+            "presentParticiple": "plotting"
+        }
+    },
+    {
+        "base": "plow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "plow",
+            "thirdPerson": "plows",
+            "past": "plowed",
+            "pastParticiple": "plowed",
+            "presentParticiple": "plowing"
+        }
+    },
+    {
+        "base": "pluck",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pluck",
+            "thirdPerson": "plucks",
+            "past": "plucked",
+            "pastParticiple": "plucked",
+            "presentParticiple": "plucking"
+        }
+    },
+    {
+        "base": "plummet",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "plummet",
+            "thirdPerson": "plummets",
+            "past": "plummetted",
+            "pastParticiple": "plummetted",
+            "presentParticiple": "plummetting"
+        }
+    },
+    {
+        "base": "point",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "point",
+            "thirdPerson": "points",
+            "past": "pointed",
+            "pastParticiple": "pointed",
+            "presentParticiple": "pointing"
+        }
+    },
+    {
+        "base": "ponder",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "ponder",
+            "thirdPerson": "ponders",
+            "past": "pondered",
+            "pastParticiple": "pondered",
+            "presentParticiple": "pondering"
+        }
+    },
+    {
+        "base": "pop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "pop",
+            "thirdPerson": "pops",
+            "past": "popped",
+            "pastParticiple": "popped",
+            "presentParticiple": "popping"
+        }
+    },
+    {
+        "base": "posit",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "posit",
+            "thirdPerson": "posits",
+            "past": "posited",
+            "pastParticiple": "posited",
+            "presentParticiple": "positing"
+        }
+    },
+    {
+        "base": "position",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "position",
+            "thirdPerson": "positions",
+            "past": "positioned",
+            "pastParticiple": "positioned",
+            "presentParticiple": "positioning"
+        }
+    },
+    {
+        "base": "pounce",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pounce",
+            "thirdPerson": "pounces",
+            "past": "pounced",
+            "pastParticiple": "pounced",
+            "presentParticiple": "pouncing"
+        }
+    },
+    {
+        "base": "prance",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "prance",
+            "thirdPerson": "prances",
+            "past": "pranced",
+            "pastParticiple": "pranced",
+            "presentParticiple": "prancing"
+        }
+    },
+    {
+        "base": "prattle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "prattle",
+            "thirdPerson": "prattles",
+            "past": "prattled",
+            "pastParticiple": "prattled",
+            "presentParticiple": "prattling"
+        }
+    },
+    {
+        "base": "pray",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "pray",
+            "thirdPerson": "prays",
+            "past": "prayed",
+            "pastParticiple": "prayed",
+            "presentParticiple": "praying"
+        }
+    },
+    {
+        "base": "preach",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "preach",
+            "thirdPerson": "preaches",
+            "past": "preached",
+            "pastParticiple": "preached",
+            "presentParticiple": "preaching"
+        }
+    },
+    {
+        "base": "predicate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "predicate",
+            "thirdPerson": "predicates",
+            "past": "predicated",
+            "pastParticiple": "predicated",
+            "presentParticiple": "predicating"
+        }
+    },
+    {
+        "base": "predict",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "predict",
+            "thirdPerson": "predicts",
+            "past": "predicted",
+            "pastParticiple": "predicted",
+            "presentParticiple": "predicting"
+        }
+    },
+    {
+        "base": "preen",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "preen",
+            "thirdPerson": "preens",
+            "past": "preened",
+            "pastParticiple": "preened",
+            "presentParticiple": "preening"
+        }
+    },
+    {
+        "base": "prescribe",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "prescribe",
+            "thirdPerson": "prescribes",
+            "past": "prescribed",
+            "pastParticiple": "prescribed",
+            "presentParticiple": "prescribing"
+        }
+    },
+    {
+        "base": "press",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "press",
+            "thirdPerson": "presses",
+            "past": "pressed",
+            "pastParticiple": "pressed",
+            "presentParticiple": "pressing"
+        }
+    },
+    {
+        "base": "proclaim",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "proclaim",
+            "thirdPerson": "proclaims",
+            "past": "proclaimed",
+            "pastParticiple": "proclaimed",
+            "presentParticiple": "proclaiming"
+        }
+    },
+    {
+        "base": "prod",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "prod",
+            "thirdPerson": "prods",
+            "past": "prodded",
+            "pastParticiple": "prodded",
+            "presentParticiple": "prodding"
+        }
+    },
+    {
+        "base": "profess",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "profess",
+            "thirdPerson": "professes",
+            "past": "professed",
+            "pastParticiple": "professed",
+            "presentParticiple": "professing"
+        }
+    },
+    {
+        "base": "proffer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "proffer",
+            "thirdPerson": "proffers",
+            "past": "proffered",
+            "pastParticiple": "proffered",
+            "presentParticiple": "proffering"
+        }
+    },
+    {
+        "base": "prognosticate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "prognosticate",
+            "thirdPerson": "prognosticates",
+            "past": "prognosticated",
+            "pastParticiple": "prognosticated",
+            "presentParticiple": "prognosticating"
+        }
+    },
+    {
+        "base": "promise",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "promise",
+            "thirdPerson": "promises",
+            "past": "promised",
+            "pastParticiple": "promised",
+            "presentParticiple": "promising"
+        }
+    },
+    {
+        "base": "pronounce",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "pronounce",
+            "thirdPerson": "pronounces",
+            "past": "pronounced",
+            "pastParticiple": "pronounced",
+            "presentParticiple": "pronouncing"
+        }
+    },
+    {
+        "base": "propel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "propel",
+            "thirdPerson": "propels",
+            "past": "propelled",
+            "pastParticiple": "propelled",
+            "presentParticiple": "propelling"
+        }
+    },
+    {
+        "base": "propose",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "propose",
+            "thirdPerson": "proposes",
+            "past": "proposed",
+            "pastParticiple": "proposed",
+            "presentParticiple": "proposing"
+        }
+    },
+    {
+        "base": "protest",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "protest",
+            "thirdPerson": "protests",
+            "past": "protested",
+            "pastParticiple": "protested",
+            "presentParticiple": "protesting"
+        }
+    },
+    {
+        "base": "prowl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "prowl",
+            "thirdPerson": "prowls",
+            "past": "prowled",
+            "pastParticiple": "prowled",
+            "presentParticiple": "prowling"
+        }
+    },
+    {
+        "base": "pull",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "pull",
+            "thirdPerson": "pulls",
+            "past": "pulled",
+            "pastParticiple": "pulled",
+            "presentParticiple": "pulling"
+        }
+    },
+    {
+        "base": "pulse",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pulse",
+            "thirdPerson": "pulses",
+            "past": "pulsed",
+            "pastParticiple": "pulsed",
+            "presentParticiple": "pulsing"
+        }
+    },
+    {
+        "base": "pummel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pummel",
+            "thirdPerson": "pummels",
+            "past": "pummeled",
+            "pastParticiple": "pummeled",
+            "presentParticiple": "pummeling"
+        }
+    },
+    {
+        "base": "pump",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pump",
+            "thirdPerson": "pumps",
+            "past": "pumped",
+            "pastParticiple": "pumped",
+            "presentParticiple": "pumping"
+        }
+    },
+    {
+        "base": "punch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "punch",
+            "thirdPerson": "punches",
+            "past": "punched",
+            "pastParticiple": "punched",
+            "presentParticiple": "punching"
+        }
+    },
+    {
+        "base": "purr",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "purr",
+            "thirdPerson": "purrs",
+            "past": "purred",
+            "pastParticiple": "purred",
+            "presentParticiple": "purring"
+        }
+    },
+    {
+        "base": "pursue",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "pursue",
+            "thirdPerson": "pursues",
+            "past": "pursued",
+            "pastParticiple": "pursued",
+            "presentParticiple": "pursuing"
+        }
+    },
+    {
+        "base": "push",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "push",
+            "thirdPerson": "pushes",
+            "past": "pushed",
+            "pastParticiple": "pushed",
+            "presentParticiple": "pushing"
+        }
+    },
+    {
+        "base": "quake",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "quake",
+            "thirdPerson": "quakes",
+            "past": "quaked",
+            "pastParticiple": "quaked",
+            "presentParticiple": "quaking"
+        }
+    },
+    {
+        "base": "quaver",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "quaver",
+            "thirdPerson": "quavers",
+            "past": "quavered",
+            "pastParticiple": "quavered",
+            "presentParticiple": "quavering"
+        }
+    },
+    {
+        "base": "query",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "query",
+            "thirdPerson": "queries",
+            "past": "queried",
+            "pastParticiple": "queried",
+            "presentParticiple": "querying"
+        }
+    },
+    {
+        "base": "question",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "question",
+            "thirdPerson": "questions",
+            "past": "questioned",
+            "pastParticiple": "questioned",
+            "presentParticiple": "questioning"
+        }
+    },
+    {
+        "base": "quip",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "quip",
+            "thirdPerson": "quips",
+            "past": "quiped",
+            "pastParticiple": "quiped",
+            "presentParticiple": "quiping"
+        }
+    },
+    {
+        "base": "quiver",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "quiver",
+            "thirdPerson": "quivers",
+            "past": "quivered",
+            "pastParticiple": "quivered",
+            "presentParticiple": "quivering"
+        }
+    },
+    {
+        "base": "quote",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "quote",
+            "thirdPerson": "quotes",
+            "past": "quoted",
+            "pastParticiple": "quoted",
+            "presentParticiple": "quoting"
+        }
+    },
+    {
+        "base": "race",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "race",
+            "thirdPerson": "races",
+            "past": "raced",
+            "pastParticiple": "raced",
+            "presentParticiple": "racing"
+        }
+    },
+    {
+        "base": "radiate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "radiate",
+            "thirdPerson": "radiates",
+            "past": "radiated",
+            "pastParticiple": "radiated",
+            "presentParticiple": "radiating"
+        }
+    },
+    {
+        "base": "raise",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "raise",
+            "thirdPerson": "raises",
+            "past": "raised",
+            "pastParticiple": "raised",
+            "presentParticiple": "raising"
+        }
+    },
+    {
+        "base": "rally",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "rally",
+            "thirdPerson": "rallies",
+            "past": "rallied",
+            "pastParticiple": "rallied",
+            "presentParticiple": "rallying"
+        }
+    },
+    {
+        "base": "ramble",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "ramble",
+            "thirdPerson": "rambles",
+            "past": "rambled",
+            "pastParticiple": "rambled",
+            "presentParticiple": "rambling"
+        }
+    },
+    {
+        "base": "rasp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rasp",
+            "thirdPerson": "rasps",
+            "past": "rasped",
+            "pastParticiple": "rasped",
+            "presentParticiple": "rasping"
+        }
+    },
+    {
+        "base": "rattle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "rattle",
+            "thirdPerson": "rattles",
+            "past": "rattled",
+            "pastParticiple": "rattled",
+            "presentParticiple": "rattling"
+        }
+    },
+    {
+        "base": "reach",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "reach",
+            "thirdPerson": "reaches",
+            "past": "reached",
+            "pastParticiple": "reached",
+            "presentParticiple": "reaching"
+        }
+    },
+    {
+        "base": "reason",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "reason",
+            "thirdPerson": "reasons",
+            "past": "reasonned",
+            "pastParticiple": "reasonned",
+            "presentParticiple": "reasonning"
+        }
+    },
+    {
+        "base": "reassure",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "reassure",
+            "thirdPerson": "reassures",
+            "past": "reassured",
+            "pastParticiple": "reassured",
+            "presentParticiple": "reassuring"
+        }
+    },
+    {
+        "base": "rebuke",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rebuke",
+            "thirdPerson": "rebukes",
+            "past": "rebuked",
+            "pastParticiple": "rebuked",
+            "presentParticiple": "rebuking"
+        }
+    },
+    {
+        "base": "rebut",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rebut",
+            "thirdPerson": "rebuts",
+            "past": "rebutted",
+            "pastParticiple": "rebutted",
+            "presentParticiple": "rebutting"
+        }
+    },
+    {
+        "base": "recall",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "recall",
+            "thirdPerson": "recalls",
+            "past": "recalled",
+            "pastParticiple": "recalled",
+            "presentParticiple": "recalling"
+        }
+    },
+    {
+        "base": "recite",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "recite",
+            "thirdPerson": "recites",
+            "past": "recited",
+            "pastParticiple": "recited",
+            "presentParticiple": "reciting"
+        }
+    },
+    {
+        "base": "recognize",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "recognize",
+            "thirdPerson": "recognizes",
+            "past": "recognized",
+            "pastParticiple": "recognized",
+            "presentParticiple": "recognizing"
+        }
+    },
+    {
+        "base": "recoil",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "recoil",
+            "thirdPerson": "recoils",
+            "past": "recoiled",
+            "pastParticiple": "recoiled",
+            "presentParticiple": "recoiling"
+        }
+    },
+    {
+        "base": "recommend",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "recommend",
+            "thirdPerson": "recommends",
+            "past": "recommended",
+            "pastParticiple": "recommended",
+            "presentParticiple": "recommending"
+        }
+    },
+    {
+        "base": "recount",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "recount",
+            "thirdPerson": "recounts",
+            "past": "recounted",
+            "pastParticiple": "recounted",
+            "presentParticiple": "recounting"
+        }
+    },
+    {
+        "base": "redirect",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "redirect",
+            "thirdPerson": "redirects",
+            "past": "redirected",
+            "pastParticiple": "redirected",
+            "presentParticiple": "redirecting"
+        }
+    },
+    {
+        "base": "reduce",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "reduce",
+            "thirdPerson": "reduces",
+            "past": "reduced",
+            "pastParticiple": "reduced",
+            "presentParticiple": "reducing"
+        }
+    },
+    {
+        "base": "reel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "reel",
+            "thirdPerson": "reels",
+            "past": "reeled",
+            "pastParticiple": "reeled",
+            "presentParticiple": "reeling"
+        }
+    },
+    {
+        "base": "refer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "refer",
+            "thirdPerson": "refers",
+            "past": "referred",
+            "pastParticiple": "referred",
+            "presentParticiple": "referring"
+        }
+    },
+    {
+        "base": "refract",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "refract",
+            "thirdPerson": "refracts",
+            "past": "refracted",
+            "pastParticiple": "refracted",
+            "presentParticiple": "refracting"
+        }
+    },
+    {
+        "base": "reiterate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "reiterate",
+            "thirdPerson": "reiterates",
+            "past": "reiterated",
+            "pastParticiple": "reiterated",
+            "presentParticiple": "reiterating"
+        }
+    },
+    {
+        "base": "rejoin",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rejoin",
+            "thirdPerson": "rejoins",
+            "past": "rejoined",
+            "pastParticiple": "rejoined",
+            "presentParticiple": "rejoining"
+        }
+    },
+    {
+        "base": "remark",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "remark",
+            "thirdPerson": "remarks",
+            "past": "remarked",
+            "pastParticiple": "remarked",
+            "presentParticiple": "remarking"
+        }
+    },
+    {
+        "base": "remind",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "remind",
+            "thirdPerson": "reminds",
+            "past": "reminded",
+            "pastParticiple": "reminded",
+            "presentParticiple": "reminding"
+        }
+    },
+    {
+        "base": "repeat",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "repeat",
+            "thirdPerson": "repeats",
+            "past": "repeated",
+            "pastParticiple": "repeated",
+            "presentParticiple": "repeating"
+        }
+    },
+    {
+        "base": "reply",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "reply",
+            "thirdPerson": "replies",
+            "past": "replied",
+            "pastParticiple": "replied",
+            "presentParticiple": "replying"
+        }
+    },
+    {
+        "base": "report",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "report",
+            "thirdPerson": "reports",
+            "past": "reported",
+            "pastParticiple": "reported",
+            "presentParticiple": "reporting"
+        }
+    },
+    {
+        "base": "request",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "request",
+            "thirdPerson": "requests",
+            "past": "requested",
+            "pastParticiple": "requested",
+            "presentParticiple": "requesting"
+        }
+    },
+    {
+        "base": "resolve",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "resolve",
+            "thirdPerson": "resolves",
+            "past": "resolved",
+            "pastParticiple": "resolved",
+            "presentParticiple": "resolving"
+        }
+    },
+    {
+        "base": "respond",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "respond",
+            "thirdPerson": "responds",
+            "past": "responded",
+            "pastParticiple": "responded",
+            "presentParticiple": "responding"
+        }
+    },
+    {
+        "base": "restate",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "restate",
+            "thirdPerson": "restates",
+            "past": "restated",
+            "pastParticiple": "restated",
+            "presentParticiple": "restating"
+        }
+    },
+    {
+        "base": "retort",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "retort",
+            "thirdPerson": "retorts",
+            "past": "retorted",
+            "pastParticiple": "retorted",
+            "presentParticiple": "retorting"
+        }
+    },
+    {
+        "base": "retreat",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "retreat",
+            "thirdPerson": "retreats",
+            "past": "retreat",
+            "pastParticiple": "retreat",
+            "presentParticiple": "retreating"
+        }
+    },
+    {
+        "base": "reveal",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "reveal",
+            "thirdPerson": "reveals",
+            "past": "revealed",
+            "pastParticiple": "revealed",
+            "presentParticiple": "revealing"
+        }
+    },
+    {
+        "base": "reverse",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "reverse",
+            "thirdPerson": "reverses",
+            "past": "reversed",
+            "pastParticiple": "reversed",
+            "presentParticiple": "reversing"
+        }
+    },
+    {
+        "base": "revolve",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "revolve",
+            "thirdPerson": "revolves",
+            "past": "revolved",
+            "pastParticiple": "revolved",
+            "presentParticiple": "revolving"
+        }
+    },
+    {
+        "base": "ricochet",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "ricochet",
+            "thirdPerson": "ricochets",
+            "past": "ricocheted",
+            "pastParticiple": "ricocheted",
+            "presentParticiple": "ricocheting"
+        }
+    },
+    {
+        "base": "rise",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rise",
+            "thirdPerson": "rises",
+            "past": "rose",
+            "pastParticiple": "risen",
+            "presentParticiple": "rising"
+        }
+    },
+    {
+        "base": "roar",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "roar",
+            "thirdPerson": "roars",
+            "past": "roared",
+            "pastParticiple": "roared",
+            "presentParticiple": "roaring"
+        }
+    },
+    {
+        "base": "rock",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "rock",
+            "thirdPerson": "rocks",
+            "past": "rocked",
+            "pastParticiple": "rocked",
+            "presentParticiple": "rocking"
+        }
+    },
+    {
+        "base": "roll",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "roll",
+            "thirdPerson": "rolls",
+            "past": "rolled",
+            "pastParticiple": "rolled",
+            "presentParticiple": "rolling"
+        }
+    },
+    {
+        "base": "run",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "run",
+            "thirdPerson": "runs",
+            "past": "ran",
+            "pastParticiple": "run",
+            "presentParticiple": "running"
+        }
+    },
+    {
+        "base": "rush",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "rush",
+            "thirdPerson": "rushes",
+            "past": "rushed",
+            "pastParticiple": "rushed",
+            "presentParticiple": "rushing"
+        }
+    },
+    {
+        "base": "sail",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sail",
+            "thirdPerson": "sails",
+            "past": "sailed",
+            "pastParticiple": "sailed",
+            "presentParticiple": "sailing"
+        }
+    },
+    {
+        "base": "sally",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sally",
+            "thirdPerson": "sallies",
+            "past": "sallied",
+            "pastParticiple": "sallied",
+            "presentParticiple": "sallying"
+        }
+    },
+    {
+        "base": "sashay",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sashay",
+            "thirdPerson": "sashays",
+            "past": "sashayed",
+            "pastParticiple": "sashayed",
+            "presentParticiple": "sashaying"
+        }
+    },
+    {
+        "base": "sass",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "sass",
+            "thirdPerson": "sasses",
+            "past": "sassed",
+            "pastParticiple": "sassed",
+            "presentParticiple": "sassing"
+        }
+    },
+    {
+        "base": "savor",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "savor",
+            "thirdPerson": "savors",
+            "past": "savored",
+            "pastParticiple": "savored",
+            "presentParticiple": "savoring"
+        }
+    },
+    {
+        "base": "say",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "say",
+            "thirdPerson": "says",
+            "past": "said",
+            "pastParticiple": "said",
+            "presentParticiple": "saying"
+        }
+    },
+    {
+        "base": "scamper",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "scamper",
+            "thirdPerson": "scampers",
+            "past": "scampered",
+            "pastParticiple": "scampered",
+            "presentParticiple": "scampering"
+        }
+    },
+    {
+        "base": "scatter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "scatter",
+            "thirdPerson": "scatters",
+            "past": "scattered",
+            "pastParticiple": "scattered",
+            "presentParticiple": "scattering"
+        }
+    },
+    {
+        "base": "scoff",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "scoff",
+            "thirdPerson": "scoffs",
+            "past": "scoffed",
+            "pastParticiple": "scoffed",
+            "presentParticiple": "scoffing"
+        }
+    },
+    {
+        "base": "scold",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "scold",
+            "thirdPerson": "scolds",
+            "past": "scolded",
+            "pastParticiple": "scolded",
+            "presentParticiple": "scolding"
+        }
+    },
+    {
+        "base": "scoot",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "scoot",
+            "thirdPerson": "scoots",
+            "past": "scooted",
+            "pastParticiple": "scooted",
+            "presentParticiple": "scooting"
+        }
+    },
+    {
+        "base": "scramble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "scramble",
+            "thirdPerson": "scrambles",
+            "past": "scrambled",
+            "pastParticiple": "scrambled",
+            "presentParticiple": "scrambling"
+        }
+    },
+    {
+        "base": "screech",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "screech",
+            "thirdPerson": "screeches",
+            "past": "screeched",
+            "pastParticiple": "screeched",
+            "presentParticiple": "screeching"
+        }
+    },
+    {
+        "base": "scrub",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "scrub",
+            "thirdPerson": "scrubs",
+            "past": "scrubbed",
+            "pastParticiple": "scrubbed",
+            "presentParticiple": "scrubbing"
+        }
+    },
+    {
+        "base": "scud",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "scud",
+            "thirdPerson": "scuds",
+            "past": "scudded",
+            "pastParticiple": "scudded",
+            "presentParticiple": "scudding"
+        }
+    },
+    {
+        "base": "scurry",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "scurry",
+            "thirdPerson": "scurries",
+            "past": "scurried",
+            "pastParticiple": "scurried",
+            "presentParticiple": "scurrying"
+        }
+    },
+    {
+        "base": "see",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "see",
+            "thirdPerson": "sees",
+            "past": "saw",
+            "pastParticiple": "seen",
+            "presentParticiple": "seeing"
+        }
+    },
+    {
+        "base": "seep",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "seep",
+            "thirdPerson": "seeps",
+            "past": "seeped",
+            "pastParticiple": "seeped",
+            "presentParticiple": "seeping"
+        }
+    },
+    {
+        "base": "seize",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "seize",
+            "thirdPerson": "seizes",
+            "past": "seized",
+            "pastParticiple": "seized",
+            "presentParticiple": "seizing"
+        }
+    },
+    {
+        "base": "set",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "set",
+            "thirdPerson": "sets",
+            "past": "set",
+            "pastParticiple": "set",
+            "presentParticiple": "setting"
+        }
+    },
+    {
+        "base": "shade",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shade",
+            "thirdPerson": "shades",
+            "past": "shaded",
+            "pastParticiple": "shaded",
+            "presentParticiple": "shading"
+        }
+    },
+    {
+        "base": "shadow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shadow",
+            "thirdPerson": "shadows",
+            "past": "shadowed",
+            "pastParticiple": "shadowed",
+            "presentParticiple": "shadowing"
+        }
+    },
+    {
+        "base": "shake",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "shake",
+            "thirdPerson": "shakes",
+            "past": "shook",
+            "pastParticiple": "shaken",
+            "presentParticiple": "shaking"
+        }
+    },
+    {
+        "base": "sharpen",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sharpen",
+            "thirdPerson": "sharpens",
+            "past": "sharpened",
+            "pastParticiple": "sharpened",
+            "presentParticiple": "sharpening"
+        }
+    },
+    {
+        "base": "shift",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shift",
+            "thirdPerson": "shifts",
+            "past": "shifted",
+            "pastParticiple": "shifted",
+            "presentParticiple": "shifting"
+        }
+    },
+    {
+        "base": "shimmer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shimmer",
+            "thirdPerson": "shimmers",
+            "past": "shimmered",
+            "pastParticiple": "shimmered",
+            "presentParticiple": "shimmering"
+        }
+    },
+    {
+        "base": "shimmy",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "shimmy",
+            "thirdPerson": "shimmies",
+            "past": "shimmied",
+            "pastParticiple": "shimmied",
+            "presentParticiple": "shimmying"
+        }
+    },
+    {
+        "base": "shine",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shine",
+            "thirdPerson": "shines",
+            "past": "shone",
+            "pastParticiple": "shone",
+            "presentParticiple": "shining"
+        }
+    },
+    {
+        "base": "shiver",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shiver",
+            "thirdPerson": "shivers",
+            "past": "shivered",
+            "pastParticiple": "shivered",
+            "presentParticiple": "shivering"
+        }
+    },
+    {
+        "base": "shout",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shout",
+            "thirdPerson": "shouts",
+            "past": "shouted",
+            "pastParticiple": "shouted",
+            "presentParticiple": "shouting"
+        }
+    },
+    {
+        "base": "shriek",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "shriek",
+            "thirdPerson": "shrieks",
+            "past": "shrieked",
+            "pastParticiple": "shrieked",
+            "presentParticiple": "shrieking"
+        }
+    },
+    {
+        "base": "shrug",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shrug",
+            "thirdPerson": "shrugs",
+            "past": "shrugged",
+            "pastParticiple": "shrugged",
+            "presentParticiple": "shrugging"
+        }
+    },
+    {
+        "base": "shudder",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "shudder",
+            "thirdPerson": "shudders",
+            "past": "shuddered",
+            "pastParticiple": "shuddered",
+            "presentParticiple": "shuddering"
+        }
+    },
+    {
+        "base": "sidestep",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sidestep",
+            "thirdPerson": "sidesteps",
+            "past": "sidestepped",
+            "pastParticiple": "sidestepped",
+            "presentParticiple": "sidestepping"
+        }
+    },
+    {
+        "base": "sift",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sift",
+            "thirdPerson": "sifts",
+            "past": "sifted",
+            "pastParticiple": "sifted",
+            "presentParticiple": "sifting"
+        }
+    },
+    {
+        "base": "sigh",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sigh",
+            "thirdPerson": "sighs",
+            "past": "sighed",
+            "pastParticiple": "sighed",
+            "presentParticiple": "sighing"
+        }
+    },
+    {
+        "base": "sing",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "sing",
+            "thirdPerson": "sings",
+            "past": "sang",
+            "pastParticiple": "sung",
+            "presentParticiple": "singing"
+        }
+    },
+    {
+        "base": "sketch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sketch",
+            "thirdPerson": "sketches",
+            "past": "sketched",
+            "pastParticiple": "sketched",
+            "presentParticiple": "sketching"
+        }
+    },
+    {
+        "base": "skid",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "skid",
+            "thirdPerson": "skids",
+            "past": "skidded",
+            "pastParticiple": "skidded",
+            "presentParticiple": "skidding"
+        }
+    },
+    {
+        "base": "skim",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "skim",
+            "thirdPerson": "skims",
+            "past": "skimmed",
+            "pastParticiple": "skimmed",
+            "presentParticiple": "skimming"
+        }
+    },
+    {
+        "base": "skip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "skip",
+            "thirdPerson": "skips",
+            "past": "skipped",
+            "pastParticiple": "skipped",
+            "presentParticiple": "skipping"
+        }
+    },
+    {
+        "base": "slash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "slash",
+            "thirdPerson": "slashes",
+            "past": "slashed",
+            "pastParticiple": "slashed",
+            "presentParticiple": "slashing"
+        }
+    },
+    {
+        "base": "slink",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "slink",
+            "thirdPerson": "slinks",
+            "past": "slunk",
+            "pastParticiple": "slunk",
+            "presentParticiple": "slinking"
+        }
+    },
+    {
+        "base": "slip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "slip",
+            "thirdPerson": "slips",
+            "past": "slipped",
+            "pastParticiple": "slipped",
+            "presentParticiple": "slipping"
+        }
+    },
+    {
+        "base": "slither",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "slither",
+            "thirdPerson": "slithers",
+            "past": "slithered",
+            "pastParticiple": "slithered",
+            "presentParticiple": "slithering"
+        }
+    },
+    {
+        "base": "slouch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "slouch",
+            "thirdPerson": "slouches",
+            "past": "slouched",
+            "pastParticiple": "slouched",
+            "presentParticiple": "slouching"
+        }
+    },
+    {
+        "base": "sluice",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sluice",
+            "thirdPerson": "sluices",
+            "past": "sluiced",
+            "pastParticiple": "sluiced",
+            "presentParticiple": "sluicing"
+        }
+    },
+    {
+        "base": "slump",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "slump",
+            "thirdPerson": "slumps",
+            "past": "slumped",
+            "pastParticiple": "slumped",
+            "presentParticiple": "slumping"
+        }
+    },
+    {
+        "base": "slur",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "slur",
+            "thirdPerson": "slurs",
+            "past": "slurred",
+            "pastParticiple": "slurred",
+            "presentParticiple": "slurring"
+        }
+    },
+    {
+        "base": "smile",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "smile",
+            "thirdPerson": "smiles",
+            "past": "smiled",
+            "pastParticiple": "smiled",
+            "presentParticiple": "smiling"
+        }
+    },
+    {
+        "base": "smirk",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "smirk",
+            "thirdPerson": "smirks",
+            "past": "smirked",
+            "pastParticiple": "smirked",
+            "presentParticiple": "smirking"
+        }
+    },
+    {
+        "base": "smite",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "smite",
+            "thirdPerson": "smites",
+            "past": "smote",
+            "pastParticiple": "smitten",
+            "presentParticiple": "smiting"
+        }
+    },
+    {
+        "base": "snake",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "snake",
+            "thirdPerson": "snakes",
+            "past": "snaked",
+            "pastParticiple": "snaked",
+            "presentParticiple": "snaking"
+        }
+    },
+    {
+        "base": "snap",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "snap",
+            "thirdPerson": "snaps",
+            "past": "snapped",
+            "pastParticiple": "snapped",
+            "presentParticiple": "snapping"
+        }
+    },
+    {
+        "base": "snarl",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "snarl",
+            "thirdPerson": "snarls",
+            "past": "snarled",
+            "pastParticiple": "snarled",
+            "presentParticiple": "snarling"
+        }
+    },
+    {
+        "base": "sneer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sneer",
+            "thirdPerson": "sneers",
+            "past": "sneered",
+            "pastParticiple": "sneered",
+            "presentParticiple": "sneering"
+        }
+    },
+    {
+        "base": "snicker",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "snicker",
+            "thirdPerson": "snickers",
+            "past": "snickered",
+            "pastParticiple": "snickered",
+            "presentParticiple": "snickering"
+        }
+    },
+    {
+        "base": "sniff",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sniff",
+            "thirdPerson": "sniffs",
+            "past": "sniffed",
+            "pastParticiple": "sniffed",
+            "presentParticiple": "sniffing"
+        }
+    },
+    {
+        "base": "snip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "snip",
+            "thirdPerson": "snips",
+            "past": "snipped",
+            "pastParticiple": "snipped",
+            "presentParticiple": "snipping"
+        }
+    },
+    {
+        "base": "snort",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "snort",
+            "thirdPerson": "snorts",
+            "past": "snorted",
+            "pastParticiple": "snorted",
+            "presentParticiple": "snorting"
+        }
+    },
+    {
+        "base": "snowball",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "snowball",
+            "thirdPerson": "snowballs",
+            "past": "snowballed",
+            "pastParticiple": "snowballed",
+            "presentParticiple": "snowballing"
+        }
+    },
+    {
+        "base": "soar",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "soar",
+            "thirdPerson": "soars",
+            "past": "soared",
+            "pastParticiple": "soared",
+            "presentParticiple": "soaring"
+        }
+    },
+    {
+        "base": "sob",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "sob",
+            "thirdPerson": "sobs",
+            "past": "sobbed",
+            "pastParticiple": "sobbed",
+            "presentParticiple": "sobbing"
+        }
+    },
+    {
+        "base": "soothe",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "soothe",
+            "thirdPerson": "soothes",
+            "past": "soothed",
+            "pastParticiple": "soothed",
+            "presentParticiple": "soothing"
+        }
+    },
+    {
+        "base": "spark",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spark",
+            "thirdPerson": "sparks",
+            "past": "sparked",
+            "pastParticiple": "sparked",
+            "presentParticiple": "sparking"
+        }
+    },
+    {
+        "base": "speak",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "speak",
+            "thirdPerson": "speaks",
+            "past": "spoke",
+            "pastParticiple": "spoken",
+            "presentParticiple": "speaking"
+        }
+    },
+    {
+        "base": "speculate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "speculate",
+            "thirdPerson": "speculates",
+            "past": "speculated",
+            "pastParticiple": "speculated",
+            "presentParticiple": "speculating"
+        }
+    },
+    {
+        "base": "spill",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spill",
+            "thirdPerson": "spills",
+            "past": "spilled",
+            "pastParticiple": "spilled",
+            "presentParticiple": "spilling"
+        }
+    },
+    {
+        "base": "spin",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spin",
+            "thirdPerson": "spins",
+            "past": "spun",
+            "pastParticiple": "spun",
+            "presentParticiple": "spinning"
+        }
+    },
+    {
+        "base": "spiral",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spiral",
+            "thirdPerson": "spirals",
+            "past": "spiraled",
+            "pastParticiple": "spiraled",
+            "presentParticiple": "spiraling"
+        }
+    },
+    {
+        "base": "splash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "splash",
+            "thirdPerson": "splashes",
+            "past": "splashed",
+            "pastParticiple": "splashed",
+            "presentParticiple": "splashing"
+        }
+    },
+    {
+        "base": "splutter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "splutter",
+            "thirdPerson": "splutters",
+            "past": "spluttered",
+            "pastParticiple": "spluttered",
+            "presentParticiple": "spluttering"
+        }
+    },
+    {
+        "base": "sprawl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sprawl",
+            "thirdPerson": "sprawls",
+            "past": "sprawled",
+            "pastParticiple": "sprawled",
+            "presentParticiple": "sprawling"
+        }
+    },
+    {
+        "base": "spray",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spray",
+            "thirdPerson": "sprays",
+            "past": "sprayed",
+            "pastParticiple": "sprayed",
+            "presentParticiple": "spraying"
+        }
+    },
+    {
+        "base": "spring",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spring",
+            "thirdPerson": "springs",
+            "past": "sprang",
+            "pastParticiple": "sprung",
+            "presentParticiple": "springing"
+        }
+    },
+    {
+        "base": "sprint",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sprint",
+            "thirdPerson": "sprints",
+            "past": "sprinted",
+            "pastParticiple": "sprinted",
+            "presentParticiple": "sprinting"
+        }
+    },
+    {
+        "base": "sprout",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sprout",
+            "thirdPerson": "sprouts",
+            "past": "sprouted",
+            "pastParticiple": "sprouted",
+            "presentParticiple": "sprouting"
+        }
+    },
+    {
+        "base": "spur",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "spur",
+            "thirdPerson": "spurs",
+            "past": "spured",
+            "pastParticiple": "spured",
+            "presentParticiple": "spuring"
+        }
+    },
+    {
+        "base": "sputter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "sputter",
+            "thirdPerson": "sputters",
+            "past": "sputtered",
+            "pastParticiple": "sputtered",
+            "presentParticiple": "sputtering"
+        }
+    },
+    {
+        "base": "square",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "square",
+            "thirdPerson": "squares",
+            "past": "squared",
+            "pastParticiple": "squared",
+            "presentParticiple": "squaring"
+        }
+    },
+    {
+        "base": "squeeze",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "squeeze",
+            "thirdPerson": "squeezes",
+            "past": "squeezed",
+            "pastParticiple": "squeezed",
+            "presentParticiple": "squeezing"
+        }
+    },
+    {
+        "base": "squint",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "squint",
+            "thirdPerson": "squints",
+            "past": "squinted",
+            "pastParticiple": "squinted",
+            "presentParticiple": "squinting"
+        }
+    },
+    {
+        "base": "squirm",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "squirm",
+            "thirdPerson": "squirms",
+            "past": "squirmed",
+            "pastParticiple": "squirmed",
+            "presentParticiple": "squirming"
+        }
+    },
+    {
+        "base": "stagger",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stagger",
+            "thirdPerson": "staggers",
+            "past": "staggered",
+            "pastParticiple": "staggered",
+            "presentParticiple": "staggering"
+        }
+    },
+    {
+        "base": "stalk",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stalk",
+            "thirdPerson": "stalks",
+            "past": "stalked",
+            "pastParticiple": "stalked",
+            "presentParticiple": "stalking"
+        }
+    },
+    {
+        "base": "stammer",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stammer",
+            "thirdPerson": "stammers",
+            "past": "stammered",
+            "pastParticiple": "stammered",
+            "presentParticiple": "stammering"
+        }
+    },
+    {
+        "base": "star",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "star",
+            "thirdPerson": "stars",
+            "past": "stared",
+            "pastParticiple": "stared",
+            "presentParticiple": "staring"
+        }
+    },
+    {
+        "base": "stare",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stare",
+            "thirdPerson": "stares",
+            "past": "stared",
+            "pastParticiple": "stared",
+            "presentParticiple": "staring"
+        }
+    },
+    {
+        "base": "state",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "state",
+            "thirdPerson": "states",
+            "past": "stated",
+            "pastParticiple": "stated",
+            "presentParticiple": "stating"
+        }
+    },
+    {
+        "base": "step",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "step",
+            "thirdPerson": "steps",
+            "past": "stepped",
+            "pastParticiple": "stepped",
+            "presentParticiple": "stepping"
+        }
+    },
+    {
+        "base": "still",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "still",
+            "thirdPerson": "stills",
+            "past": "stilled",
+            "pastParticiple": "stilled",
+            "presentParticiple": "stilling"
+        }
+    },
+    {
+        "base": "stipulate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stipulate",
+            "thirdPerson": "stipulates",
+            "past": "stipulated",
+            "pastParticiple": "stipulated",
+            "presentParticiple": "stipulating"
+        }
+    },
+    {
+        "base": "stomp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stomp",
+            "thirdPerson": "stomps",
+            "past": "stomped",
+            "pastParticiple": "stomped",
+            "presentParticiple": "stomping"
+        }
+    },
+    {
+        "base": "stoop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stoop",
+            "thirdPerson": "stoops",
+            "past": "stooped",
+            "pastParticiple": "stooped",
+            "presentParticiple": "stooping"
+        }
+    },
+    {
+        "base": "storm",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "storm",
+            "thirdPerson": "storms",
+            "past": "stormed",
+            "pastParticiple": "stormed",
+            "presentParticiple": "storming"
+        }
+    },
+    {
+        "base": "straddle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "straddle",
+            "thirdPerson": "straddles",
+            "past": "straddled",
+            "pastParticiple": "straddled",
+            "presentParticiple": "straddling"
+        }
+    },
+    {
+        "base": "strain",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "strain",
+            "thirdPerson": "strains",
+            "past": "strained",
+            "pastParticiple": "strained",
+            "presentParticiple": "straining"
+        }
+    },
+    {
+        "base": "stray",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stray",
+            "thirdPerson": "strays",
+            "past": "strayed",
+            "pastParticiple": "strayed",
+            "presentParticiple": "straying"
+        }
+    },
+    {
+        "base": "streak",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "streak",
+            "thirdPerson": "streaks",
+            "past": "streaked",
+            "pastParticiple": "streaked",
+            "presentParticiple": "streaking"
+        }
+    },
+    {
+        "base": "stress",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stress",
+            "thirdPerson": "stresses",
+            "past": "stressed",
+            "pastParticiple": "stressed",
+            "presentParticiple": "stressing"
+        }
+    },
+    {
+        "base": "stretch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stretch",
+            "thirdPerson": "stretches",
+            "past": "stretched",
+            "pastParticiple": "stretched",
+            "presentParticiple": "stretching"
+        }
+    },
+    {
+        "base": "stride",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stride",
+            "thirdPerson": "strides",
+            "past": "strode",
+            "pastParticiple": "stridden",
+            "presentParticiple": "striding"
+        }
+    },
+    {
+        "base": "strike",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "strike",
+            "thirdPerson": "strikes",
+            "past": "struck",
+            "pastParticiple": "struck",
+            "presentParticiple": "striking"
+        }
+    },
+    {
+        "base": "stroll",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "stroll",
+            "thirdPerson": "strolls",
+            "past": "strolled",
+            "pastParticiple": "strolled",
+            "presentParticiple": "strolling"
+        }
+    },
+    {
+        "base": "struggle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "struggle",
+            "thirdPerson": "struggles",
+            "past": "struggled",
+            "pastParticiple": "struggled",
+            "presentParticiple": "struggling"
+        }
+    },
+    {
+        "base": "strum",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "strum",
+            "thirdPerson": "strums",
+            "past": "strummed",
+            "pastParticiple": "strummed",
+            "presentParticiple": "strumming"
+        }
+    },
+    {
+        "base": "strut",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "strut",
+            "thirdPerson": "struts",
+            "past": "strutted",
+            "pastParticiple": "strutted",
+            "presentParticiple": "strutting"
+        }
+    },
+    {
+        "base": "stumble",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stumble",
+            "thirdPerson": "stumbles",
+            "past": "stumbled",
+            "pastParticiple": "stumbled",
+            "presentParticiple": "stumbling"
+        }
+    },
+    {
+        "base": "stutter",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "stutter",
+            "thirdPerson": "stutters",
+            "past": "stuttered",
+            "pastParticiple": "stuttered",
+            "presentParticiple": "stuttering"
+        }
+    },
+    {
+        "base": "submerge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "submerge",
+            "thirdPerson": "submerges",
+            "past": "submerged",
+            "pastParticiple": "submerged",
+            "presentParticiple": "submerging"
+        }
+    },
+    {
+        "base": "suggest",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "suggest",
+            "thirdPerson": "suggests",
+            "past": "suggested",
+            "pastParticiple": "suggested",
+            "presentParticiple": "suggesting"
+        }
+    },
+    {
+        "base": "summarize",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "summarize",
+            "thirdPerson": "summarizes",
+            "past": "summarized",
+            "pastParticiple": "summarized",
+            "presentParticiple": "summarizing"
+        }
+    },
+    {
+        "base": "summon",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "summon",
+            "thirdPerson": "summons",
+            "past": "summoned",
+            "pastParticiple": "summoned",
+            "presentParticiple": "summoning"
+        }
+    },
+    {
+        "base": "surge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "surge",
+            "thirdPerson": "surges",
+            "past": "surged",
+            "pastParticiple": "surged",
+            "presentParticiple": "surging"
+        }
+    },
+    {
+        "base": "surmise",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "surmise",
+            "thirdPerson": "surmises",
+            "past": "surmised",
+            "pastParticiple": "surmised",
+            "presentParticiple": "surmising"
+        }
+    },
+    {
+        "base": "swagger",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "swagger",
+            "thirdPerson": "swaggers",
+            "past": "swaggered",
+            "pastParticiple": "swaggered",
+            "presentParticiple": "swaggering"
+        }
+    },
+    {
+        "base": "swallow",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "swallow",
+            "thirdPerson": "swallows",
+            "past": "swallowed",
+            "pastParticiple": "swallowed",
+            "presentParticiple": "swallowing"
+        }
+    },
+    {
+        "base": "swap",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "swap",
+            "thirdPerson": "swaps",
+            "past": "swapped",
+            "pastParticiple": "swapped",
+            "presentParticiple": "swapping"
+        }
+    },
+    {
+        "base": "swarm",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "swarm",
+            "thirdPerson": "swarms",
+            "past": "swarmed",
+            "pastParticiple": "swarmed",
+            "presentParticiple": "swarming"
+        }
+    },
+    {
+        "base": "swat",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "swat",
+            "thirdPerson": "swats",
+            "past": "swatted",
+            "pastParticiple": "swatted",
+            "presentParticiple": "swatting"
+        }
+    },
+    {
+        "base": "sway",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "sway",
+            "thirdPerson": "sways",
+            "past": "swayed",
+            "pastParticiple": "swayed",
+            "presentParticiple": "swaying"
+        }
+    },
+    {
+        "base": "swear",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "swear",
+            "thirdPerson": "swears",
+            "past": "swore",
+            "pastParticiple": "sworn",
+            "presentParticiple": "swearing"
+        }
+    },
+    {
+        "base": "sweep",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "sweep",
+            "thirdPerson": "sweeps",
+            "past": "swept",
+            "pastParticiple": "swept",
+            "presentParticiple": "sweeping"
+        }
+    },
+    {
+        "base": "swing",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "swing",
+            "thirdPerson": "swings",
+            "past": "swung",
+            "pastParticiple": "swung",
+            "presentParticiple": "swinging"
+        }
+    },
+    {
+        "base": "swirl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "swirl",
+            "thirdPerson": "swirls",
+            "past": "swirled",
+            "pastParticiple": "swirled",
+            "presentParticiple": "swirling"
+        }
+    },
+    {
+        "base": "swivel",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "swivel",
+            "thirdPerson": "swivels",
+            "past": "swiveled",
+            "pastParticiple": "swiveled",
+            "presentParticiple": "swiveling"
+        }
+    },
+    {
+        "base": "tackle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tackle",
+            "thirdPerson": "tackles",
+            "past": "tackled",
+            "pastParticiple": "tackled",
+            "presentParticiple": "tackling"
+        }
+    },
+    {
+        "base": "tail",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tail",
+            "thirdPerson": "tails",
+            "past": "tailed",
+            "pastParticiple": "tailed",
+            "presentParticiple": "tailing"
+        }
+    },
+    {
+        "base": "take",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "take",
+            "thirdPerson": "takes",
+            "past": "took",
+            "pastParticiple": "taken",
+            "presentParticiple": "taking"
+        }
+    },
+    {
+        "base": "tap",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tap",
+            "thirdPerson": "taps",
+            "past": "tapped",
+            "pastParticiple": "tapped",
+            "presentParticiple": "tapping"
+        }
+    },
+    {
+        "base": "taunt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "taunt",
+            "thirdPerson": "taunts",
+            "past": "taunted",
+            "pastParticiple": "taunted",
+            "presentParticiple": "taunting"
+        }
+    },
+    {
+        "base": "tease",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tease",
+            "thirdPerson": "teases",
+            "past": "teased",
+            "pastParticiple": "teased",
+            "presentParticiple": "teasing"
+        }
+    },
+    {
+        "base": "tell",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tell",
+            "thirdPerson": "tells",
+            "past": "told",
+            "pastParticiple": "told",
+            "presentParticiple": "telling"
+        }
+    },
+    {
+        "base": "tense",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tense",
+            "thirdPerson": "tenses",
+            "past": "tensed",
+            "pastParticiple": "tensed",
+            "presentParticiple": "tensing"
+        }
+    },
+    {
+        "base": "testify",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "testify",
+            "thirdPerson": "testifies",
+            "past": "testified",
+            "pastParticiple": "testified",
+            "presentParticiple": "testifying"
+        }
+    },
+    {
+        "base": "thank",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "thank",
+            "thirdPerson": "thanks",
+            "past": "thanked",
+            "pastParticiple": "thanked",
+            "presentParticiple": "thanking"
+        }
+    },
+    {
+        "base": "theorize",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "theorize",
+            "thirdPerson": "theorizes",
+            "past": "theorized",
+            "pastParticiple": "theorized",
+            "presentParticiple": "theorizing"
+        }
+    },
+    {
+        "base": "think",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "think",
+            "thirdPerson": "thinks",
+            "past": "thought",
+            "pastParticiple": "thought",
+            "presentParticiple": "thinking"
+        }
+    },
+    {
+        "base": "thrash",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "thrash",
+            "thirdPerson": "thrashes",
+            "past": "thrashed",
+            "pastParticiple": "thrashed",
+            "presentParticiple": "thrashing"
+        }
+    },
+    {
+        "base": "threaten",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "threaten",
+            "thirdPerson": "threatens",
+            "past": "threatened",
+            "pastParticiple": "threatened",
+            "presentParticiple": "threatening"
+        }
+    },
+    {
+        "base": "throw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "throw",
+            "thirdPerson": "throws",
+            "past": "threw",
+            "pastParticiple": "thrown",
+            "presentParticiple": "throwing"
+        }
+    },
+    {
+        "base": "thrust",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "thrust",
+            "thirdPerson": "thrusts",
+            "past": "thrust",
+            "pastParticiple": "thrust",
+            "presentParticiple": "thrusting"
+        }
+    },
+    {
+        "base": "thud",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "thud",
+            "thirdPerson": "thuds",
+            "past": "thudded",
+            "pastParticiple": "thudded",
+            "presentParticiple": "thudding"
+        }
+    },
+    {
+        "base": "tick",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tick",
+            "thirdPerson": "ticks",
+            "past": "ticked",
+            "pastParticiple": "ticked",
+            "presentParticiple": "ticking"
+        }
+    },
+    {
+        "base": "tilt",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tilt",
+            "thirdPerson": "tilts",
+            "past": "tilted",
+            "pastParticiple": "tilted",
+            "presentParticiple": "tilting"
+        }
+    },
+    {
+        "base": "tingle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tingle",
+            "thirdPerson": "tingles",
+            "past": "tingled",
+            "pastParticiple": "tingled",
+            "presentParticiple": "tingling"
+        }
+    },
+    {
+        "base": "tip",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tip",
+            "thirdPerson": "tips",
+            "past": "tipped",
+            "pastParticiple": "tipped",
+            "presentParticiple": "tipping"
+        }
+    },
+    {
+        "base": "tiptoe",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tiptoe",
+            "thirdPerson": "tiptoes",
+            "past": "tiptoeed",
+            "pastParticiple": "tiptoeed",
+            "presentParticiple": "tiptoeing"
+        }
+    },
+    {
+        "base": "topple",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "topple",
+            "thirdPerson": "topples",
+            "past": "toppled",
+            "pastParticiple": "toppled",
+            "presentParticiple": "toppling"
+        }
+    },
+    {
+        "base": "toss",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "toss",
+            "thirdPerson": "tosses",
+            "past": "tossed",
+            "pastParticiple": "tossed",
+            "presentParticiple": "tossing"
+        }
+    },
+    {
+        "base": "tout",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tout",
+            "thirdPerson": "touts",
+            "past": "touted",
+            "pastParticiple": "touted",
+            "presentParticiple": "touting"
+        }
+    },
+    {
+        "base": "trace",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trace",
+            "thirdPerson": "traces",
+            "past": "traced",
+            "pastParticiple": "traced",
+            "presentParticiple": "tracing"
+        }
+    },
+    {
+        "base": "track",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "track",
+            "thirdPerson": "tracks",
+            "past": "tracked",
+            "pastParticiple": "tracked",
+            "presentParticiple": "tracking"
+        }
+    },
+    {
+        "base": "trail",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trail",
+            "thirdPerson": "trails",
+            "past": "trailed",
+            "pastParticiple": "trailed",
+            "presentParticiple": "trailing"
+        }
+    },
+    {
+        "base": "tramp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "tramp",
+            "thirdPerson": "tramps",
+            "past": "tramped",
+            "pastParticiple": "tramped",
+            "presentParticiple": "tramping"
+        }
+    },
+    {
+        "base": "transfix",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "transfix",
+            "thirdPerson": "transfixes",
+            "past": "transfixed",
+            "pastParticiple": "transfixed",
+            "presentParticiple": "transfixing"
+        }
+    },
+    {
+        "base": "tremble",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tremble",
+            "thirdPerson": "trembles",
+            "past": "trembled",
+            "pastParticiple": "trembled",
+            "presentParticiple": "trembling"
+        }
+    },
+    {
+        "base": "trickle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trickle",
+            "thirdPerson": "trickles",
+            "past": "trickled",
+            "pastParticiple": "trickled",
+            "presentParticiple": "trickling"
+        }
+    },
+    {
+        "base": "trill",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trill",
+            "thirdPerson": "trills",
+            "past": "trilled",
+            "pastParticiple": "trilled",
+            "presentParticiple": "trilling"
+        }
+    },
+    {
+        "base": "trudge",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trudge",
+            "thirdPerson": "trudges",
+            "past": "trudged",
+            "pastParticiple": "trudged",
+            "presentParticiple": "trudging"
+        }
+    },
+    {
+        "base": "trumpet",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "trumpet",
+            "thirdPerson": "trumpets",
+            "past": "trumpeted",
+            "pastParticiple": "trumpeted",
+            "presentParticiple": "trumpeting"
+        }
+    },
+    {
+        "base": "trundle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "trundle",
+            "thirdPerson": "trundles",
+            "past": "trundled",
+            "pastParticiple": "trundled",
+            "presentParticiple": "trundling"
+        }
+    },
+    {
+        "base": "turn",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "turn",
+            "thirdPerson": "turns",
+            "past": "turned",
+            "pastParticiple": "turned",
+            "presentParticiple": "turning"
+        }
+    },
+    {
+        "base": "tweet",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "tweet",
+            "thirdPerson": "tweets",
+            "past": "tweeted",
+            "pastParticiple": "tweeted",
+            "presentParticiple": "tweeting"
+        }
+    },
+    {
+        "base": "twin",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "twin",
+            "thirdPerson": "twins",
+            "past": "twinned",
+            "pastParticiple": "twinned",
+            "presentParticiple": "twinning"
+        }
+    },
+    {
+        "base": "twirl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "twirl",
+            "thirdPerson": "twirls",
+            "past": "twirled",
+            "pastParticiple": "twirled",
+            "presentParticiple": "twirling"
+        }
+    },
+    {
+        "base": "twist",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "twist",
+            "thirdPerson": "twists",
+            "past": "twisted",
+            "pastParticiple": "twisted",
+            "presentParticiple": "twisting"
+        }
+    },
+    {
+        "base": "twitter",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "twitter",
+            "thirdPerson": "twitters",
+            "past": "twittered",
+            "pastParticiple": "twittered",
+            "presentParticiple": "twittering"
+        }
+    },
+    {
+        "base": "underline",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "underline",
+            "thirdPerson": "underlines",
+            "past": "underlined",
+            "pastParticiple": "underlined",
+            "presentParticiple": "underlining"
+        }
+    },
+    {
+        "base": "undulate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "undulate",
+            "thirdPerson": "undulates",
+            "past": "undulated",
+            "pastParticiple": "undulated",
+            "presentParticiple": "undulating"
+        }
+    },
+    {
+        "base": "unsheathe",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "unsheathe",
+            "thirdPerson": "unsheathes",
+            "past": "unsheathed",
+            "pastParticiple": "unsheathed",
+            "presentParticiple": "unsheathing"
+        }
+    },
+    {
+        "base": "update",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "updeat",
+            "thirdPerson": "updeats",
+            "past": "update",
+            "pastParticiple": "updeaten",
+            "presentParticiple": "updeating"
+        }
+    },
+    {
+        "base": "upload",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "upload",
+            "thirdPerson": "uploads",
+            "past": "uploaded",
+            "pastParticiple": "uploaded",
+            "presentParticiple": "uploading"
+        }
+    },
+    {
+        "base": "urge",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "urge",
+            "thirdPerson": "urges",
+            "past": "urged",
+            "pastParticiple": "urged",
+            "presentParticiple": "urging"
+        }
+    },
+    {
+        "base": "utter",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "utter",
+            "thirdPerson": "utters",
+            "past": "uttered",
+            "pastParticiple": "uttered",
+            "presentParticiple": "uttering"
+        }
+    },
+    {
+        "base": "vault",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "vault",
+            "thirdPerson": "vaults",
+            "past": "vaulted",
+            "pastParticiple": "vaulted",
+            "presentParticiple": "vaulting"
+        }
+    },
+    {
+        "base": "veer",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "veer",
+            "thirdPerson": "veers",
+            "past": "veered",
+            "pastParticiple": "veered",
+            "presentParticiple": "veering"
+        }
+    },
+    {
+        "base": "vibrate",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "vibrate",
+            "thirdPerson": "vibrates",
+            "past": "vibrated",
+            "pastParticiple": "vibrated",
+            "presentParticiple": "vibrating"
+        }
+    },
+    {
+        "base": "vow",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "vow",
+            "thirdPerson": "vows",
+            "past": "vowed",
+            "pastParticiple": "vowed",
+            "presentParticiple": "vowing"
+        }
+    },
+    {
+        "base": "wad",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wad",
+            "thirdPerson": "wads",
+            "past": "wadded",
+            "pastParticiple": "wadded",
+            "presentParticiple": "wadding"
+        }
+    },
+    {
+        "base": "wade",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "wade",
+            "thirdPerson": "wades",
+            "past": "waded",
+            "pastParticiple": "waded",
+            "presentParticiple": "wading"
+        }
+    },
+    {
+        "base": "wail",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "wail",
+            "thirdPerson": "wails",
+            "past": "wailed",
+            "pastParticiple": "wailed",
+            "presentParticiple": "wailing"
+        }
+    },
+    {
+        "base": "wait",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wait",
+            "thirdPerson": "waits",
+            "past": "waited",
+            "pastParticiple": "waited",
+            "presentParticiple": "waiting"
+        }
+    },
+    {
+        "base": "wake",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "wake",
+            "thirdPerson": "wakes",
+            "past": "woke",
+            "pastParticiple": "woken",
+            "presentParticiple": "waking"
+        }
+    },
+    {
+        "base": "walk",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "walk",
+            "thirdPerson": "walks",
+            "past": "walked",
+            "pastParticiple": "walked",
+            "presentParticiple": "walking"
+        }
+    },
+    {
+        "base": "wander",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wander",
+            "thirdPerson": "wanders",
+            "past": "wandered",
+            "pastParticiple": "wandered",
+            "presentParticiple": "wandering"
+        }
+    },
+    {
+        "base": "warn",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "warn",
+            "thirdPerson": "warns",
+            "past": "warned",
+            "pastParticiple": "warned",
+            "presentParticiple": "warning"
+        }
+    },
+    {
+        "base": "warp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "warp",
+            "thirdPerson": "warps",
+            "past": "warped",
+            "pastParticiple": "warped",
+            "presentParticiple": "warping"
+        }
+    },
+    {
+        "base": "watch",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "watch",
+            "thirdPerson": "watches",
+            "past": "watched",
+            "pastParticiple": "watched",
+            "presentParticiple": "watching"
+        }
+    },
+    {
+        "base": "wave",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "wave",
+            "thirdPerson": "waves",
+            "past": "waved",
+            "pastParticiple": "waved",
+            "presentParticiple": "waving"
+        }
+    },
+    {
+        "base": "weave",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "weave",
+            "thirdPerson": "weaves",
+            "past": "wove",
+            "pastParticiple": "woven",
+            "presentParticiple": "weaving"
+        }
+    },
+    {
+        "base": "whimper",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "whimper",
+            "thirdPerson": "whimpers",
+            "past": "whimpered",
+            "pastParticiple": "whimpered",
+            "presentParticiple": "whimpering"
+        }
+    },
+    {
+        "base": "whine",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "whine",
+            "thirdPerson": "whines",
+            "past": "whined",
+            "pastParticiple": "whined",
+            "presentParticiple": "whining"
+        }
+    },
+    {
+        "base": "whirl",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "whirl",
+            "thirdPerson": "whirls",
+            "past": "whirled",
+            "pastParticiple": "whirled",
+            "presentParticiple": "whirling"
+        }
+    },
+    {
+        "base": "whisper",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "whisper",
+            "thirdPerson": "whispers",
+            "past": "whispered",
+            "pastParticiple": "whispered",
+            "presentParticiple": "whispering"
+        }
+    },
+    {
+        "base": "whistle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "whistle",
+            "thirdPerson": "whistles",
+            "past": "whistled",
+            "pastParticiple": "whistled",
+            "presentParticiple": "whistling"
+        }
+    },
+    {
+        "base": "whoop",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "whoop",
+            "thirdPerson": "whoops",
+            "past": "whooped",
+            "pastParticiple": "whooped",
+            "presentParticiple": "whooping"
+        }
+    },
+    {
+        "base": "widen",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "widen",
+            "thirdPerson": "widens",
+            "past": "widened",
+            "pastParticiple": "widened",
+            "presentParticiple": "widening"
+        }
+    },
+    {
+        "base": "wince",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wince",
+            "thirdPerson": "winces",
+            "past": "winced",
+            "pastParticiple": "winced",
+            "presentParticiple": "wincing"
+        }
+    },
+    {
+        "base": "wind",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wind",
+            "thirdPerson": "winds",
+            "past": "wound",
+            "pastParticiple": "wound",
+            "presentParticiple": "winding"
+        }
+    },
+    {
+        "base": "windmilled",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "windmillead",
+            "thirdPerson": "windmilleads",
+            "past": "windmilled",
+            "pastParticiple": "windmilled",
+            "presentParticiple": "windmilleading"
+        }
+    },
+    {
+        "base": "withdraw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": true,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "withdraw",
+            "thirdPerson": "withdraws",
+            "past": "withdrew",
+            "pastParticiple": "withdrawn",
+            "presentParticiple": "withdrawing"
+        }
+    },
+    {
+        "base": "wonder",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "wonder",
+            "thirdPerson": "wonders",
+            "past": "wondered",
+            "pastParticiple": "wondered",
+            "presentParticiple": "wondering"
+        }
+    },
+    {
+        "base": "wrap",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wrap",
+            "thirdPerson": "wraps",
+            "past": "wrapped",
+            "pastParticiple": "wrapped",
+            "presentParticiple": "wrapping"
+        }
+    },
+    {
+        "base": "wrestle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wrestle",
+            "thirdPerson": "wrestles",
+            "past": "wrestled",
+            "pastParticiple": "wrestled",
+            "presentParticiple": "wrestling"
+        }
+    },
+    {
+        "base": "wriggle",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "wriggle",
+            "thirdPerson": "wriggles",
+            "past": "wriggled",
+            "pastParticiple": "wriggled",
+            "presentParticiple": "wriggling"
+        }
+    },
+    {
+        "base": "yank",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "yank",
+            "thirdPerson": "yanks",
+            "past": "yanked",
+            "pastParticiple": "yanked",
+            "presentParticiple": "yanking"
+        }
+    },
+    {
+        "base": "yaw",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "yaw",
+            "thirdPerson": "yaws",
+            "past": "yawed",
+            "pastParticiple": "yawed",
+            "presentParticiple": "yawing"
+        }
+    },
+    {
+        "base": "yearn",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "yearn",
+            "thirdPerson": "yearns",
+            "past": "yearned",
+            "pastParticiple": "yearned",
+            "presentParticiple": "yearning"
+        }
+    },
+    {
+        "base": "yell",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "yell",
+            "thirdPerson": "yells",
+            "past": "yelled",
+            "pastParticiple": "yelled",
+            "presentParticiple": "yelling"
+        }
+    },
+    {
+        "base": "yelp",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "yelp",
+            "thirdPerson": "yelps",
+            "past": "yelped",
+            "pastParticiple": "yelped",
+            "presentParticiple": "yelping"
+        }
+    },
+    {
+        "base": "yowl",
+        "categories": {
+            "attribution": {
+                "default": true,
+                "extended": true
+            },
+            "action": {
+                "default": false,
+                "extended": false
+            }
+        },
+        "forms": {
+            "base": "yowl",
+            "thirdPerson": "yowls",
+            "past": "yowled",
+            "pastParticiple": "yowled",
+            "presentParticiple": "yowling"
+        }
+    },
+    {
+        "base": "zigzag",
+        "categories": {
+            "attribution": {
+                "default": false,
+                "extended": false
+            },
+            "action": {
+                "default": false,
+                "extended": true
+            }
+        },
+        "forms": {
+            "base": "zigzag",
+            "thirdPerson": "zigzags",
+            "past": "zigzagged",
+            "pastParticiple": "zigzagged",
+            "presentParticiple": "zigzagging"
+        }
+    }
+];

--- a/test/verbCatalog.test.js
+++ b/test/verbCatalog.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+await register(new URL("./module-mock-loader.js", import.meta.url));
+
+import {
+    DEFAULT_ACTION_VERBS_THIRD_PERSON,
+    DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
+    EXTENDED_ACTION_VERBS_THIRD_PERSON,
+    EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+} from "../verbs.js";
+
+const { getVerbInflections } = await import("../index.js");
+
+test("third-person slices expose legacy and extended verbs", () => {
+    assert.ok(DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON.includes("acknowledges"));
+    assert.ok(EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON.includes("says"));
+    assert.ok(DEFAULT_ACTION_VERBS_THIRD_PERSON.includes("runs"));
+    assert.ok(EXTENDED_ACTION_VERBS_THIRD_PERSON.includes("accelerates"));
+});
+
+test("getVerbInflections exposes configurable tense slices", () => {
+    const attribution = getVerbInflections("attribution", "default");
+    assert.ok(attribution.thirdPerson.includes("acknowledges"));
+    const extendedAction = getVerbInflections("action", "extended");
+    assert.ok(extendedAction.base.includes("accelerate"));
+    assert.ok(extendedAction.thirdPerson.includes("accelerates"));
+});

--- a/verbs.js
+++ b/verbs.js
@@ -1,188 +1,44 @@
-export const DEFAULT_ATTRIBUTION_VERBS = [
-    "acknowledged", "added", "addressed", "admitted", "advised", "affirmed",
-    "agreed", "announced", "answered", "argued", "asked", "asserted",
-    "assured", "averred", "avowed", "barked", "begged", "began",
-    "bellowed", "blurted", "boasted", "bragged", "breathed", "called",
-    "cautioned", "cheered", "chimed", "chirped", "clarified", "commanded",
-    "commented", "complained", "conceded", "concluded", "confessed",
-    "confirmed", "consoled", "continued", "countered", "cried", "croaked",
-    "crowed", "declared", "decreed", "demanded", "denied", "described",
-    "directed", "drawled", "echoed", "emphasized", "encouraged",
-    "enquired", "entreated", "enthused", "estimated", "exclaimed",
-    "explained", "expressed", "gasped", "grinned", "grumbled", "guaranteed",
-    "guessed", "hinted", "insisted", "instructed", "interjected",
-    "interrupted", "intimated", "joked", "lamented", "laughed", "lied",
-    "maintained", "mentioned", "murmured", "mused", "muttered", "nagged",
-    "nodded", "noted", "objected", "observed", "offered", "opined",
-    "ordered", "perked up", "pleaded", "pledged", "pondered", "prayed",
-    "predicted", "proclaimed", "promised", "proposed", "protested",
-    "quavered", "queried", "questioned", "quipped", "quoted", "rambled",
-    "reasoned", "reassured", "recited", "recognized", "recounted",
-    "rejoined", "remarked", "repeated", "replied", "reported", "requested",
-    "responded", "restated", "retorted", "revealed", "roared", "sang",
-    "scolded", "scoffed", "screeched", "shrieked", "sighed", "snapped",
-    "snarled", "soothed", "spoke", "stammered", "stated", "stressed",
-    "stuttered", "suggested", "surmised", "swore", "thanked", "threatened",
-    "told", "touted", "trembled", "urged", "uttered", "vowed", "wailed",
-    "warned", "whimpered", "whined", "whispered", "wondered", "yelled",
-    "yowled"
-];
+import {
+    VERB_CATALOG,
+    buildLegacyVerbList,
+    buildVerbSlices,
+} from "./src/data/verbCatalog.js";
 
-export const DEFAULT_ACTION_VERBS = [
-    "adjust", "adjusted", "amble", "ambled", "appear", "appeared",
-    "approach", "approached", "arc", "arched", "arrive", "arrived", "ascend",
-    "ascended", "balance", "balanced", "bend", "bent", "blink", "blinked",
-    "bolt", "bolted", "bound", "bounded", "bow", "bowed", "breathe",
-    "breathed", "charge", "charged", "chase", "chased", "circle", "circled",
-    "clamber", "clambered", "clap", "clapped", "climb", "climbed",
-    "collapse", "collapsed", "crawl", "crawled", "creep", "crept",
-    "crouch", "crouched", "dance", "danced", "dart", "darted", "dash",
-    "dashed", "depart", "departed", "descend", "descended", "dive",
-    "dived", "dodge", "dodged", "drag", "dragged", "drift", "drifted",
-    "drop", "dropped", "duck", "ducked", "emerge", "emerged", "enter",
-    "entered", "escape", "escaped", "exit", "exited", "fall", "fell",
-    "fidget", "fidgeted", "flee", "fled", "flinch", "flinched", "float",
-    "floated", "flow", "flowed", "flurry", "flurried", "fly", "flew",
-    "follow", "followed", "freeze", "froze", "frown", "frowned", "gallop",
-    "galloped", "gesture", "gestured", "giggle", "giggled", "glance",
-    "glanced", "glide", "glided", "glimmer", "glimmered", "grab",
-    "grabbed", "grasp", "grasped", "grimace", "grimaced", "grin",
-    "grinned", "groan", "groaned", "growl", "growled", "grumble",
-    "grumbled", "grunt", "grunted", "hitch", "hitched", "hobble",
-    "hobbled", "hold", "held", "hop", "hopped", "huddle", "huddled",
-    "hurry", "hurried", "inch", "inched", "jerk", "jerked", "jog",
-    "jogged", "jolt", "jolted", "jump", "jumped", "kick", "kicked",
-    "kneel", "knelt", "knock", "knocked", "laugh", "laughed", "lean",
-    "leaned", "leap", "leapt", "left", "limp", "limped", "lurch",
-    "lurched", "look", "looked", "loosen", "loosened", "lower", "lowered",
-    "lunge", "lunged", "march", "marched", "meander", "meandered",
-    "motion", "motioned", "move", "moved", "nod", "nodded", "observe",
-    "observed", "pace", "paced", "pause", "paused", "peek", "peeked",
-    "peer", "peered", "pivot", "pivoted", "point", "pointed", "pop",
-    "popped", "position", "positioned", "pounce", "pounced", "prowl",
-    "prowled", "pull", "pulled", "push", "pushed", "race", "raced",
-    "raise", "raised", "reach", "reached", "recoil", "recoiled",
-    "retreat", "retreated", "rise", "rose", "roll", "rolled", "run",
-    "ran", "rush", "rushed", "scoot", "scooted", "scramble", "scrambled",
-    "scurry", "scurried", "set", "shift", "shifted", "shimmy", "shimmied",
-    "shiver", "shivered", "shake", "shook", "shrug", "shrugged", "shudder",
-    "shuddered", "sigh", "sighed", "slink", "slinked", "slip", "slipped",
-    "slither", "slithered", "slouch", "slouched", "slump", "slumped",
-    "smile", "smiled", "smirk", "smirked", "snap", "snapped", "snort",
-    "snorted", "sprawl", "sprawled", "spin", "spun", "sprint",
-    "sprinted", "squirm", "squirmed", "stagger", "staggered", "stalk",
-    "stalked", "stare", "stared", "step", "stepped", "stomp", "stomped",
-    "stoop", "stooped", "stride", "strode", "strike", "struck",
-    "strut", "strutted", "stumble", "stumbled", "sway", "swayed",
-    "swagger", "swaggered", "swallow", "swallowed", "swap", "swapped",
-    "sweep", "swept", "swing", "swung", "tackle", "tackled", "tap",
-    "tapped", "throw", "threw", "tilt", "tilted", "tiptoe", "tiptoed",
-    "toss", "tossed", "tramp", "tramped", "tremble", "trembled", "trudge",
-    "trudged", "turn", "turned", "twirl", "twirled", "twist", "twisted",
-    "vault", "vaulted", "veer", "veered", "wade", "waded", "wake",
-    "woke", "walk", "walked", "wander", "wandered", "watch", "watched",
-    "wave", "waved", "wince", "winced", "withdraw", "withdrew"
-];
+const defaultAttributionSlices = buildVerbSlices({ category: "attribution", edition: "default" });
+const extendedAttributionSlices = buildVerbSlices({ category: "attribution", edition: "extended" });
+const defaultActionSlices = buildVerbSlices({ category: "action", edition: "default" });
+const extendedActionSlices = buildVerbSlices({ category: "action", edition: "extended" });
 
-export const EXTENDED_ATTRIBUTION_VERBS = [
-    "acknowledged", "added", "addressed", "adjudged", "admitted", "affirmed",
-    "agreed", "alleged", "announced", "answered", "appealed", "applauded",
-    "argued", "articulated", "asked", "asserted", "assured", "avowed",
-    "averred", "babbled", "bantered", "barked", "bawled", "begged",
-    "bellowed", "blathered", "bleated", "blubbered", "blurted", "boasted",
-    "bragged", "breathed", "bubbled", "cackled", "cajoled", "called",
-    "cautioned", "celebrated", "chanted", "chatted", "cheered", "chirped",
-    "chortled", "chuckled", "clamored", "clarified", "commanded",
-    "commented", "conceded", "confessed", "confided", "confirmed",
-    "congratulated", "contended", "continued", "countered", "croaked",
-    "crowed", "cried", "debated", "declared", "decreed", "defended",
-    "demanded", "denied", "described", "detailed", "dictated", "drawled",
-    "droned", "emphasized", "enquired", "entreated", "enumerated",
-    "enthused", "epitomized", "equivocated", "exclaimed",
-    "exhorted", "exonerated", "explained", "expounded", "expostulated",
-    "fumed", "gasped", "gestured", "giggled", "grinned", "groaned",
-    "growled", "grumbled", "guaranteed", "guessed",
-    "harangued", "hinted", "hissed", "hollered", "howled", "hypothesized",
-    "implored", "implied", "improvised", "insisted", "intoned", "intimated",
-    "interjected", "interrogated", "interrupted", "inquired", "jabbered",
-    "jeered", "jested", "joked", "lectured", "lamented", "laughed",
-    "maintained", "marveled", "mewled", "mimicked", "mumbled", "murmured",
-    "mused", "muttered", "nagged", "narrated", "noted", "notified",
-    "observed", "offered", "opined", "orated", "ordered", "petitioned",
-    "phrased", "pleaded", "pledged", "posited", "prattled", "preached",
-    "predicated", "prescribed", "proclaimed", "professed", "proffered",
-    "prognosticated", "promised", "pronounced", "proposed", "protested",
-    "purred", "queried", "questioned", "quipped", "quoted", "rambled",
-    "rasped", "reasoned", "reassured", "rebuked", "rebutted", "recalled",
-    "recited", "recommended", "recounted", "referred", "reiterated",
-    "remarked", "reminded", "repeated", "replied", "reported", "requested",
-    "resolved", "responded", "restated", "retorted", "revealed", "roared",
-    "sang", "sassed", "scolded", "screeched", "shouted", "shrieked",
-    "sighed", "slurred", "snapped", "sneered", "snickered", "sniped",
-    "snorted", "sobbed", "soothed", "speculated", "spluttered", "spoke",
-    "sprouted", "sputtered", "stammered", "stated", "stipulated", "stormed",
-    "suggested", "summarized", "surmised", "swore", "taunted", "teased",
-    "testified", "thanked", "theorized", "threatened", "trilled", "trumpeted",
-    "tweeted", "twittered", "underlined", "updated", "uploaded", "urged",
-    "uttered", "vowed", "wailed", "warned", "whimpered", "whined",
-    "whispered", "whooped", "wondered", "yelled", "yelped", "yowled"
-];
+export const DEFAULT_ATTRIBUTION_VERBS = buildLegacyVerbList({ category: "attribution", edition: "default" });
+export const DEFAULT_ATTRIBUTION_VERBS_PRESENT = defaultAttributionSlices.base;
+export const DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON = defaultAttributionSlices.thirdPerson;
+export const DEFAULT_ATTRIBUTION_VERBS_PAST = defaultAttributionSlices.past;
+export const DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE = defaultAttributionSlices.pastParticiple;
+export const DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE = defaultAttributionSlices.presentParticiple;
 
-export const EXTENDED_ACTION_VERBS = [
-    "accelerated", "ambled", "angled", "arched", "ascended", "assembled",
-    "attacked", "backpedaled", "balanced", "barged", "beckoned", "bolted",
-    "bounded", "braced", "brandished", "breached", "breezed", "bristled",
-    "brooded", "brushed", "burrowed", "bustled", "butted", "calibrated",
-    "careened", "carved", "cast", "charged", "chased", "circled",
-    "clambered", "clapped", "clashed", "clawed", "clenched", "clung",
-    "clutched", "coiled", "collided", "commandeered", "commanded",
-    "conjured", "contorted", "contemplated", "corkscrewed", "crawled",
-    "cowered", "cradled", "crashed", "creaked", "crept", "crinkled",
-    "crooned", "crumpled", "crushed", "curled", "darted", "dashed",
-    "deflected", "descended", "detoured", "dipped", "dodged", "drained",
-    "draped", "drifted", "drilled", "dripped", "drizzled", "drummed",
-    "faltered", "fidgeted", "flared", "fled", "flew", "flinched",
-    "flitted", "flopped", "flourished", "fluttered", "focused", "forged",
-    "fractured", "frolicked", "galloped", "gathered", "glanced", "glided",
-    "glimmered", "glinted", "glissaded", "glowered", "gnashed", "gnawed",
-    "grimaced", "grinned", "gripped", "groaned", "ground", "hacked",
-    "halted", "hammered", "harnessed", "hauled", "heaved", "hinged",
-    "hissed", "hovered", "huddled", "hunted", "hustled", "illuminated",
-    "immerged", "inched", "intercepted", "jogged", "jolted", "jostled",
-    "juggled", "jutted", "kindled", "knelt", "knitted", "knocked",
-    "lanced", "lashed", "laughed", "launched", "leaned", "leapt",
-    "levered", "lingered", "loomed", "lunged", "lurched", "massed",
-    "meandered", "melted", "mended", "merged", "migrated", "milled",
-    "mimed", "morphed", "motioned", "mounted", "mustered", "muttered",
-    "navigated", "nodded", "nudged", "nuzzled", "observed", "orbited",
-    "paced", "paddled", "parried", "paused", "pawed", "peered", "perched",
-    "pivoted", "planted", "plodded", "plotted", "plowed", "plucked",
-    "plummeted", "pounced", "pranced", "preened", "pressed", "prodded",
-    "propelled", "prowled", "pulsed", "pummeled", "pumped", "punched",
-    "pursued", "quaked", "quavered", "quivered", "raced", "radiated",
-    "rallied", "rattled", "reeled", "refracted", "reached", "recoiled",
-    "redirected", "reduced", "retreated", "reversed", "revolved",
-    "ricocheted", "roared", "rocked", "rolled", "sailed", "sallied",
-    "sashayed", "savored", "scampered", "scattered", "screeched",
-    "scrubbed", "scudded", "scurried", "seeped", "seized", "shaded",
-    "shadowed", "sharpened", "shifted", "shimmered", "shivered", "shone",
-    "shouted", "shrugged", "shuddered", "sidestepped", "sifted", "sighed",
-    "sketched", "skidded", "skimmed", "skipped", "slashed", "slithered",
-    "slunk", "sluiced", "smirked", "smote", "snaked", "snapped",
-    "sneered", "snickered", "sniffed", "snorted", "snowballed", "soared",
-    "sparked", "spilled", "spiraled", "splashed", "sprawled", "sprayed",
-    "sprouted", "sprinted", "sprung", "spun", "spurred", "sputtered",
-    "squared", "squeezed", "squinted", "staggered", "stalked", "stilled",
-    "stooped", "stormed", "straddled", "strained", "strayed", "streaked",
-    "stretched", "strode", "strolled", "struggled", "strummed", "strutted",
-    "submerged", "summoned", "surged", "swarmed", "swatted", "swirled",
-    "swiveled", "swung", "tackled", "tailed", "tensed", "thrashed",
-    "threw", "thrust", "thudded", "ticked", "tilted", "tingled", "tipped",
-    "toppled", "tracked", "traced", "trailed", "tramped", "transfixed",
-    "trickled", "trilled", "trudged", "trundled", "twined", "twirled",
-    "twisted", "undulated", "unsheathed", "vaulted", "veered", "vibrated",
-    "waded", "waited", "wandered", "warped", "watched", "weaved", "whirled",
-    "whispered", "whistled", "widened", "windmilled", "winced", "wound",
-    "wove", "wrapped", "wrestled", "wriggled", "yanked", "yearned",
-    "yawed", "zigzagged"
-];
+export const EXTENDED_ATTRIBUTION_VERBS = buildLegacyVerbList({ category: "attribution", edition: "extended" });
+export const EXTENDED_ATTRIBUTION_VERBS_PRESENT = extendedAttributionSlices.base;
+export const EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON = extendedAttributionSlices.thirdPerson;
+export const EXTENDED_ATTRIBUTION_VERBS_PAST = extendedAttributionSlices.past;
+export const EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE = extendedAttributionSlices.pastParticiple;
+export const EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE = extendedAttributionSlices.presentParticiple;
+
+export const DEFAULT_ACTION_VERBS = buildLegacyVerbList({ category: "action", edition: "default" });
+export const DEFAULT_ACTION_VERBS_PRESENT = defaultActionSlices.base;
+export const DEFAULT_ACTION_VERBS_THIRD_PERSON = defaultActionSlices.thirdPerson;
+export const DEFAULT_ACTION_VERBS_PAST = defaultActionSlices.past;
+export const DEFAULT_ACTION_VERBS_PAST_PARTICIPLE = defaultActionSlices.pastParticiple;
+export const DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE = defaultActionSlices.presentParticiple;
+
+export const EXTENDED_ACTION_VERBS = buildLegacyVerbList({ category: "action", edition: "extended" });
+export const EXTENDED_ACTION_VERBS_PRESENT = extendedActionSlices.base;
+export const EXTENDED_ACTION_VERBS_THIRD_PERSON = extendedActionSlices.thirdPerson;
+export const EXTENDED_ACTION_VERBS_PAST = extendedActionSlices.past;
+export const EXTENDED_ACTION_VERBS_PAST_PARTICIPLE = extendedActionSlices.pastParticiple;
+export const EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE = extendedActionSlices.presentParticiple;
+
+export {
+    VERB_CATALOG,
+    buildLegacyVerbList,
+    buildVerbSlices,
+};


### PR DESCRIPTION
## Summary
- replace the node-specific loader in `verbCatalog.js` with a direct ESM import so the catalog works in the browser
- convert the catalog dataset into a JavaScript module export, removing the JSON require that broke extension loading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6902faf0719c8325bbd17717a1da3a7c