### PR TITLE
Refine verb defaults for tense-specific exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,18 +2,26 @@ import { extension_settings, getContext } from "../../../extensions.js";
 import { saveSettingsDebounced, event_types, eventSource } from "../../../../script.js";
 import { executeSlashCommandsOnChatInput, registerSlashCommand } from "../../../slash-commands.js";
 import {
-    DEFAULT_ACTION_VERBS,
     DEFAULT_ACTION_VERBS_PRESENT,
     DEFAULT_ACTION_VERBS_THIRD_PERSON,
-    DEFAULT_ATTRIBUTION_VERBS,
+    DEFAULT_ACTION_VERBS_PAST,
+    DEFAULT_ACTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE,
     DEFAULT_ATTRIBUTION_VERBS_PRESENT,
     DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
-    EXTENDED_ACTION_VERBS,
+    DEFAULT_ATTRIBUTION_VERBS_PAST,
+    DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
     EXTENDED_ACTION_VERBS_PRESENT,
     EXTENDED_ACTION_VERBS_THIRD_PERSON,
-    EXTENDED_ATTRIBUTION_VERBS,
+    EXTENDED_ACTION_VERBS_PAST,
+    EXTENDED_ACTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE,
     EXTENDED_ATTRIBUTION_VERBS_PRESENT,
     EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+    EXTENDED_ATTRIBUTION_VERBS_PAST,
+    EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
     buildVerbSlices,
 } from "./verbs.js";
 import { loadProfiles, normalizeProfile, normalizeMappingEntry } from "./profile-utils.js";
@@ -21,6 +29,42 @@ import { loadProfiles, normalizeProfile, normalizeMappingEntry } from "./profile
 const extensionName = "SillyTavern-CostumeSwitch-Testing";
 const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
 const logPrefix = "[CostumeSwitch]";
+
+function buildVerbList(...lists) {
+    return Array.from(new Set(lists.flat().filter(Boolean)));
+}
+
+const DEFAULT_ATTRIBUTION_VERB_FORMS = buildVerbList(
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT,
+    DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
+    DEFAULT_ATTRIBUTION_VERBS_PAST,
+    DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+);
+
+const EXTENDED_ATTRIBUTION_VERB_FORMS = buildVerbList(
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT,
+    EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+    EXTENDED_ATTRIBUTION_VERBS_PAST,
+    EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+);
+
+const DEFAULT_ACTION_VERB_FORMS = buildVerbList(
+    DEFAULT_ACTION_VERBS_PRESENT,
+    DEFAULT_ACTION_VERBS_THIRD_PERSON,
+    DEFAULT_ACTION_VERBS_PAST,
+    DEFAULT_ACTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE,
+);
+
+const EXTENDED_ACTION_VERB_FORMS = buildVerbList(
+    EXTENDED_ACTION_VERBS_PRESENT,
+    EXTENDED_ACTION_VERBS_THIRD_PERSON,
+    EXTENDED_ACTION_VERBS_PAST,
+    EXTENDED_ACTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE,
+);
 
 // ======================================================================
 // PRESET PROFILES
@@ -250,8 +294,8 @@ const PROFILE_DEFAULTS = {
     detectPronoun: true,
     detectGeneral: false,
     pronounVocabulary: [...DEFAULT_PRONOUNS],
-    attributionVerbs: [...DEFAULT_ATTRIBUTION_VERBS],
-    actionVerbs: [...DEFAULT_ACTION_VERBS],
+    attributionVerbs: [...DEFAULT_ATTRIBUTION_VERB_FORMS],
+    actionVerbs: [...DEFAULT_ACTION_VERB_FORMS],
     detectionBias: 0,
     enableSceneRoster: true,
     sceneRosterTTL: 5,
@@ -274,21 +318,13 @@ const KNOWN_PRONOUNS = new Set([
 ].map(value => String(value).toLowerCase()));
 
 const KNOWN_ATTRIBUTION_VERBS = new Set([
-    ...PROFILE_DEFAULTS.attributionVerbs,
-    ...DEFAULT_ATTRIBUTION_VERBS_PRESENT,
-    ...DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
-    ...EXTENDED_ATTRIBUTION_VERBS,
-    ...EXTENDED_ATTRIBUTION_VERBS_PRESENT,
-    ...EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+    ...DEFAULT_ATTRIBUTION_VERB_FORMS,
+    ...EXTENDED_ATTRIBUTION_VERB_FORMS,
 ].map(value => String(value).toLowerCase()));
 
 const KNOWN_ACTION_VERBS = new Set([
-    ...PROFILE_DEFAULTS.actionVerbs,
-    ...DEFAULT_ACTION_VERBS_PRESENT,
-    ...DEFAULT_ACTION_VERBS_THIRD_PERSON,
-    ...EXTENDED_ACTION_VERBS,
-    ...EXTENDED_ACTION_VERBS_PRESENT,
-    ...EXTENDED_ACTION_VERBS_THIRD_PERSON,
+    ...DEFAULT_ACTION_VERB_FORMS,
+    ...EXTENDED_ACTION_VERB_FORMS,
 ].map(value => String(value).toLowerCase()));
 
 function getVerbInflections(category = "attribution", edition = "default") {

--- a/test/verbCatalog.test.js
+++ b/test/verbCatalog.test.js
@@ -5,10 +5,27 @@ import { register } from "node:module";
 await register(new URL("./module-mock-loader.js", import.meta.url));
 
 import {
+    DEFAULT_ACTION_VERBS_PRESENT,
     DEFAULT_ACTION_VERBS_THIRD_PERSON,
+    DEFAULT_ACTION_VERBS_PAST,
+    DEFAULT_ACTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT,
     DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
+    DEFAULT_ATTRIBUTION_VERBS_PAST,
+    DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+    EXTENDED_ACTION_VERBS_PRESENT,
     EXTENDED_ACTION_VERBS_THIRD_PERSON,
+    EXTENDED_ACTION_VERBS_PAST,
+    EXTENDED_ACTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE,
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT,
     EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON,
+    EXTENDED_ATTRIBUTION_VERBS_PAST,
+    EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+    VERB_CATALOG,
 } from "../verbs.js";
 
 const { getVerbInflections } = await import("../index.js");
@@ -26,4 +43,49 @@ test("getVerbInflections exposes configurable tense slices", () => {
     const extendedAction = getVerbInflections("action", "extended");
     assert.ok(extendedAction.base.includes("accelerate"));
     assert.ok(extendedAction.thirdPerson.includes("accelerates"));
+});
+
+test("tense-specific verb lists align with catalog forms", () => {
+    const validations = [
+        { name: "DEFAULT_ATTRIBUTION_VERBS_PRESENT", list: DEFAULT_ATTRIBUTION_VERBS_PRESENT, category: "attribution", edition: "default", form: "base" },
+        { name: "DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON", list: DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON, category: "attribution", edition: "default", form: "thirdPerson" },
+        { name: "DEFAULT_ATTRIBUTION_VERBS_PAST", list: DEFAULT_ATTRIBUTION_VERBS_PAST, category: "attribution", edition: "default", form: "past" },
+        { name: "DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE", list: DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE, category: "attribution", edition: "default", form: "pastParticiple" },
+        { name: "DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE", list: DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE, category: "attribution", edition: "default", form: "presentParticiple" },
+        { name: "EXTENDED_ATTRIBUTION_VERBS_PRESENT", list: EXTENDED_ATTRIBUTION_VERBS_PRESENT, category: "attribution", edition: "extended", form: "base" },
+        { name: "EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON", list: EXTENDED_ATTRIBUTION_VERBS_THIRD_PERSON, category: "attribution", edition: "extended", form: "thirdPerson" },
+        { name: "EXTENDED_ATTRIBUTION_VERBS_PAST", list: EXTENDED_ATTRIBUTION_VERBS_PAST, category: "attribution", edition: "extended", form: "past" },
+        { name: "EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE", list: EXTENDED_ATTRIBUTION_VERBS_PAST_PARTICIPLE, category: "attribution", edition: "extended", form: "pastParticiple" },
+        { name: "EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE", list: EXTENDED_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE, category: "attribution", edition: "extended", form: "presentParticiple" },
+        { name: "DEFAULT_ACTION_VERBS_PRESENT", list: DEFAULT_ACTION_VERBS_PRESENT, category: "action", edition: "default", form: "base" },
+        { name: "DEFAULT_ACTION_VERBS_THIRD_PERSON", list: DEFAULT_ACTION_VERBS_THIRD_PERSON, category: "action", edition: "default", form: "thirdPerson" },
+        { name: "DEFAULT_ACTION_VERBS_PAST", list: DEFAULT_ACTION_VERBS_PAST, category: "action", edition: "default", form: "past" },
+        { name: "DEFAULT_ACTION_VERBS_PAST_PARTICIPLE", list: DEFAULT_ACTION_VERBS_PAST_PARTICIPLE, category: "action", edition: "default", form: "pastParticiple" },
+        { name: "DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE", list: DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE, category: "action", edition: "default", form: "presentParticiple" },
+        { name: "EXTENDED_ACTION_VERBS_PRESENT", list: EXTENDED_ACTION_VERBS_PRESENT, category: "action", edition: "extended", form: "base" },
+        { name: "EXTENDED_ACTION_VERBS_THIRD_PERSON", list: EXTENDED_ACTION_VERBS_THIRD_PERSON, category: "action", edition: "extended", form: "thirdPerson" },
+        { name: "EXTENDED_ACTION_VERBS_PAST", list: EXTENDED_ACTION_VERBS_PAST, category: "action", edition: "extended", form: "past" },
+        { name: "EXTENDED_ACTION_VERBS_PAST_PARTICIPLE", list: EXTENDED_ACTION_VERBS_PAST_PARTICIPLE, category: "action", edition: "extended", form: "pastParticiple" },
+        { name: "EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE", list: EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE, category: "action", edition: "extended", form: "presentParticiple" },
+    ];
+
+    for (const { name, list, category, edition, form } of validations) {
+        const expected = new Set(
+            VERB_CATALOG
+                .filter(entry => Boolean(entry?.categories?.[category]?.[edition]))
+                .map(entry => entry?.forms?.[form])
+                .filter(Boolean),
+        );
+
+        const uniqueList = new Set(list);
+        assert.strictEqual(list.length, uniqueList.size, `${name} should not contain duplicate verbs`);
+
+        const sortedList = Array.from(uniqueList).sort();
+        const sortedExpected = Array.from(expected).sort();
+        assert.deepStrictEqual(
+            sortedList,
+            sortedExpected,
+            `${name} should only include ${form} forms for ${edition} ${category} verbs`,
+        );
+    }
 });


### PR DESCRIPTION
## Summary
- update default profile verb lists to merge the catalog's tense-specific exports instead of the legacy mixed arrays
- rebuild known verb caches from the tense-aware slices for both action and attribution verbs
- add catalog-backed tests that validate every tense export only contains the correct conjugations without duplicates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903016aaf088325a7d2c3f0c165e0c8