### PR TITLE
Refine detection and tester reporting

### DIFF
--- a/src/detector-core.js
+++ b/src/detector-core.js
@@ -1,0 +1,333 @@
+const DEFAULT_UNICODE_WORD_PATTERN = "[\\p{L}\\p{M}\\p{N}_]";
+const WORD_CHAR_REGEX = /[\p{L}\p{M}\p{N}]/u;
+const DEFAULT_BOUNDARY_LOOKBEHIND = "(?<![A-Za-z0-9_'’])";
+
+export function escapeRegex(value) {
+    return String(value).replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+}
+
+export function parsePatternEntry(raw) {
+    const text = String(raw ?? "").trim();
+    if (!text) {
+        return null;
+    }
+    const regexMatch = text.match(/^\/((?:\\.|[^\/])+)\/([gimsuy]*)$/);
+    if (regexMatch) {
+        return { body: regexMatch[1], flags: regexMatch[2] || "", raw: text };
+    }
+    return { body: escapeRegex(text), flags: "", raw: text };
+}
+
+export function computeFlags(entries, requireI = true) {
+    const flags = new Set(requireI ? ["i"] : []);
+    for (const entry of entries || []) {
+        if (!entry) {
+            continue;
+        }
+        for (const flag of entry.flags || "") {
+            if ("gimsuy".includes(flag)) {
+                flags.add(flag);
+            }
+        }
+    }
+    return Array.from(flags).join("");
+}
+
+export function buildRegex(patternList, template, options = {}) {
+    const entries = (patternList || []).map(parsePatternEntry).filter(Boolean);
+    if (!entries.length) {
+        return null;
+    }
+    const patternBody = entries.map(entry => `(?:${entry.body})`).join("|");
+    const finalBody = template.replace("{{PATTERNS}}", patternBody);
+    let finalFlags = computeFlags(entries, options.requireI !== false);
+    if (options.extraFlags) {
+        for (const flag of options.extraFlags) {
+            if (flag && !finalFlags.includes(flag)) {
+                finalFlags += flag;
+            }
+        }
+    }
+    return new RegExp(finalBody, finalFlags);
+}
+
+export function buildGenericRegex(patternList) {
+    if (!patternList || !patternList.length) {
+        return null;
+    }
+    const entries = patternList.map(parsePatternEntry).filter(Boolean);
+    if (!entries.length) {
+        return null;
+    }
+    const body = entries.map(entry => entry.body).join("|");
+    return new RegExp(`(?:${body})`, computeFlags(entries));
+}
+
+function buildAlternation(list) {
+    const seen = new Set();
+    return (list || [])
+        .map(parsePatternEntry)
+        .filter(Boolean)
+        .map(entry => entry.body)
+        .filter(body => {
+            if (!body || seen.has(body)) {
+                return false;
+            }
+            seen.add(body);
+            return true;
+        })
+        .join("|");
+}
+
+export function getQuoteRanges(text) {
+    if (!text) {
+        return [];
+    }
+    const ranges = [];
+    const stack = [];
+    const QUOTE_PAIRS = [
+        { open: "\"", close: "\"", symmetric: true },
+        { open: "＂", close: "＂", symmetric: true },
+        { open: "“", close: "”" },
+        { open: "„", close: "”" },
+        { open: "‟", close: "”" },
+        { open: "«", close: "»" },
+        { open: "‹", close: "›" },
+        { open: "「", close: "」" },
+        { open: "『", close: "』" },
+        { open: "｢", close: "｣" },
+        { open: "《", close: "》" },
+        { open: "〈", close: "〉" },
+        { open: "﹁", close: "﹂" },
+        { open: "﹃", close: "﹄" },
+        { open: "〝", close: "〞" },
+        { open: "‘", close: "’" },
+        { open: "‚", close: "’" },
+        { open: "‛", close: "’" },
+        { open: "'", close: "'", symmetric: true, apostropheSensitive: true },
+    ];
+    const QUOTE_OPENERS = new Map();
+    const QUOTE_CLOSERS = new Map();
+    for (const pair of QUOTE_PAIRS) {
+        const info = {
+            close: pair.close,
+            symmetric: Boolean(pair.symmetric),
+            apostropheSensitive: Boolean(pair.apostropheSensitive),
+        };
+        QUOTE_OPENERS.set(pair.open, info);
+        if (info.symmetric) {
+            continue;
+        }
+        if (!QUOTE_CLOSERS.has(pair.close)) {
+            QUOTE_CLOSERS.set(pair.close, []);
+        }
+        QUOTE_CLOSERS.get(pair.close).push(pair.open);
+    }
+
+    const isLikelyApostrophe = (index) => {
+        if (index < 0 || index >= text.length) {
+            return false;
+        }
+        const prev = index > 0 ? text[index - 1] : "";
+        const next = index + 1 < text.length ? text[index + 1] : "";
+        return WORD_CHAR_REGEX.test(prev) && WORD_CHAR_REGEX.test(next);
+    };
+
+    for (let i = 0; i < text.length; i += 1) {
+        const ch = text[i];
+        const openerInfo = QUOTE_OPENERS.get(ch);
+        if (openerInfo) {
+            if (openerInfo.symmetric) {
+                if (openerInfo.apostropheSensitive && isLikelyApostrophe(i)) {
+                    continue;
+                }
+                const top = stack[stack.length - 1];
+                if (top && top.open === ch && top.symmetric) {
+                    stack.pop();
+                    ranges.push([top.index, i]);
+                } else {
+                    stack.push({
+                        open: ch,
+                        close: openerInfo.close,
+                        index: i,
+                        symmetric: true,
+                        apostropheSensitive: openerInfo.apostropheSensitive,
+                    });
+                }
+                continue;
+            }
+            stack.push({ open: ch, close: openerInfo.close, index: i, symmetric: false });
+            continue;
+        }
+
+        const closeCandidates = QUOTE_CLOSERS.get(ch);
+        if (closeCandidates && stack.length) {
+            for (let j = stack.length - 1; j >= 0; j -= 1) {
+                const candidate = stack[j];
+                if (!candidate.symmetric && candidate.close === ch && closeCandidates.includes(candidate.open)) {
+                    stack.splice(j, 1);
+                    ranges.push([candidate.index, i]);
+                    break;
+                }
+            }
+            continue;
+        }
+
+        const top = stack[stack.length - 1];
+        if (top && top.symmetric && ch === top.close) {
+            stack.pop();
+            ranges.push([top.index, i]);
+        }
+    }
+
+    return ranges.sort((a, b) => a[0] - b[0]);
+}
+
+export function isIndexInsideQuotes(index, quoteRanges) {
+    for (const [start, end] of quoteRanges) {
+        if (index > start && index < end) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function findMatches(text, regex, quoteRanges, options = {}) {
+    if (!text || !regex) {
+        return [];
+    }
+    const results = [];
+    const searchInsideQuotes = Boolean(options.searchInsideQuotes);
+    const flags = regex.flags.includes("g") ? regex.flags : `${regex.flags}g`;
+    const matcher = new RegExp(regex.source, flags);
+    let match;
+    while ((match = matcher.exec(text)) !== null) {
+        if (searchInsideQuotes || !isIndexInsideQuotes(match.index, quoteRanges)) {
+            results.push({ match: match[0], groups: match.slice(1), index: match.index });
+        }
+    }
+    return results;
+}
+
+export function compileProfileRegexes(profile = {}, options = {}) {
+    const unicodeWordPattern = options.unicodeWordPattern || DEFAULT_UNICODE_WORD_PATTERN;
+    const boundaryLookbehind = options.boundaryLookbehind || DEFAULT_BOUNDARY_LOOKBEHIND;
+    const defaultPronouns = Array.isArray(options.defaultPronouns) && options.defaultPronouns.length
+        ? options.defaultPronouns
+        : ["he", "she", "they"];
+
+    const ignored = (profile.ignorePatterns || []).map(value => String(value ?? "").trim().toLowerCase()).filter(Boolean);
+    const effectivePatterns = (profile.patterns || [])
+        .map(value => String(value ?? "").trim())
+        .filter(value => value && !ignored.includes(value.toLowerCase()));
+
+    const attributionVerbsPattern = buildAlternation(profile.attributionVerbs);
+    const actionVerbsPattern = buildAlternation(profile.actionVerbs);
+    const pronounVocabulary = Array.isArray(profile.pronounVocabulary) && profile.pronounVocabulary.length
+        ? profile.pronounVocabulary
+        : defaultPronouns;
+    const pronounPattern = buildAlternation(pronounVocabulary);
+
+    const speakerTemplate = "(?:^|[\\r\\n]+|[>\\]]\\s*)({{PATTERNS}})\\s*:";
+    const attributionTemplate = attributionVerbsPattern
+        ? `${boundaryLookbehind}({{PATTERNS}})\\s+(?:${attributionVerbsPattern})`
+        : null;
+    const actionTemplate = actionVerbsPattern
+        ? `${boundaryLookbehind}({{PATTERNS}})(?:['’]s)?\\s+(?:${unicodeWordPattern}+\\s+){0,3}?(?:${actionVerbsPattern})`
+        : null;
+
+    const regexes = {
+        speakerRegex: buildRegex(effectivePatterns, speakerTemplate),
+        attributionRegex: attributionTemplate ? buildRegex(effectivePatterns, attributionTemplate) : null,
+        actionRegex: actionTemplate ? buildRegex(effectivePatterns, actionTemplate, { extraFlags: "u" }) : null,
+        pronounRegex: (actionVerbsPattern && pronounPattern)
+            ? new RegExp(
+                `(?:^|[\\r\\n]+)\\s*(?:${pronounPattern})(?:['’]s)?\\s+(?:${unicodeWordPattern}+\\s+){0,3}?(?:${actionVerbsPattern})`,
+                "iu",
+            )
+            : null,
+        vocativeRegex: buildRegex(effectivePatterns, `["“'\\s]({{PATTERNS}})[,.!?]`),
+        possessiveRegex: buildRegex(effectivePatterns, `\\b({{PATTERNS}})['’]s\\b`),
+        nameRegex: buildRegex(effectivePatterns, `\\b({{PATTERNS}})\\b`),
+        vetoRegex: buildGenericRegex(profile.vetoPatterns),
+    };
+
+    return {
+        regexes,
+        effectivePatterns,
+        pronounPattern,
+    };
+}
+
+export function collectDetections(text, profile = {}, regexes = {}, options = {}) {
+    if (!text || !profile) {
+        return [];
+    }
+    const quoteRanges = options.quoteRanges || getQuoteRanges(text);
+    const priorityWeights = options.priorityWeights || {};
+    const matches = [];
+
+    const addMatch = (name, matchKind, index, priority) => {
+        const trimmedName = String(name ?? "").trim();
+        if (!trimmedName) {
+            return;
+        }
+        matches.push({
+            name: trimmedName,
+            matchKind,
+            matchIndex: Number.isFinite(index) ? index : null,
+            priority: Number.isFinite(priority) ? priority : null,
+        });
+    };
+
+    if (regexes.speakerRegex) {
+        findMatches(text, regexes.speakerRegex, quoteRanges).forEach(match => {
+            const name = match.groups?.[0]?.trim();
+            addMatch(name, "speaker", match.index, priorityWeights.speaker);
+        });
+    }
+
+    if (profile.detectAttribution !== false && regexes.attributionRegex) {
+        findMatches(text, regexes.attributionRegex, quoteRanges).forEach(match => {
+            const name = match.groups?.find(group => group)?.trim();
+            addMatch(name, "attribution", match.index, priorityWeights.attribution);
+        });
+    }
+
+    if (profile.detectAction !== false && regexes.actionRegex) {
+        findMatches(text, regexes.actionRegex, quoteRanges).forEach(match => {
+            const name = match.groups?.find(group => group)?.trim();
+            addMatch(name, "action", match.index, priorityWeights.action);
+        });
+    }
+
+    if (profile.detectPronoun && regexes.pronounRegex && options.lastSubject) {
+        findMatches(text, regexes.pronounRegex, quoteRanges).forEach(match => {
+            addMatch(options.lastSubject, "pronoun", match.index, priorityWeights.pronoun);
+        });
+    }
+
+    if (profile.detectVocative !== false && regexes.vocativeRegex) {
+        findMatches(text, regexes.vocativeRegex, quoteRanges, { searchInsideQuotes: true }).forEach(match => {
+            const name = match.groups?.[0]?.trim();
+            addMatch(name, "vocative", match.index, priorityWeights.vocative);
+        });
+    }
+
+    if (profile.detectPossessive && regexes.possessiveRegex) {
+        findMatches(text, regexes.possessiveRegex, quoteRanges).forEach(match => {
+            const name = match.groups?.[0]?.trim();
+            addMatch(name, "possessive", match.index, priorityWeights.possessive);
+        });
+    }
+
+    if (profile.detectGeneral && regexes.nameRegex) {
+        findMatches(text, regexes.nameRegex, quoteRanges).forEach(match => {
+            const raw = match.groups?.[0] ?? match.match;
+            const name = String(raw ?? "").replace(/-(?:sama|san)$/i, "").trim();
+            addMatch(name, "name", match.index, priorityWeights.name);
+        });
+    }
+
+    return matches;
+}

--- a/src/report-utils.js
+++ b/src/report-utils.js
@@ -1,0 +1,129 @@
+function normalizeMatchIndex(value) {
+    return Number.isFinite(value) ? value : null;
+}
+
+function buildKey(name, matchKind, index) {
+    const normalizedName = String(name ?? "").trim().toLowerCase();
+    const kindKey = String(matchKind ?? "").toLowerCase();
+    const indexKey = Number.isFinite(index) ? index : "?";
+    return `${normalizedName}|${kindKey}|${indexKey}`;
+}
+
+export function mergeDetectionsForReport(report = {}) {
+    const merged = [];
+    const seen = new Set();
+
+    const add = (entry) => {
+        if (!entry || !entry.name) {
+            return;
+        }
+        const matchIndex = normalizeMatchIndex(entry.matchIndex ?? entry.charIndex);
+        const priority = Number.isFinite(entry.priority) ? entry.priority : null;
+        const key = buildKey(entry.name, entry.matchKind, matchIndex);
+        if (seen.has(key)) {
+            return;
+        }
+        merged.push({
+            name: entry.name,
+            matchKind: entry.matchKind || null,
+            matchIndex,
+            priority,
+        });
+        seen.add(key);
+    };
+
+    if (Array.isArray(report.matches)) {
+        report.matches.forEach(match => add(match));
+    }
+
+    if (Array.isArray(report.scoreDetails)) {
+        report.scoreDetails.forEach(detail => {
+            add({
+                name: detail.name,
+                matchKind: detail.matchKind,
+                matchIndex: normalizeMatchIndex(detail.charIndex ?? detail.matchIndex),
+                priority: Number.isFinite(detail.priority) ? detail.priority : null,
+            });
+        });
+    }
+
+    if (Array.isArray(report.events)) {
+        report.events.forEach(event => {
+            add({
+                name: event.name,
+                matchKind: event.matchKind || null,
+                matchIndex: normalizeMatchIndex(event.charIndex),
+                priority: null,
+            });
+        });
+    }
+
+    merged.sort((a, b) => {
+        const aIndex = Number.isFinite(a.matchIndex) ? a.matchIndex : Number.MAX_SAFE_INTEGER;
+        const bIndex = Number.isFinite(b.matchIndex) ? b.matchIndex : Number.MAX_SAFE_INTEGER;
+        if (aIndex !== bIndex) {
+            return aIndex - bIndex;
+        }
+        const aPriority = Number.isFinite(a.priority) ? a.priority : -Infinity;
+        const bPriority = Number.isFinite(b.priority) ? b.priority : -Infinity;
+        if (bPriority !== aPriority) {
+            return bPriority - aPriority;
+        }
+        return String(a.name || "").localeCompare(String(b.name || ""), undefined, { sensitivity: "base" });
+    });
+
+    return merged;
+}
+
+export function summarizeDetections(matches = []) {
+    const summaries = new Map();
+    matches.forEach(match => {
+        const key = String(match.name || "").toLowerCase();
+        if (!key) {
+            return;
+        }
+        if (!summaries.has(key)) {
+            summaries.set(key, {
+                name: match.name || key,
+                total: 0,
+                highestPriority: -Infinity,
+                earliest: Infinity,
+                latest: -Infinity,
+                kinds: {},
+            });
+        }
+        const summary = summaries.get(key);
+        summary.total += 1;
+        const kind = match.matchKind || "unknown";
+        summary.kinds[kind] = (summary.kinds[kind] || 0) + 1;
+        if (Number.isFinite(match.priority)) {
+            summary.highestPriority = Math.max(summary.highestPriority, match.priority);
+        }
+        if (Number.isFinite(match.matchIndex)) {
+            summary.earliest = Math.min(summary.earliest, match.matchIndex);
+            summary.latest = Math.max(summary.latest, match.matchIndex);
+        }
+    });
+
+    return Array.from(summaries.values()).map(summary => ({
+        ...summary,
+        highestPriority: summary.highestPriority === -Infinity ? null : summary.highestPriority,
+        earliest: summary.earliest === Infinity ? null : summary.earliest + 1,
+        latest: summary.latest === -Infinity ? null : summary.latest + 1,
+    })).sort((a, b) => {
+        if (b.total !== a.total) {
+            return b.total - a.total;
+        }
+        const aPriority = Number.isFinite(a.highestPriority) ? a.highestPriority : -Infinity;
+        const bPriority = Number.isFinite(b.highestPriority) ? b.highestPriority : -Infinity;
+        if (bPriority !== aPriority) {
+            return bPriority - aPriority;
+        }
+        const aEarliest = Number.isFinite(a.earliest) ? a.earliest : Number.MAX_SAFE_INTEGER;
+        const bEarliest = Number.isFinite(b.earliest) ? b.earliest : Number.MAX_SAFE_INTEGER;
+        if (aEarliest !== bEarliest) {
+            return aEarliest - bEarliest;
+        }
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    });
+}

--- a/test/detector-core.test.js
+++ b/test/detector-core.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    compileProfileRegexes,
+    collectDetections,
+} from '../src/detector-core.js';
+import {
+    DEFAULT_ACTION_VERBS_PRESENT,
+    DEFAULT_ACTION_VERBS_THIRD_PERSON,
+    DEFAULT_ACTION_VERBS_PAST,
+    DEFAULT_ACTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT,
+    DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
+    DEFAULT_ATTRIBUTION_VERBS_PAST,
+    DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+} from '../verbs.js';
+
+const buildVerbList = (...lists) => Array.from(new Set(lists.flat().filter(Boolean)));
+
+const DEFAULT_ACTION_VERB_FORMS = buildVerbList(
+    DEFAULT_ACTION_VERBS_PRESENT,
+    DEFAULT_ACTION_VERBS_THIRD_PERSON,
+    DEFAULT_ACTION_VERBS_PAST,
+    DEFAULT_ACTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ACTION_VERBS_PRESENT_PARTICIPLE,
+);
+
+const DEFAULT_ATTRIBUTION_VERB_FORMS = buildVerbList(
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT,
+    DEFAULT_ATTRIBUTION_VERBS_THIRD_PERSON,
+    DEFAULT_ATTRIBUTION_VERBS_PAST,
+    DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
+    DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
+);
+
+test('collectDetections identifies action matches for narrative cues', () => {
+    const profile = {
+        patterns: ['Kotori', 'Reine', 'Shido', 'Tohka', 'Yuzuru', 'Kaguya'],
+        ignorePatterns: [],
+        attributionVerbs: DEFAULT_ATTRIBUTION_VERB_FORMS,
+        actionVerbs: DEFAULT_ACTION_VERB_FORMS,
+        pronounVocabulary: ['he', 'she', 'they'],
+        detectAttribution: true,
+        detectAction: true,
+        detectVocative: true,
+        detectPossessive: true,
+        detectPronoun: true,
+        detectGeneral: false,
+    };
+
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: '[\\p{L}\\p{M}\\p{N}_]',
+        defaultPronouns: ['he', 'she', 'they'],
+    });
+
+    const sample = `"Umu! Shido is right to be concerned!" Tohka stepped forward, planting her hands on her hips. ` +
+        `"Assertion. Yuzuru's combat abilities are optimized for zero-gravity maneuvering," Yuzuru added.`;
+
+    const matches = collectDetections(sample, profile, regexes, {
+        priorityWeights: {
+            speaker: 5,
+            attribution: 4,
+            action: 3,
+            pronoun: 2,
+            vocative: 2,
+            possessive: 1,
+            name: 0,
+        },
+    });
+
+    const actionMatches = matches.filter(match => match.matchKind === 'action').map(match => match.name);
+    const attributionMatches = matches.filter(match => match.matchKind === 'attribution').map(match => match.name);
+
+    assert.ok(actionMatches.includes('Tohka'), 'expected Tohka action detection');
+    assert.ok(attributionMatches.includes('Yuzuru'), 'expected Yuzuru attribution detection');
+});

--- a/test/report-utils.test.js
+++ b/test/report-utils.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    mergeDetectionsForReport,
+    summarizeDetections,
+} from '../src/report-utils.js';
+
+test('mergeDetectionsForReport combines matches, score details, and events', () => {
+    const report = {
+        matches: [
+            { name: 'Kotori', matchKind: 'vocative', matchIndex: 10, priority: 2 },
+        ],
+        scoreDetails: [
+            { name: 'Yuzuru', matchKind: 'attribution', charIndex: 1560, priority: 4, totalScore: 320, priorityScore: 400 },
+        ],
+        events: [
+            { type: 'switch', name: 'Kaguya', matchKind: 'attribution', charIndex: 1680 },
+        ],
+    };
+
+    const merged = mergeDetectionsForReport(report);
+    const names = merged.map(item => item.name);
+
+    assert.deepEqual(
+        new Set(names),
+        new Set(['Kotori', 'Yuzuru', 'Kaguya']),
+        'expected merged detections to include vocative, score detail, and event-derived names',
+    );
+});
+
+test('summarizeDetections tallies counts and priority ranges', () => {
+    const merged = [
+        { name: 'Kotori', matchKind: 'vocative', matchIndex: 10, priority: 2 },
+        { name: 'Kotori', matchKind: 'action', matchIndex: 150, priority: 3 },
+        { name: 'Reine', matchKind: 'attribution', matchIndex: 200, priority: 4 },
+    ];
+
+    const summary = summarizeDetections(merged);
+    const kotoriSummary = summary.find(item => item.name === 'Kotori');
+    const reineSummary = summary.find(item => item.name === 'Reine');
+
+    assert.ok(kotoriSummary, 'expected Kotori to be summarized');
+    assert.equal(kotoriSummary.total, 2);
+    assert.equal(kotoriSummary.highestPriority, 3);
+    assert.deepEqual(kotoriSummary.kinds, { action: 1, vocative: 1 });
+    assert.ok(reineSummary);
+    assert.equal(reineSummary.total, 1);
+    assert.equal(reineSummary.highestPriority, 4);
+});


### PR DESCRIPTION
## Summary
- extract core detection regex compilation and matching helpers into a reusable module
- rebuild the live tester report to merge detections from matches, score details, and events for consistency
- add unit tests covering detection of narrative actions and report aggregation utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_69038ca29d048325b66a3983210afe53