### PR TITLE
Allow outfit lab to switch characters with shared outfit folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -1432,7 +1432,13 @@ function evaluateSwitchDecision(rawName, opts = {}, contextState = null, nowOver
                 now,
             };
         }
-        if (lastIssuedFolder && normalizedMapped && lastIssuedFolder.toLowerCase() === normalizedMapped.toLowerCase()) {
+        if (
+            lastIssuedFolder &&
+            normalizedMapped &&
+            lastIssuedFolder.toLowerCase() === normalizedMapped.toLowerCase() &&
+            currentName &&
+            currentName.toLowerCase() === decision.name.toLowerCase()
+        ) {
             updateMessageOutfitRoster(normalizedKey, decision.outfit, opts, profile);
             return { shouldSwitch: false, reason: 'already-active', name: decision.name, folder: mappedFolder, now };
         }

--- a/test/outfits.test.js
+++ b/test/outfits.test.js
@@ -220,3 +220,27 @@ test("per-trigger cooldown still applies with outfits", () => {
     assert.equal(second.shouldSwitch, false);
     assert.equal(second.reason, "per-trigger-cooldown");
 });
+
+test("evaluateSwitchDecision switches characters sharing the same outfit folder", () => {
+    setupProfile({
+        mappings: [
+            { name: "Hero", defaultFolder: "shared/outfit", outfits: [] },
+            { name: "Rival", defaultFolder: "shared/outfit", outfits: [] },
+        ],
+    });
+
+    const runtime = {
+        lastIssuedCostume: "Hero",
+        lastIssuedFolder: "shared/outfit",
+        lastSwitchTimestamp: 0,
+        lastTriggerTimes: new Map([["shared/outfit", 1000]]),
+        failedTriggerTimes: new Map(),
+        characterOutfits: new Map([["hero", { folder: "shared/outfit", updatedAt: 1000 }]]),
+    };
+
+    const decision = evaluateSwitchDecision("Rival", { matchKind: "action" }, runtime, 2000);
+
+    assert.equal(decision.shouldSwitch, true, decision.reason);
+    assert.equal(decision.name, "Rival");
+    assert.equal(decision.folder, "shared/outfit");
+});


### PR DESCRIPTION
## Summary
- prevent outfit lab from blocking character switches when different characters share the same outfit folder
- add regression coverage to verify evaluateSwitchDecision switches characters with shared outfit folders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903a565c9408325a8813950c8c1108f