### PR TITLE
Graduate Outfit Lab with priority-based variant resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Fine-tune responsiveness and tie-breaking behaviour:
 Map any detected name or alias to a specific costume folder. Use **Add Mapping** to append rows, then fill in the character and destination folder names.
 
 ### Outfit Lab
-The Outfit Lab is an experimental workspace for staging wardrobe variants without destabilising your live mappings. Variants saved here run in the detection engine as soon as **Enable Experimental Outfits** is toggled on for the active profile.
+The Outfit Lab is the home for outfit-aware automation. Variants saved here run in the detection engine as soon as **Enable Outfit Automation** is toggled on for the active profile.
 
 #### 1. Prepare your character folders
 Keep your prototypes in an `Outfit Lab` subdirectory under the character’s main folder. Each outfit variant receives its own subfolder, and every variant should reuse the same expression filenames as the parent directory so expression lookups remain valid.
@@ -206,7 +206,7 @@ SillyTavern/data/default-user/characters/Mythic Frontier/
 - Store shared assets (e.g., accessories or props) alongside the variant art if you reference them directly. SillyTavern only serves files that live inside the selected outfit directory.
 
 #### 2. Enable the lab in settings
-Open **Settings → Extensions → Costume Switcher → Outfits (Preview)**. The editor stays read-only until you flip **Enable Experimental Outfits** on. Once enabled you can add, edit, or remove variants; turning it back off preserves the data but keeps the profile on its default folders.
+Open **Settings → Extensions → Costume Switcher → Outfits**. The editor stays read-only until you flip **Enable Outfit Automation** on. Once enabled you can add, edit, or remove variants; turning it back off preserves the data but keeps the profile on its default folders.
 
 #### 3. Add characters and defaults
 Use **Add Character Slot** to create a card per character you want to experiment with. Fill in:
@@ -217,15 +217,16 @@ Use **Add Character Slot** to create a card per character you want to experiment
 These values sync with the main **Costume Mappings** table, so characters you configure in the lab are also available to the standard mapping workflow.
 
 #### 4. Build outfit variations
-Inside each card, click **Add Outfit Variation** to define experimental looks:
+Inside each card, click **Add Outfit Variation** to define automated looks:
 
 - **Label (optional)** – Friendly display name for the Live Tester and debug logs.
 - **Folder** – Path to the prototype outfit. Use the directory picker or paste the relative path shown in your SillyTavern character tree.
 - **Triggers** – One literal or `/regex/` pattern per line. Variants with no triggers act as always-on fallbacks after earlier variants fail.
 - **Match Types** – Limit the variant to specific detection sources. Options include `Speaker`, `Attribution`, `Action`, `Pronoun`, `Vocative`, `Possessive`, and `General Name`. Leave all unchecked to accept every match.
 - **Scene Awareness** – Require or exclude characters from the active scene roster. Fill in **Requires all of…**, **Requires any of…**, or **Exclude when present** (one name per line). The roster is case-insensitive and only populated when the **Scene Roster** detector is enabled in **Detection Strategy**.
+- **Priority** – Higher numbers take precedence when more than one variant qualifies. Ties resolve in favour of variants that matched triggers, then variants with more awareness rules, then variants limited to specific match types, and finally by creation order.
 
-Variants evaluate in order from top to bottom. The first entry whose folder exists, whose match type (if any) aligns with the detection event, whose triggers match the streaming text, and whose scene-awareness rules pass becomes the active outfit. Everything else falls back to the card’s default folder.
+Variants evaluate using priority before folder order. The engine selects the highest-priority variant that matches, breaking ties using trigger matches, awareness specificity, match-type filters, and finally the order the variants were created. If nothing qualifies the character falls back to the card’s default folder.
 
 #### 5. Test and iterate safely
 - Use the **Live Pattern Tester** with the lab enabled to verify which variant would win given sample prose. Trigger matches and awareness reasons appear in the report.
@@ -233,10 +234,10 @@ Variants evaluate in order from top to bottom. The first entry whose folder exis
 - Profiles store their lab configuration alongside mappings. Exporting a profile JSON carries the variants with it for backups or sharing.
 
 #### Troubleshooting the Outfit Lab
-- **Variant never fires** – Confirm the variant folder path is relative to your `characters/` directory and spelled exactly like the filesystem entry. Remember variants run sequentially; drag the card handles to reorder if a broader variant is catching the trigger first.
+- **Variant never fires** – Confirm the variant folder path is relative to your `characters/` directory and spelled exactly like the filesystem entry. Use the new **Priority** field to make the desired variant win when multiple entries match the same context.
 - **Scene rules never pass** – Enable **Scene Roster** under **Detection Strategy** and keep the TTL high enough for characters to remain “active.” Names are normalised to lowercase; match the roster spelling (e.g., `captain ardan`).
 - **Missing expressions** – Copy the full expression set into each variant directory. Because the manifest is shared, only files that physically exist in the selected folder can render.
-- **Editor looks disabled** – The lab requires **Enable Experimental Outfits** to be on. When off, the UI intentionally locks to prevent accidental edits during live sessions.
+- **Editor looks disabled** – Turn on **Enable Outfit Automation**. When off, the UI intentionally locks to prevent accidental edits during live sessions.
 - **Profile reset lost variants** – Variants live inside the active profile. Save the profile after edits and export periodic backups via the Profiles card.
 
 #### Organizing multi-character cards

--- a/settings.html
+++ b/settings.html
@@ -37,7 +37,7 @@
       </button>
       <button class="cs-tab-button" id="cs-tab-outfits" type="button" role="tab" aria-selected="false" aria-controls="cs-panel-outfits" data-tab="outfits">
         <i class="fa-solid fa-shirt"></i>
-        <span>Outfits (Preview)</span>
+        <span>Outfits</span>
       </button>
       <button class="cs-tab-button" id="cs-tab-detection" type="button" role="tab" aria-selected="false" aria-controls="cs-panel-detection" data-tab="detection">
         <i class="fa-solid fa-sliders"></i>
@@ -202,40 +202,29 @@
                   <i class="fa-solid fa-user-astronaut"></i>
                   <div>
                     <h3>Outfit Lab</h3>
-                    <p>Preview controls for outfit-aware detection. Variants you configure here run in the live detector once enabled.</p>
+                    <p>Manage per-character outfit automation. Variants you configure here run in the live detector when enabled.</p>
                   </div>
                 </div>
               </header>
               <div class="cs-card-body cs-card-body--stacked">
-                <div class="cs-experiment-banner cs-experiment-banner--outfits" role="note" aria-live="polite">
-                  <span class="cs-experiment-badge">Experimental</span>
-                  <div class="cs-experiment-copy">
-                    <p>
-                      Outfit awareness is an early preview feature. Expect rough edges, limited functionality, and breaking changes as the system evolves.
-                    </p>
-                    <p class="cs-experiment-subcopy">
-                      Use this lab to stage per-character wardrobes, configure trigger filters, and test scene-aware variants before the feature graduates into the main Characters tab.
-                    </p>
-                  </div>
-                </div>
                 <label class="cs-master-toggle" for="cs-outfits-enable">
                   <input id="cs-outfits-enable" type="checkbox" />
                   <span class="cs-switch-thumb" aria-hidden="true"></span>
                   <div class="cs-switch-copy">
-                    <strong>Enable Experimental Outfits</strong>
-                    <small>Turns on the lab features and activates outfit-aware detection for this profile. Leave disabled if you need today&rsquo;s stable behaviour.</small>
+                    <strong>Enable Outfit Automation</strong>
+                    <small>Turns on outfit-aware detection for this profile. Disable it to keep characters on their default folders.</small>
                   </div>
                 </label>
                 <div id="cs-outfit-disabled-notice" class="cs-outfit-disabled-notice" role="alert" hidden>
                   <i class="fa-solid fa-flask"></i>
                   <div>
-                    <strong>Flip the switch above to explore the Outfit Lab.</strong>
-                    <p>When disabled the editor remains read-only so your current profile stays stable. All data will be wiped if disabled.</p>
+                    <strong>Enable outfit automation to edit variants.</strong>
+                    <p>The editor stays read-only while automation is off, but your saved outfits remain intact.</p>
                   </div>
                 </div>
                 <div id="cs-outfit-editor" class="cs-outfit-editor" aria-live="polite" aria-busy="false">
                   <p class="cs-helper-text cs-outfit-editor-intro">
-                    Add characters to prototype nested outfit mappings. Variations can include triggers (one per line, supports <code>/regex/</code>), match-type filters, and scene awareness requirements before falling back to the default folder.
+                    Add characters to manage nested outfit mappings. Variations can include triggers (one per line, supports <code>/regex/</code>), match-type filters, awareness requirements, and priority values before falling back to the default folder.
                   </p>
                   <div id="cs-outfit-character-list" class="cs-outfit-character-list" data-empty-text="No characters have outfit variations yet."></div>
                   <button id="cs-outfit-add-character" class="menu_button interactable cs-outfit-add-button" type="button" data-change-notice="Adds a new character slot and auto-saves your mappings.">

--- a/test/manual-outfit-lab.md
+++ b/test/manual-outfit-lab.md
@@ -2,20 +2,20 @@
 
 Use this checklist to verify the Outfit Lab UI behaves as expected when testing locally in the SillyTavern client.
 
-1. Open the extension settings and switch to the **Outfits (Preview)** tab.
-2. Confirm the experimental banner is visible, uses the "Experimental" badge, and explains that outfit variants affect live detection when the toggle is enabled.
-3. With **Enable Experimental Outfits** turned **off**:
+1. Open the extension settings and switch to the **Outfits** tab.
+2. With **Enable Outfit Automation** turned **off**:
    - The disabled notice should appear below the toggle.
    - The editor card should be dimmed, and the **Add Character Slot** button should be disabled.
    - Attempting to interact with any inputs inside the editor should have no effect.
-4. Toggle **Enable Experimental Outfits** **on**:
+3. Toggle **Enable Outfit Automation** **on**:
    - The disabled notice disappears and the editor becomes interactive.
    - Click **Add Character Slot** and verify a new character card appears with editable name and default folder fields.
-5. Add at least one outfit variation inside the new character card:
+4. Add at least one outfit variation inside the new character card:
    - Confirm the folder picker button opens a directory picker (browser support permitting) and populates the folder input when a directory is chosen.
-   - Enter several trigger lines and confirm they persist when you switch tabs or toggle the experimental switch off and back on.
+   - Enter several trigger lines and confirm they persist when you switch tabs or toggle the automation switch off and back on.
    - Check the Match Types options and ensure selected checkboxes persist after saving and reloading the profile.
    - Populate the Scene Awareness fields (requires all / requires any / exclude) with sample names and confirm they save and restore.
-6. Remove the variation and the character to ensure the list updates and the mapping table in the Characters tab reflects the changes.
+   - Adjust the Priority field and confirm the value is saved, reloaded, and accepts negative, zero, and positive integers.
+5. Remove the variation and the character to ensure the list updates and the mapping table in the Characters tab reflects the changes.
 
 Mark each item as you complete it before delivering the build.


### PR DESCRIPTION
## Summary
- add priority-aware outfit resolution with deterministic tie-breaking and enable automation by default
- expose a priority control in the Outfit Lab UI while updating copy to reflect the stable feature
- refresh documentation and unit/manual tests for priority conflicts and the renamed automation toggle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6906ba438e0c832588eb27a4235fdc98