### PR TITLE
Retire Costume Mappings table in favor of the Outfit Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Under the hood the extension listens to streaming output from your model, scores
     4. [Presets & Focus](#presets--focus)
     5. [Detection Strategy](#detection-strategy)
     6. [Performance & Bias](#performance--bias)
-    7. [Costume Mappings](#costume-mappings)
-    8. [Outfit Lab](#outfit-lab)
+    7. [Outfit Lab](#outfit-lab)
         1. [Prepare your character folders](#1-prepare-your-character-folders)
         2. [Enable the lab in settings](#2-enable-the-lab-in-settings)
         3. [Add characters and defaults](#3-add-characters-and-defaults)
@@ -34,8 +33,8 @@ Under the hood the extension listens to streaming output from your model, scores
         5. [Test and iterate safely](#5-test-and-iterate-safely)
         6. [Troubleshooting the Outfit Lab](#troubleshooting-the-outfit-lab)
         7. [Organizing multi-character cards](#organizing-multi-character-cards)
-    9. [Live Pattern Tester](#live-pattern-tester)
-    10. [Footer Controls](#footer-controls)
+    8. [Live Pattern Tester](#live-pattern-tester)
+    9. [Footer Controls](#footer-controls)
 8. [Understanding Live Tester Reports](#understanding-live-tester-reports)
 9. [Advanced Configuration Tips](#advanced-configuration-tips)
 10. [Slash Commands](#slash-commands)
@@ -175,9 +174,6 @@ Fine-tune responsiveness and tie-breaking behaviour:
 - **Token Process Threshold (chars)** – Number of characters that must arrive before the buffer is rescored.
 - **Detection Bias** – Slider balancing match priority versus recency; positive numbers favour dialogue/action tags, negative values favour the latest mention.
 
-### Costume Mappings
-Map any detected name or alias to a specific costume folder. Use **Add Mapping** to append rows, then fill in the character and destination folder names.
-
 ### Outfit Lab
 The Outfit Lab is the home for outfit-aware automation. Variants saved here run in the detection engine as soon as **Enable Outfit Automation** is toggled on for the active profile.
 
@@ -214,7 +210,7 @@ Use **Add Character Slot** to create a card per character you want to experiment
 - **Character Name** – the detected name or alias that should trigger the outfit.
 - **Default Folder** – the production-ready costume directory. Variants fall back here when no triggers match.
 
-These values sync with the main **Costume Mappings** table, so characters you configure in the lab are also available to the standard mapping workflow.
+These values feed directly into the live detector, so characters you configure in the lab participate in automation without an extra mapping table.
 
 #### 4. Build outfit variations
 Inside each card, click **Add Outfit Variation** to define automated looks:

--- a/settings.html
+++ b/settings.html
@@ -168,28 +168,6 @@
               </div>
             </section>
           </div>
-          <div class="cs-column cs-column--wide">
-            <section class="cs-card">
-              <header class="cs-card-header">
-                <div class="cs-card-title">
-                  <i class="fa-solid fa-layer-group"></i>
-                  <div>
-                    <h3>Costume Mappings</h3>
-                    <p>Map detected names to specific costume folders.</p>
-                  </div>
-                </div>
-              </header>
-              <div class="cs-card-body">
-                <table id="cs-mappings" class="text_pole">
-                  <thead>
-                    <tr><th>Character Name</th><th>Costume Folder</th><th>Action</th></tr>
-                  </thead>
-                  <tbody id="cs-mappings-tbody"></tbody>
-                </table>
-                <button id="cs-mapping-add" class="menu_button interactable" style="margin-top: 12px;" data-change-notice="Adding a row will be saved once details are filled in.">Add Mapping</button>
-              </div>
-            </section>
-          </div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -1204,36 +1204,6 @@
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
-#costume-switcher-settings.cs-theme #cs-mappings {
-  width: 100%;
-  border-collapse: collapse;
-  background: rgba(255, 255, 255, 0.02);
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-#costume-switcher-settings.cs-theme #cs-mappings thead {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-color);
-}
-
-#costume-switcher-settings.cs-theme #cs-mappings th,
-#costume-switcher-settings.cs-theme #cs-mappings td {
-  padding: 10px 12px;
-  text-align: left;
-  font-size: 0.92rem;
-}
-
-#costume-switcher-settings.cs-theme #cs-mappings tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-#costume-switcher-settings.cs-theme #cs-mappings .map-name,
-#costume-switcher-settings.cs-theme #cs-mappings .map-folder {
-  width: 100%;
-  padding: 6px 8px;
-}
-
 #costume-switcher-settings.cs-theme .menu_button,
 #costume-switcher-settings.cs-theme .text_pole {
   border-radius: 10px !important;


### PR DESCRIPTION
## Summary
- remove the legacy Costume Mappings card from the Characters tab so the Outfit Lab owns character mapping edits
- simplify mapping persistence logic to read directly from the Outfit Lab data and drop unused table handlers
- update documentation and styles to reflect the streamlined workflow

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906c3b6a3d88325b7f35ee3445b4661