### PR TITLE
Preserve Outfit Lab character slots without default folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ import {
     mergeDetectionsForReport,
     summarizeDetections,
 } from "./src/report-utils.js";
-import { loadProfiles, normalizeProfile, normalizeMappingEntry } from "./profile-utils.js";
+import { loadProfiles, normalizeProfile, normalizeMappingEntry, mappingHasIdentity } from "./profile-utils.js";
 
 const extensionName = "SillyTavern-CostumeSwitch-Testing";
 const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
@@ -2138,7 +2138,7 @@ function saveCurrentProfileData() {
     profileData.mappings = mappingSource
         .map((entry) => {
             const normalized = normalizeMappingEntry(entry);
-            if (!normalized.name || !normalized.defaultFolder) {
+            if (!mappingHasIdentity(normalized, { normalized: true })) {
                 return null;
             }
             if (Array.isArray(normalized.outfits)) {

--- a/profile-utils.js
+++ b/profile-utils.js
@@ -150,3 +150,20 @@ export function loadProfiles(rawProfiles = {}, defaults = {}) {
 
     return normalized;
 }
+
+export function mappingHasIdentity(entry = {}, { normalized = false } = {}) {
+    if (!entry || typeof entry !== 'object') {
+        return false;
+    }
+
+    const source = normalized ? entry : normalizeMappingEntry(entry);
+    if (!source || typeof source !== 'object') {
+        return false;
+    }
+
+    const name = typeof source.name === 'string' ? source.name.trim() : '';
+    const defaultFolder = typeof source.defaultFolder === 'string' ? source.defaultFolder.trim() : '';
+    const folder = typeof source.folder === 'string' ? source.folder.trim() : '';
+
+    return Boolean(name || defaultFolder || folder);
+}

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { loadProfiles, normalizeProfile } from '../profile-utils.js';
+import { loadProfiles, normalizeProfile, mappingHasIdentity } from '../profile-utils.js';
 
 const PROFILE_DEFAULTS = {
     mappings: [],
@@ -91,4 +91,13 @@ test('normalizeProfile preserves non-enumerable mapping identifiers', () => {
     const descriptor = Object.getOwnPropertyDescriptor(normalized.mappings[0], '__cardId');
     assert.equal(normalized.mappings[0].__cardId, 'card-123', 'card identifier should persist through normalization');
     assert.ok(descriptor && descriptor.enumerable === false, 'card identifier should remain non-enumerable');
+});
+
+test('mappingHasIdentity accepts partially configured character slots', () => {
+    assert.equal(mappingHasIdentity({}), false, 'empty mapping should not persist');
+    assert.equal(mappingHasIdentity({ name: 'Draft Character' }), true, 'name-only mapping should persist');
+    assert.equal(mappingHasIdentity({ defaultFolder: 'draft/base' }), true, 'default folder should mark mapping as persistent');
+    assert.equal(mappingHasIdentity({ folder: 'legacy/folder' }), true, 'legacy folder field should mark mapping as persistent');
+    const normalized = normalizeProfile({ mappings: [{ name: 'Temp' }] }, PROFILE_DEFAULTS).mappings[0];
+    assert.equal(mappingHasIdentity(normalized, { normalized: true }), true, 'normalized mapping identity should be detected');
 });


### PR DESCRIPTION
## Summary
- allow Outfit Lab character mappings to persist even when the default folder is not yet set
- add a reusable helper for determining whether a mapping has any identifying fields
- extend profile persistence tests to cover the new helper behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690708a28f088325be009dfcec7a4bd5