### PR TITLE
Prevent pronoun switches before confirming new message subject

### DIFF
--- a/src/detector-core.js
+++ b/src/detector-core.js
@@ -338,9 +338,13 @@ export function collectDetections(text, profile = {}, regexes = {}, options = {}
         });
     }
 
-    if (profile.detectPronoun && regexes.pronounRegex && options.lastSubject) {
+    const validatedSubject = typeof options.lastSubject === "string"
+        ? options.lastSubject.trim()
+        : "";
+
+    if (profile.detectPronoun && regexes.pronounRegex && validatedSubject) {
         findMatches(text, regexes.pronounRegex, quoteRanges).forEach(match => {
-            addMatch(options.lastSubject, "pronoun", match.index, priorityWeights.pronoun);
+            addMatch(validatedSubject, "pronoun", match.index, priorityWeights.pronoun);
         });
     }
 


### PR DESCRIPTION
## Summary
- reset carried subjects when starting a new message until a non-pronoun match confirms the name
- restrict pronoun detections to validated subjects and trim inherited values
- cover pronoun-first messages with a regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690939a0c980832583b7d583910f742e