### PR TITLE
Warn when no detection patterns remain

### DIFF
--- a/test/simulate-tester-stream.test.js
+++ b/test/simulate-tester-stream.test.js
@@ -66,7 +66,7 @@ function setupProfile(overrides = {}) {
         unicodeWordPattern: "[\\\\p{L}\\\\p{M}\\\\p{N}_]",
         defaultPronouns: profile.pronounVocabulary,
     });
-    state.compiledRegexes = compiled.regexes;
+    state.compiledRegexes = { ...compiled.regexes, effectivePatterns: compiled.effectivePatterns };
     return profile;
 }
 


### PR DESCRIPTION
## Summary
- surface an explicit warning when compiling profiles results in no effective detection patterns
- propagate the warning into live tester simulations so reports and timelines note that detectors are disabled
- expand detector core and simulate tester tests to cover the no-pattern scenario

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d93ff3ea48325b3b5d1b9149b1f38)