### PR TITLE
Log focus lock status when focus lock suppresses streaming

### DIFF
--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -7,7 +7,7 @@ await register(new URL("./module-mock-loader.js", import.meta.url));
 const extensionSettingsStore = {};
 globalThis.__extensionSettingsStore = extensionSettingsStore;
 
-const { getWinner, extensionName, adjustWindowForTrim } = await import("../index.js");
+const { getWinner, extensionName, adjustWindowForTrim, handleStream, state } = await import("../index.js");
 
 extensionSettingsStore[extensionName] = {
     enabled: true,
@@ -61,4 +61,64 @@ test("adjustWindowForTrim grows processed length with new characters", () => {
     adjustWindowForTrim(msgState, 0, 150);
     assert.equal(msgState.bufferOffset, 0);
     assert.equal(msgState.processedLength, 150);
+});
+
+test("handleStream logs focus lock status when locked", () => {
+    const original$ = globalThis.$;
+    const stubElement = {
+        find: () => stubElement,
+        toggleClass: () => stubElement,
+        stop: () => stubElement,
+        fadeIn: () => stubElement,
+        fadeOut: (duration, callback) => {
+            if (typeof callback === "function") {
+                callback();
+            }
+            return stubElement;
+        },
+        removeClass: () => stubElement,
+        text: () => stubElement,
+        html: () => stubElement,
+        prop: () => stubElement,
+    };
+    globalThis.$ = () => stubElement;
+
+    const settings = extensionSettingsStore[extensionName];
+    const previousFocusLock = settings.focusLock.character;
+    const previousDebug = settings.profiles.Default.debug;
+
+    settings.enabled = true;
+    settings.focusLock.character = "Kotori";
+    settings.profiles.Default.debug = true;
+    state.focusLockNotice = { at: 0, character: null, displayName: null, message: null, event: null };
+
+    const logs = [];
+    const originalDebug = console.debug;
+    console.debug = (...args) => { logs.push(args.join(" ")); };
+
+    let noticeSnapshot = null;
+    try {
+        handleStream(0, "Hello");
+        noticeSnapshot = { ...state.focusLockNotice };
+    } finally {
+        console.debug = originalDebug;
+        settings.focusLock.character = previousFocusLock;
+        settings.profiles.Default.debug = previousDebug;
+        if (state.statusTimer) {
+            clearTimeout(state.statusTimer);
+            state.statusTimer = null;
+        }
+        state.focusLockNotice = { at: 0, character: null, displayName: null, message: null, event: null };
+        if (typeof original$ === "undefined") {
+            delete globalThis.$;
+        } else {
+            globalThis.$ = original$;
+        }
+    }
+
+    assert.ok(logs.some(entry => entry.includes("Focus lock active;")));
+    assert.ok(noticeSnapshot);
+    assert.equal(noticeSnapshot.character, "kotori");
+    assert.equal(noticeSnapshot.event.reason, "focus-lock");
+    assert.equal(noticeSnapshot.event.matchKind, "focus-lock");
 });


### PR DESCRIPTION
## Summary
- emit a focus lock status/debug notice from the stream handler so users see when detection is paused
- surface a matching `reason: "focus-lock"` skip entry in tester simulations and extend skip reason messaging
- add a unit test for the new focus lock notice and make HTML escaping safe when the DOM is unavailable

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d996d0ba48325b314c0d33ec88326)