### PR TITLE
Surface skip reasons and veto context

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -439,22 +439,27 @@
                   </ol>
                 </div>
                 <div id="cs-regex-test-output-container" class="text_pole cs-tester-output-container">
-                  <div class="cs-tester-summary-grid">
-                    <div class="cs-summary-card">
-                      <span class="cs-summary-label">Top Characters</span>
-                      <div id="cs-test-top-characters" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
-                      <p>Highest scoring matches from the last run.</p>
+                    <div class="cs-tester-summary-grid">
+                        <div class="cs-summary-card">
+                            <span class="cs-summary-label">Top Characters</span>
+                            <div id="cs-test-top-characters" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                            <p>Highest scoring matches from the last run.</p>
+                        </div>
+                        <div class="cs-summary-card">
+                            <span class="cs-summary-label">Veto Status</span>
+                            <div id="cs-test-veto-result" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
+                            <p>Explains whether a cooldown or lock blocked the switch.</p>
+                        </div>
+                        <div class="cs-summary-card">
+                            <span class="cs-summary-label">Recent Skip Reasons</span>
+                            <div id="cs-test-skip-reasons" class="cs-summary-value cs-tester-list-placeholder">None recorded</div>
+                            <p>Counts from the latest tester events.</p>
+                        </div>
+                        <div class="cs-summary-card">
+                            <span class="cs-summary-label">Quick Tip</span>
+                            <p class="cs-summary-help">Use the score, roster, and coverage panes below to focus your next tweaks.</p>
+                        </div>
                     </div>
-                    <div class="cs-summary-card">
-                      <span class="cs-summary-label">Veto Status</span>
-                      <div id="cs-test-veto-result" class="cs-summary-value cs-tester-list-placeholder">N/A</div>
-                      <p>Explains whether a cooldown or lock blocked the switch.</p>
-                    </div>
-                    <div class="cs-summary-card">
-                      <span class="cs-summary-label">Quick Tip</span>
-                      <p class="cs-summary-help">Use the score, roster, and coverage panes below to focus your next tweaks.</p>
-                    </div>
-                  </div>
                   <div class="cs-tester-panels">
                     <section class="cs-tester-panel cs-tester-panel--flow">
                       <header class="cs-tester-panel-header">

--- a/src/report-utils.js
+++ b/src/report-utils.js
@@ -127,3 +127,22 @@ export function summarizeDetections(matches = []) {
         return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
     });
 }
+
+export function summarizeSkipReasonsForReport(events = []) {
+    const counts = new Map();
+
+    events.forEach((event) => {
+        if (!event || event.type !== "skipped") {
+            return;
+        }
+        const code = event.reason || "unknown";
+        counts.set(code, (counts.get(code) || 0) + 1);
+    });
+
+    return Array.from(counts.entries()).map(([code, count]) => ({ code, count })).sort((a, b) => {
+        if (b.count !== a.count) {
+            return b.count - a.count;
+        }
+        return a.code.localeCompare(b.code);
+    });
+}

--- a/test/report-utils.test.js
+++ b/test/report-utils.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
     mergeDetectionsForReport,
     summarizeDetections,
+    summarizeSkipReasonsForReport,
 } from '../src/report-utils.js';
 
 test('mergeDetectionsForReport combines matches, score details, and events', () => {
@@ -47,4 +48,25 @@ test('summarizeDetections tallies counts and priority ranges', () => {
     assert.ok(reineSummary);
     assert.equal(reineSummary.total, 1);
     assert.equal(reineSummary.highestPriority, 4);
+});
+
+test('summarizeSkipReasonsForReport aggregates skip codes', () => {
+    const events = [
+        { type: 'switch', name: 'Kotori', matchKind: 'action' },
+        { type: 'skipped', name: 'Kotori', matchKind: 'action', reason: 'repeat-suppression' },
+        { type: 'skipped', name: 'Shido', matchKind: 'action', reason: 'repeat-suppression' },
+        { type: 'skipped', name: 'Reine', matchKind: 'attribution', reason: 'global-cooldown' },
+        { type: 'skipped', name: 'Shido', matchKind: 'action', reason: 'repeat-suppression' },
+        { type: 'skipped', name: 'Kotori', matchKind: 'action', reason: 'per-trigger-cooldown' },
+    ];
+
+    const summary = summarizeSkipReasonsForReport(events);
+    assert.deepEqual(
+        summary,
+        [
+            { code: 'repeat-suppression', count: 3 },
+            { code: 'global-cooldown', count: 1 },
+            { code: 'per-trigger-cooldown', count: 1 },
+        ],
+    );
 });

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -122,3 +122,80 @@ test("handleStream logs focus lock status when locked", () => {
     assert.equal(noticeSnapshot.event.reason, "focus-lock");
     assert.equal(noticeSnapshot.event.matchKind, "focus-lock");
 });
+
+test("handleStream records veto phrase and recent events", () => {
+    const original$ = globalThis.$;
+    const statusMessages = [];
+    const stubElement = {
+        find: () => stubElement,
+        toggleClass: () => stubElement,
+        stop: () => stubElement,
+        fadeIn: () => stubElement,
+        fadeOut: (duration, callback) => {
+            if (typeof callback === "function") {
+                callback();
+            }
+            return stubElement;
+        },
+        removeClass: () => stubElement,
+        text: (value) => {
+            if (typeof value === "string") {
+                statusMessages.push(value);
+            }
+            return stubElement;
+        },
+        html: (value) => {
+            if (typeof value === "string") {
+                statusMessages.push(value);
+            }
+            return stubElement;
+        },
+        prop: () => stubElement,
+    };
+    globalThis.$ = () => stubElement;
+
+    const settings = extensionSettingsStore[extensionName];
+    settings.enabled = true;
+    settings.profiles.Default = settings.profiles.Default || {};
+    settings.focusLock.character = null;
+
+    state.recentDecisionEvents = [];
+    state.lastVetoMatch = null;
+    state.compiledRegexes = { vetoRegex: /OOC:/i, effectivePatterns: ["Kotori"] };
+    state.currentGenerationKey = "live";
+    state.perMessageStates = new Map([["live", {
+        lastAcceptedName: null,
+        lastAcceptedTs: 0,
+        vetoed: false,
+        lastSubject: null,
+        lastSubjectNormalized: null,
+        pendingSubject: null,
+        pendingSubjectNormalized: null,
+        sceneRoster: new Set(),
+        outfitRoster: new Map(),
+        rosterTTL: 5,
+        outfitTTL: 5,
+        processedLength: 0,
+        lastAcceptedIndex: -1,
+        bufferOffset: 0,
+    }]]);
+    state.perMessageBuffers = new Map([["live", ""]]);
+
+    try {
+        handleStream("OOC:");
+    } finally {
+        if (typeof original$ === "undefined") {
+            delete globalThis.$;
+        } else {
+            globalThis.$ = original$;
+        }
+    }
+
+    assert.equal(state.perMessageStates.get("live").vetoed, true, "message state should be marked vetoed");
+    assert.ok(state.lastVetoMatch);
+    assert.equal(state.lastVetoMatch.phrase, "OOC:");
+    assert.ok(statusMessages.some(message => message.includes("Veto phrase")));
+    const vetoEvents = state.recentDecisionEvents.filter(event => event.type === "veto");
+    assert.equal(vetoEvents.length > 0, true, "expected veto event to be recorded");
+    assert.equal(vetoEvents[vetoEvents.length - 1].match, "OOC:");
+});


### PR DESCRIPTION
## Summary
- surface recent skip reasons in the live tester summary and record veto matches for reporting
- persist decision events so repeat, cooldown, and failure skips are visible in UI diagnostics
- expose skip reason aggregation in report-utils with tests covering the new helper and stream veto logging

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9ec8fea88325bf84da239dc13063)