### PR TITLE
Replace personalized references in settings guidance

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -155,7 +155,7 @@
                 <div class="cs-field">
                   <label for="cs-patterns">Active Characters</label>
                   <textarea id="cs-patterns" class="text_pole" rows="3" placeholder="Character One&#10;Character Two&#10;/Regular Expression/" title="Enter character names or /regex/, one per line."></textarea>
-                  <small class="cs-tip"><strong>Tip:</strong> List longer names before shorter ones that are part of them (e.g., put “Arthur” before “Art”).</small>
+                  <small class="cs-tip"><strong>Tip:</strong> List longer names before shorter ones that are part of them (e.g., put “Team Leader” before “Lead”).</small>
                 </div>
                 <div class="cs-field">
                   <label for="cs-ignore-patterns">Ignored Characters</label>
@@ -236,7 +236,7 @@
                     <span class="cs-toggle-indicator"></span>
                     <span><i class="fa-solid fa-bullhorn"></i>Detect Vocative</span>
                   </label>
-                  <label class="cs-toggle" title="Finds ownership, like Her eyes widened or Merlin's staff.">
+                  <label class="cs-toggle" title="Finds ownership, like Her eyes widened or a mage's staff.">
                     <input id="cs-detect-possessive" type="checkbox" />
                     <span class="cs-toggle-indicator"></span>
                     <span><i class="fa-solid fa-hand-holding"></i>Detect Possessive</span>
@@ -252,7 +252,7 @@
                     <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Mentions</span>
                   </label>
                 </div>
-                <small class="cs-helper-text">Enable the dialogue scan toggle if you work with transcripts that embed narration inside quoted speech, such as “Kotori recounted, ‘Form up.’”.</small>
+                <small class="cs-helper-text">Enable the dialogue scan toggle if you work with transcripts that embed narration inside quoted speech, such as “the squad leader recounted, ‘Form up.’”.</small>
                 <div class="cs-field-group">
                   <label class="cs-inline-label" for="cs-scene-roster-enable">Scene Awareness</label>
                   <label class="cs-toggle cs-toggle--inline" title="Improves group scenario accuracy by tracking recently active characters.">
@@ -350,7 +350,7 @@
                   </div>
                   <div class="cs-field-group">
                     <label for="cs-priority-possessive">Possessive Priority</label>
-                    <input id="cs-priority-possessive" class="text_pole" type="number" step="0.1" min="0" title="Weight for possessive mentions like Merlin's staff." />
+                    <input id="cs-priority-possessive" class="text_pole" type="number" step="0.1" min="0" title="Weight for possessive mentions like a mage's staff." />
                   </div>
                   <div class="cs-field-group">
                     <label for="cs-priority-name">General Name Priority</label>


### PR DESCRIPTION
## Summary
- replace the Kotori narration example with a generic description in the detection helper text
- swap the Arthur and Merlin references in the character pattern tips with neutral phrasing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da62700ec83258b6e6f3993223b41)