### PR TITLE
Add scroll container for character slot list

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -156,7 +156,9 @@
                   <label for="cs-patterns">Active Characters</label>
                   <div id="cs-patterns" class="cs-pattern-editor" aria-live="polite" aria-busy="false">
                     <p class="cs-helper-text">Create character slots with primary names, alternate detection patterns, and optional folder overrides.</p>
-                    <div id="cs-pattern-slot-list" class="cs-pattern-slot-list" data-empty-text="No characters have been added yet."></div>
+                    <div class="cs-pattern-slot-scroll">
+                      <div id="cs-pattern-slot-list" class="cs-pattern-slot-list" data-empty-text="No characters have been added yet."></div>
+                    </div>
                     <button id="cs-pattern-add-slot" class="menu_button interactable cs-pattern-add-button" type="button" data-change-notice="Adds a new character slot and auto-saves your patterns.">
                       <i class="fa-solid fa-user-plus"></i>
                       <span>Add Character Slot</span>

--- a/style.css
+++ b/style.css
@@ -418,6 +418,13 @@
     gap: 16px;
 }
 
+#costume-switcher-settings.cs-theme .cs-pattern-slot-scroll {
+    max-height: 360px;
+    overflow-y: auto;
+    padding-right: 6px;
+    margin-right: -6px;
+}
+
 #costume-switcher-settings.cs-theme .cs-pattern-editor .cs-helper-text {
     color: var(--text-color-soft);
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- wrap the character slot list in a scrollable container to reduce the card height
- cap the pattern list height with new styles so additional slots remain accessible

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db33898608325a3add1c33319f43e)