### PR TITLE
Add search filter for character patterns

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -153,6 +153,10 @@
               </header>
               <div class="cs-card-body cs-card-body--stacked">
                 <div class="cs-field">
+                  <label for="cs-pattern-search">Search Character Slots</label>
+                  <input id="cs-pattern-search" class="text_pole" type="search" placeholder="Search by name, alias, or folder…" title="Filter character slots by name, alias, or folder." />
+                </div>
+                <div class="cs-field">
                   <label for="cs-patterns">Active Characters</label>
                   <div id="cs-patterns" class="cs-pattern-editor" aria-live="polite" aria-busy="false">
                     <p class="cs-helper-text">Create character slots with primary names, alternate detection patterns, and optional folder overrides.</p>


### PR DESCRIPTION
## Summary
- add a search input above the character patterns list
- filter pattern slot cards based on the search query while preserving original order
- store and reset the query in state and wire up keyboard handling for quick clearing

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db40173c08325ae7fa1fcce89949d)