### PR TITLE
Handle missing scene panel template gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -6155,7 +6155,19 @@ async function mountScenePanelTemplate() {
             return;
         }
 
-        const templateHtml = await renderExtensionTemplateAsync(extensionName, "ui/templates/scenePanel");
+        let templateHtml;
+        try {
+            templateHtml = await renderExtensionTemplateAsync(extensionName, "ui/templates/scenePanel");
+        } catch (primaryError) {
+            console.warn(`${logPrefix} Scene panel template missing at ui/templates/scenePanel.html, attempting fallback.`, primaryError);
+            try {
+                templateHtml = await renderExtensionTemplateAsync(extensionName, "src/ui/templates/scenePanel");
+            } catch (fallbackError) {
+                console.error(`${logPrefix} Failed to load scene panel template from both primary and fallback locations.`, fallbackError);
+                return;
+            }
+        }
+
         if (!templateHtml) {
             console.warn(`${logPrefix} Scene panel template did not return any markup.`);
             return;

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -15,7 +15,7 @@ export async function load(url, context, defaultLoad) {
     if (url === "node:mock/extensions") {
         return {
             format: "module",
-            source: `const store = globalThis.__extensionSettingsStore || (globalThis.__extensionSettingsStore = {});\nexport const extension_settings = store;\nexport function getContext() {\n    return { extensionSettings: store, saveSettingsDebounced: () => {} };\n}`,
+            source: `const store = globalThis.__extensionSettingsStore || (globalThis.__extensionSettingsStore = {});\nexport const extension_settings = store;\nexport function getContext() {\n    return { extensionSettings: store, saveSettingsDebounced: () => {} };\n}\nexport async function renderExtensionTemplateAsync() {\n    return '<div id="cs-scene-panel"></div>';\n}`,
             shortCircuit: true,
         };
     }


### PR DESCRIPTION
## Summary
- add a fallback template lookup in the scene panel mount routine so the UI still renders when the packaged html is missing
- update the test harness mock for SillyTavern APIs to expose renderExtensionTemplateAsync

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911041709088325af10a3b8f22eb9d3)