### PR TITLE
Implement scene panel renderers and diagnostics UI

### DIFF
--- a/src/ui/render/activeCharacters.js
+++ b/src/ui/render/activeCharacters.js
@@ -1,0 +1,99 @@
+import {
+    resolveContainer,
+    clearContainer,
+    appendContent,
+    createElement,
+    createTextElement,
+    createPlaceholder,
+    formatRelativeTime,
+} from "./utils.js";
+
+function renderCard(entry, { displayNames, now }) {
+    const container = createElement("article", "cs-scene-active__card");
+    if (!container) {
+        return null;
+    }
+    if (entry.normalized) {
+        container.dataset.character = entry.normalized;
+    }
+    if (entry.inSceneRoster) {
+        container.dataset.roster = "true";
+    }
+    const name = entry.name || (entry.normalized ? displayNames?.get(entry.normalized) : null) || entry.normalized || "Unknown";
+    const title = createTextElement("h5", "cs-scene-active__name", name);
+    if (title) {
+        container.appendChild(title);
+    }
+    const detailParts = [];
+    if (Number.isFinite(entry.count)) {
+        detailParts.push(`${entry.count} detection${entry.count === 1 ? "" : "s"}`);
+    }
+    if (Number.isFinite(entry.score)) {
+        detailParts.push(`Score ${entry.score}`);
+    } else if (Number.isFinite(entry.bestPriority)) {
+        detailParts.push(`Priority ${entry.bestPriority}`);
+    }
+    if (detailParts.length) {
+        const detail = createTextElement("p", "cs-scene-active__details", detailParts.join(" • "));
+        if (detail) {
+            container.appendChild(detail);
+        }
+    }
+    if (Array.isArray(entry.events) && entry.events.length) {
+        const lastEvent = entry.events[entry.events.length - 1];
+        const when = Number.isFinite(lastEvent.timestamp) ? formatRelativeTime(lastEvent.timestamp, now) : null;
+        const eventParts = [];
+        if (lastEvent.type) {
+            eventParts.push(lastEvent.type);
+        }
+        if (lastEvent.matchKind) {
+            eventParts.push(lastEvent.matchKind);
+        }
+        if (Number.isFinite(lastEvent.charIndex)) {
+            eventParts.push(`#${lastEvent.charIndex + 1}`);
+        }
+        if (when) {
+            eventParts.push(when);
+        }
+        const eventLine = createTextElement("p", "cs-scene-active__event", eventParts.join(" · "));
+        if (eventLine) {
+            container.appendChild(eventLine);
+        }
+    }
+    return container;
+}
+
+export function renderActiveCharacters(target, panelState = {}) {
+    if (typeof document === "undefined") {
+        return;
+    }
+    const container = resolveContainer(target);
+    if (!container.$ && !container.el) {
+        return;
+    }
+    clearContainer(container);
+
+    const ranking = Array.isArray(panelState.ranking) ? panelState.ranking : [];
+    if (!ranking.length) {
+        const placeholder = createPlaceholder("No recent detections to highlight.");
+        appendContent(container, placeholder);
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    const now = Number.isFinite(panelState.now) ? panelState.now : Date.now();
+    ranking.forEach((entry) => {
+        if (!entry || typeof entry !== "object") {
+            return;
+        }
+        const card = renderCard(entry, {
+            displayNames: panelState.displayNames,
+            now,
+        });
+        if (card) {
+            fragment.appendChild(card);
+        }
+    });
+
+    appendContent(container, fragment);
+}

--- a/src/ui/render/liveLog.js
+++ b/src/ui/render/liveLog.js
@@ -1,0 +1,185 @@
+import {
+    resolveContainer,
+    clearContainer,
+    appendContent,
+    createElement,
+    createTextElement,
+    createPlaceholder,
+    formatRelativeTime,
+} from "./utils.js";
+
+const SKIP_REASON_LABELS = {
+    "already-active": "Already active",
+    "outfit-unchanged": "Outfit unchanged",
+    "global-cooldown": "Global cooldown",
+    "per-trigger-cooldown": "Per-trigger cooldown",
+    "failed-trigger-cooldown": "Retry cooldown",
+    "repeat-suppression": "Repeat suppression",
+    "focus-lock": "Focus lock",
+    "no-profile": "Profile unavailable",
+    "no-name": "No detected name",
+};
+
+function describeSkip(code) {
+    return SKIP_REASON_LABELS[code] || code || "Unknown reason";
+}
+
+function renderMetric(label, value) {
+    const wrapper = createElement("div", "cs-scene-log__metric");
+    if (!wrapper) {
+        return null;
+    }
+    const labelEl = createTextElement("span", "cs-scene-log__metric-label", label);
+    const valueEl = createTextElement("span", "cs-scene-log__metric-value", value);
+    if (labelEl) {
+        wrapper.appendChild(labelEl);
+    }
+    if (valueEl) {
+        wrapper.appendChild(valueEl);
+    }
+    return wrapper;
+}
+
+function renderStatsList(stats, displayNames) {
+    if (!(stats instanceof Map) || stats.size === 0) {
+        return null;
+    }
+    const list = createElement("ul", "cs-scene-log__stats");
+    if (!list) {
+        return null;
+    }
+    const entries = Array.from(stats.entries()).slice(0, 8);
+    entries.forEach(([normalized, count]) => {
+        const name = displayNames?.get(normalized) || normalized;
+        const item = createElement("li");
+        if (!item) {
+            return;
+        }
+        item.textContent = `${name} × ${count}`;
+        list.appendChild(item);
+    });
+    return list;
+}
+
+function renderEvent(entry, displayNames, now) {
+    if (!entry || typeof entry !== "object") {
+        return null;
+    }
+    const wrapper = createElement("div", "cs-scene-log__event");
+    if (!wrapper) {
+        return null;
+    }
+    if (entry.type) {
+        wrapper.dataset.eventType = entry.type;
+    }
+    const title = createElement("div", "cs-scene-log__event-title");
+    if (title) {
+        if (entry.type === "switch") {
+            const folder = entry.folder ? ` → ${entry.folder}` : "";
+            title.textContent = `Switch${folder}`;
+        } else if (entry.type === "skipped") {
+            const reason = describeSkip(entry.reason);
+            const name = entry.name ? ` ${entry.name}` : "";
+            title.textContent = `Skipped${name} · ${reason}`;
+        } else if (entry.type === "veto") {
+            title.textContent = `Veto · ${entry.match || "unknown"}`;
+        } else {
+            title.textContent = entry.type;
+        }
+        wrapper.appendChild(title);
+    }
+    const metaParts = [];
+    if (entry.name && entry.type !== "skipped") {
+        const displayName = entry.normalized ? displayNames?.get(entry.normalized) || entry.name : entry.name;
+        metaParts.push(displayName);
+    }
+    if (entry.matchKind) {
+        metaParts.push(entry.matchKind);
+    }
+    if (Number.isFinite(entry.charIndex)) {
+        metaParts.push(`#${entry.charIndex + 1}`);
+    }
+    if (entry.outfit?.label) {
+        metaParts.push(entry.outfit.label);
+    }
+    const when = Number.isFinite(entry.timestamp) ? formatRelativeTime(entry.timestamp, now) : null;
+    if (when) {
+        metaParts.push(when);
+    }
+    if (metaParts.length) {
+        const meta = createTextElement("div", "cs-scene-log__event-meta", metaParts.join(" • "));
+        if (meta) {
+            wrapper.appendChild(meta);
+        }
+    }
+    return wrapper;
+}
+
+export function renderLiveLog(target, panelState = {}) {
+    if (typeof document === "undefined") {
+        return;
+    }
+    const container = resolveContainer(target);
+    if (!container.$ && !container.el) {
+        return;
+    }
+    clearContainer(container);
+
+    const analytics = panelState.analytics || {};
+    const events = Array.isArray(analytics.events) ? analytics.events : [];
+    const stats = analytics.stats instanceof Map ? analytics.stats : null;
+    const buffer = typeof analytics.buffer === "string" ? analytics.buffer : "";
+    const tokenCount = buffer.trim() ? buffer.trim().split(/\s+/).filter(Boolean).length : 0;
+    const charCount = buffer.length;
+    const now = Number.isFinite(panelState.now) ? panelState.now : Date.now();
+
+    const metrics = createElement("div", "cs-scene-log__metrics");
+    if (metrics) {
+        if (tokenCount > 0) {
+            const tokenMetric = renderMetric("Approx. tokens", tokenCount.toString());
+            if (tokenMetric) {
+                metrics.appendChild(tokenMetric);
+            }
+        }
+        const charMetric = renderMetric("Characters", charCount.toString());
+        if (charMetric) {
+            metrics.appendChild(charMetric);
+        }
+        if (Number.isFinite(analytics.updatedAt)) {
+            const updatedMetric = renderMetric("Updated", formatRelativeTime(analytics.updatedAt, now) || "just now");
+            if (updatedMetric) {
+                metrics.appendChild(updatedMetric);
+            }
+        }
+        if (metrics.childNodes.length) {
+            appendContent(container, metrics);
+        }
+    }
+
+    const statsList = renderStatsList(stats, panelState.displayNames);
+    if (statsList) {
+        appendContent(container, statsList);
+    }
+
+    if (!events.length) {
+        const placeholder = createPlaceholder(panelState.isStreaming
+            ? "Awaiting detections for this message…"
+            : "No live diagnostics recorded yet.");
+        appendContent(container, placeholder);
+        return;
+    }
+
+    const list = createElement("div", "cs-scene-log__events");
+    if (!list) {
+        return;
+    }
+
+    events.slice(-25).forEach((event) => {
+        const item = renderEvent(event, panelState.displayNames, now);
+        if (item) {
+            list.appendChild(item);
+        }
+    });
+
+    appendContent(container, list);
+}

--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -1,0 +1,54 @@
+import {
+    getScenePanelContainer,
+    getSceneCollapseToggle,
+    getSceneRosterList,
+    getSceneActiveCards,
+    getSceneLiveLog,
+} from "../scenePanelState.js";
+import { renderSceneRoster } from "./sceneRoster.js";
+import { renderActiveCharacters } from "./activeCharacters.js";
+import { renderLiveLog } from "./liveLog.js";
+
+function applyCollapsedState(collapsed) {
+    const container = getScenePanelContainer?.();
+    const toggle = getSceneCollapseToggle?.();
+    if (container && typeof container.attr === "function") {
+        container.attr("data-cs-collapsed", collapsed ? "true" : "false");
+    } else if (container?.[0]) {
+        container[0].setAttribute("data-cs-collapsed", collapsed ? "true" : "false");
+    }
+    if (toggle && typeof toggle.attr === "function") {
+        toggle.attr("aria-expanded", collapsed ? "false" : "true");
+        toggle.attr("title", collapsed ? "Expand scene roster" : "Collapse scene roster");
+    } else if (toggle?.[0]) {
+        toggle[0].setAttribute("aria-expanded", collapsed ? "false" : "true");
+        toggle[0].setAttribute("title", collapsed ? "Expand scene roster" : "Collapse scene roster");
+    }
+}
+
+export function renderScenePanel(panelState = {}) {
+    if (typeof document === "undefined") {
+        return;
+    }
+    const container = getScenePanelContainer?.();
+    if (!container || (typeof container.length === "number" && container.length === 0)) {
+        return;
+    }
+
+    applyCollapsedState(Boolean(panelState.collapsed));
+
+    const rosterTarget = getSceneRosterList?.();
+    if (rosterTarget) {
+        renderSceneRoster(rosterTarget, panelState);
+    }
+
+    const activeTarget = getSceneActiveCards?.();
+    if (activeTarget) {
+        renderActiveCharacters(activeTarget, panelState);
+    }
+
+    const liveLogTarget = getSceneLiveLog?.();
+    if (liveLogTarget) {
+        renderLiveLog(liveLogTarget, panelState);
+    }
+}

--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -1,0 +1,326 @@
+import {
+    resolveContainer,
+    clearContainer,
+    appendContent,
+    createElement,
+    createTextElement,
+    formatRelativeTime,
+    resolveAvatarUrl,
+    createPlaceholder,
+} from "./utils.js";
+
+function buildDisplayName(normalized, fallback, displayNames) {
+    if (normalized && displayNames instanceof Map && displayNames.has(normalized)) {
+        return displayNames.get(normalized);
+    }
+    return fallback || normalized || "Unknown";
+}
+
+function formatRosterMeta(entry, now) {
+    const parts = [];
+    if (Number.isFinite(entry.joinedAt)) {
+        const joined = formatRelativeTime(entry.joinedAt, now);
+        if (joined) {
+            parts.push(`Joined ${joined}`);
+        }
+    }
+    if (entry.active) {
+        if (Number.isFinite(entry.lastSeenAt)) {
+            const seen = formatRelativeTime(entry.lastSeenAt, now);
+            if (seen) {
+                parts.push(`Seen ${seen}`);
+            }
+        }
+    } else {
+        const leftTs = Number.isFinite(entry.lastLeftAt) ? entry.lastLeftAt : entry.lastSeenAt;
+        const label = Number.isFinite(entry.lastLeftAt) ? "Left" : "Last seen";
+        const relative = formatRelativeTime(leftTs, now);
+        if (relative) {
+            parts.push(`${label} ${relative}`);
+        }
+    }
+    return parts.join(" • ");
+}
+
+function describeTesterSummary(testerEntry, now) {
+    if (!testerEntry || typeof testerEntry !== "object") {
+        return "No live tester activity recorded.";
+    }
+    const summary = testerEntry.summary || {};
+    const parts = [];
+    if (Number.isFinite(summary.switches) && summary.switches > 0) {
+        parts.push(`${summary.switches} switch${summary.switches === 1 ? "" : "es"}`);
+    }
+    if (Number.isFinite(summary.skips) && summary.skips > 0) {
+        parts.push(`${summary.skips} skip${summary.skips === 1 ? "" : "s"}`);
+    }
+    if (Number.isFinite(summary.vetoes) && summary.vetoes > 0) {
+        parts.push(`${summary.vetoes} veto${summary.vetoes === 1 ? "" : "es"}`);
+    }
+    const lastEvent = testerEntry.lastEvent;
+    if (lastEvent) {
+        const label = typeof lastEvent.type === "string" ? lastEvent.type : "event";
+        const detailParts = [];
+        if (typeof lastEvent.matchKind === "string" && lastEvent.matchKind.trim()) {
+            detailParts.push(lastEvent.matchKind.trim());
+        }
+        if (Number.isFinite(lastEvent.charIndex)) {
+            detailParts.push(`#${lastEvent.charIndex + 1}`);
+        }
+        const detail = detailParts.length ? ` (${detailParts.join(" · ")})` : "";
+        const when = Number.isFinite(lastEvent.timestamp) ? formatRelativeTime(lastEvent.timestamp, now) : null;
+        const line = `Last ${label}${detail}${when ? ` · ${when}` : ""}`;
+        parts.push(line);
+    }
+    if (!parts.length) {
+        return "No live tester activity recorded.";
+    }
+    return parts.join(" • ");
+}
+
+function resolveAvatarElement(name, showAvatars) {
+    const wrapper = createElement("div", "cs-scene-roster__avatar");
+    if (!wrapper) {
+        return null;
+    }
+    if (!showAvatars) {
+        wrapper.classList.add("cs-scene-roster__avatar--hidden");
+        return wrapper;
+    }
+    const url = resolveAvatarUrl(name);
+    if (url) {
+        const img = createElement("img", "cs-scene-roster__avatar-image");
+        if (img) {
+            img.src = url;
+            img.alt = "";
+            img.loading = "lazy";
+            wrapper.appendChild(img);
+        }
+        return wrapper;
+    }
+    const fallback = createElement("span", "cs-scene-roster__avatar-fallback");
+    if (fallback) {
+        const initial = typeof name === "string" && name.trim() ? name.trim().charAt(0).toUpperCase() : "?";
+        fallback.textContent = initial;
+        wrapper.appendChild(fallback);
+    }
+    return wrapper;
+}
+
+function renderRosterRow(entry, { displayNames, showAvatars, now }) {
+    const container = createElement("div", "cs-scene-roster__row");
+    if (!container) {
+        return null;
+    }
+    if (entry.normalized) {
+        container.dataset.character = entry.normalized;
+    }
+    container.dataset.active = entry.active ? "true" : "false";
+    if (entry.isLatest) {
+        container.dataset.latest = "true";
+    }
+    const displayName = buildDisplayName(entry.normalized, entry.name, displayNames);
+    const avatar = resolveAvatarElement(displayName, showAvatars);
+    if (avatar) {
+        container.appendChild(avatar);
+    }
+    const body = createElement("div", "cs-scene-roster__body");
+    if (!body) {
+        return container;
+    }
+    const nameRow = createElement("div", "cs-scene-roster__name-row");
+    const nameEl = createElement("span", "cs-scene-roster__name");
+    if (nameEl) {
+        nameEl.textContent = displayName;
+        nameRow.appendChild(nameEl);
+    }
+    const status = createElement("span", "cs-scene-roster__status");
+    if (status) {
+        if (entry.active) {
+            status.classList.add("cs-scene-roster__status--active");
+            status.textContent = "Active";
+        } else if (Number.isFinite(entry.lastSeenAt)) {
+            const seen = formatRelativeTime(entry.lastSeenAt, now);
+            status.textContent = seen ? `Inactive · ${seen}` : "Inactive";
+        } else {
+            status.textContent = "Inactive";
+        }
+        nameRow.appendChild(status);
+    }
+    if (entry.isLatest) {
+        const badge = createElement("span", "cs-scene-roster__badge");
+        if (badge) {
+            badge.textContent = "Latest match";
+            nameRow.appendChild(badge);
+        }
+    }
+    body.appendChild(nameRow);
+
+    const meta = formatRosterMeta(entry, now);
+    if (meta) {
+        const metaEl = createTextElement("div", "cs-scene-roster__meta", meta);
+        if (metaEl) {
+            body.appendChild(metaEl);
+        }
+    }
+
+    const analysis = describeTesterSummary(entry.tester, now);
+    if (analysis) {
+        const analysisEl = createTextElement("div", "cs-scene-roster__analysis", analysis);
+        if (analysisEl) {
+            body.appendChild(analysisEl);
+        }
+    }
+
+    container.appendChild(body);
+    return container;
+}
+
+function normalizeMember(member) {
+    if (!member || typeof member !== "object") {
+        return null;
+    }
+    const normalized = typeof member.normalized === "string" && member.normalized.trim()
+        ? member.normalized.trim().toLowerCase()
+        : typeof member.name === "string" && member.name.trim()
+            ? member.name.trim().toLowerCase()
+            : null;
+    if (!normalized) {
+        return null;
+    }
+    return {
+        name: member.name || normalized,
+        normalized,
+        joinedAt: Number.isFinite(member.joinedAt) ? member.joinedAt : null,
+        lastSeenAt: Number.isFinite(member.lastSeenAt) ? member.lastSeenAt : null,
+        lastLeftAt: Number.isFinite(member.lastLeftAt) ? member.lastLeftAt : null,
+        active: Boolean(member.active),
+    };
+}
+
+function mergeRosterData(scene, membership, testers, now) {
+    const map = new Map();
+    if (membership && Array.isArray(membership.members)) {
+        membership.members.forEach((member) => {
+            const normalized = normalizeMember(member);
+            if (!normalized) {
+                return;
+            }
+            map.set(normalized.normalized, normalized);
+        });
+    }
+
+    if (scene && Array.isArray(scene.roster)) {
+        scene.roster.forEach((entry) => {
+            const normalized = normalizeMember(entry);
+            if (!normalized) {
+                return;
+            }
+            const existing = map.get(normalized.normalized) || normalized;
+            existing.active = true;
+            if (Number.isFinite(normalized.lastSeenAt)) {
+                existing.lastSeenAt = Math.max(existing.lastSeenAt || 0, normalized.lastSeenAt);
+            }
+            if (Number.isFinite(normalized.joinedAt)) {
+                existing.joinedAt = existing.joinedAt || normalized.joinedAt;
+            }
+            map.set(normalized.normalized, existing);
+        });
+    }
+
+    const testerMap = new Map();
+    if (testers && Array.isArray(testers.entries)) {
+        testers.entries.forEach((entry) => {
+            if (!entry || typeof entry !== "object") {
+                return;
+            }
+            const normalized = typeof entry.normalized === "string" && entry.normalized.trim()
+                ? entry.normalized.trim().toLowerCase()
+                : typeof entry.name === "string" && entry.name.trim()
+                    ? entry.name.trim().toLowerCase()
+                    : null;
+            if (!normalized) {
+                return;
+            }
+            testerMap.set(normalized, entry);
+            if (!map.has(normalized)) {
+                map.set(normalized, {
+                    name: entry.name || normalized,
+                    normalized,
+                    joinedAt: Number.isFinite(entry.updatedAt) ? entry.updatedAt : null,
+                    lastSeenAt: Number.isFinite(entry.updatedAt) ? entry.updatedAt : null,
+                    lastLeftAt: null,
+                    active: Boolean(entry.activeInRoster),
+                });
+            }
+        });
+    }
+
+    const latestMatch = scene?.lastEvent?.normalized
+        ? scene.lastEvent.normalized.toLowerCase()
+        : null;
+
+    const entries = Array.from(map.values()).map((entry) => {
+        const tester = entry.normalized ? testerMap.get(entry.normalized) : null;
+        return {
+            ...entry,
+            tester,
+            isLatest: latestMatch && entry.normalized === latestMatch,
+        };
+    });
+
+    entries.sort((a, b) => {
+        if (a.active !== b.active) {
+            return a.active ? -1 : 1;
+        }
+        const aSeen = Number.isFinite(a.lastSeenAt) ? a.lastSeenAt : 0;
+        const bSeen = Number.isFinite(b.lastSeenAt) ? b.lastSeenAt : 0;
+        if (aSeen !== bSeen) {
+            return bSeen - aSeen;
+        }
+        return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    });
+
+    return entries;
+}
+
+export function renderSceneRoster(target, panelState = {}) {
+    if (typeof document === "undefined") {
+        return;
+    }
+    const container = resolveContainer(target);
+    if (!container.$ && !container.el) {
+        return;
+    }
+    clearContainer(container);
+
+    const now = Number.isFinite(panelState.now) ? panelState.now : Date.now();
+    const entries = mergeRosterData(panelState.scene, panelState.membership, panelState.testers, now);
+    const showAvatars = panelState.settings?.showRosterAvatars !== false;
+
+    if (panelState.isStreaming && entries.length === 0) {
+        const placeholder = createPlaceholder("Listening for live detections…", { tone: "informative" });
+        appendContent(container, placeholder);
+        return;
+    }
+
+    if (entries.length === 0) {
+        const placeholder = createPlaceholder("No characters are in the scene roster yet.");
+        appendContent(container, placeholder);
+        return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    entries.forEach((entry) => {
+        const row = renderRosterRow(entry, {
+            displayNames: panelState.displayNames,
+            showAvatars,
+            now,
+        });
+        if (row) {
+            fragment.appendChild(row);
+        }
+    });
+
+    appendContent(container, fragment);
+}

--- a/src/ui/render/utils.js
+++ b/src/ui/render/utils.js
@@ -1,0 +1,202 @@
+const avatarCache = new Map();
+
+function isElement(value) {
+    return typeof Element !== "undefined" && value instanceof Element;
+}
+
+function isJQueryLike(value) {
+    return value && typeof value === "object" && typeof value.jquery === "string";
+}
+
+export function resolveContainer(target) {
+    const result = { $: null, el: null };
+    if (!target) {
+        return result;
+    }
+
+    if (isJQueryLike(target)) {
+        result.$ = target;
+        result.el = target[0] || null;
+        return result;
+    }
+
+    if (typeof window !== "undefined" && typeof window.jQuery === "function") {
+        const $instance = window.jQuery(target);
+        if ($instance && $instance.length) {
+            result.$ = $instance;
+            result.el = $instance[0] || null;
+            return result;
+        }
+    }
+
+    if (isElement(target)) {
+        result.el = target;
+        return result;
+    }
+
+    return result;
+}
+
+export function clearContainer(target) {
+    const { $, el } = resolveContainer(target);
+    if ($ && $.length) {
+        $.empty();
+        return;
+    }
+    if (el) {
+        while (el.firstChild) {
+            el.removeChild(el.firstChild);
+        }
+    }
+}
+
+export function appendContent(target, node) {
+    if (!node) {
+        return;
+    }
+    const { $, el } = resolveContainer(target);
+    if ($ && $.length) {
+        $.append(node);
+        return;
+    }
+    if (el) {
+        el.appendChild(node);
+    }
+}
+
+export function createElement(tagName, className = null) {
+    if (typeof document === "undefined" || typeof document.createElement !== "function") {
+        return null;
+    }
+    const el = document.createElement(tagName);
+    if (className) {
+        el.className = className;
+    }
+    return el;
+}
+
+export function createTextElement(tagName, className, text) {
+    const el = createElement(tagName, className);
+    if (!el) {
+        return null;
+    }
+    el.textContent = text;
+    return el;
+}
+
+export function formatRelativeTime(timestamp, now = Date.now()) {
+    if (!Number.isFinite(timestamp)) {
+        return null;
+    }
+    const delta = Math.max(0, now - timestamp);
+    const seconds = Math.round(delta / 1000);
+    if (seconds <= 1) {
+        return "just now";
+    }
+    if (seconds < 60) {
+        return `${seconds}s ago`;
+    }
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) {
+        return `${minutes}m ago`;
+    }
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) {
+        return `${hours}h ago`;
+    }
+    const days = Math.round(hours / 24);
+    if (days < 14) {
+        return `${days}d ago`;
+    }
+    const weeks = Math.round(days / 7);
+    if (weeks < 8) {
+        return `${weeks}w ago`;
+    }
+    const months = Math.round(days / 30);
+    if (months < 18) {
+        return `${months}mo ago`;
+    }
+    const years = Math.round(days / 365);
+    return `${years}y ago`;
+}
+
+function findAvatarInCollection(collection, normalizedName) {
+    if (!collection) {
+        return null;
+    }
+    if (collection instanceof Map) {
+        const entry = collection.get(normalizedName);
+        if (entry && typeof entry === "object") {
+            return entry.avatar || entry.thumbnail || entry.img || entry.image || null;
+        }
+        return null;
+    }
+    if (!Array.isArray(collection)) {
+        return null;
+    }
+    for (const entry of collection) {
+        if (!entry || typeof entry !== "object") {
+            continue;
+        }
+        const name = String(entry.name || entry.display_name || entry.nickname || "").toLowerCase();
+        if (name && name === normalizedName) {
+            return entry.avatar || entry.thumbnail || entry.img || entry.image || entry.portrait || null;
+        }
+    }
+    return null;
+}
+
+export function resolveAvatarUrl(name) {
+    if (typeof name !== "string" || !name.trim()) {
+        return null;
+    }
+    const normalized = name.trim().toLowerCase();
+    if (avatarCache.has(normalized)) {
+        return avatarCache.get(normalized);
+    }
+    let resolved = null;
+    if (typeof window !== "undefined") {
+        try {
+            if (typeof window.getThumbnail === "function") {
+                resolved = window.getThumbnail(name) || null;
+            }
+        } catch (err) {
+        }
+        if (!resolved) {
+            const candidates = [
+                window.characters,
+                window.SillyTavern?.characters,
+                window.SillyTavern?.characterCache,
+                window.SillyTavern?.characterController?.characters,
+            ];
+            for (const candidate of candidates) {
+                resolved = findAvatarInCollection(candidate, normalized);
+                if (resolved) {
+                    break;
+                }
+            }
+        }
+    }
+    avatarCache.set(normalized, resolved);
+    return resolved;
+}
+
+export function createPlaceholder(message, { tone = "neutral" } = {}) {
+    const el = createElement("div", "cs-scene-panel__placeholder");
+    if (!el) {
+        return null;
+    }
+    el.dataset.tone = tone;
+    el.textContent = message;
+    return el;
+}
+
+export function capitalizeName(name) {
+    if (typeof name !== "string") {
+        return "";
+    }
+    if (!name.length) {
+        return "";
+    }
+    return name.charAt(0).toUpperCase() + name.slice(1);
+}

--- a/style.css
+++ b/style.css
@@ -1618,6 +1618,213 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     padding: 12px;
 }
 
+.cs-scene-panel__placeholder {
+    padding: 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.04);
+    color: rgba(255, 255, 255, 0.7);
+    text-align: center;
+    font-size: 0.85rem;
+}
+
+.cs-scene-panel__placeholder[data-tone="informative"] {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cs-scene-roster__row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.cs-scene-roster__row[data-active="true"] {
+    border-color: rgba(156, 125, 255, 0.35);
+    box-shadow: inset 0 0 0 1px rgba(156, 125, 255, 0.2);
+}
+
+.cs-scene-roster__row[data-latest="true"] {
+    background: rgba(156, 125, 255, 0.12);
+}
+
+.cs-scene-roster__avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    flex-shrink: 0;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cs-scene-roster__avatar--hidden {
+    display: none;
+}
+
+.cs-scene-roster__avatar-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.cs-scene-roster__avatar-fallback {
+    font-weight: 600;
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.cs-scene-roster__body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.cs-scene-roster__name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.cs-scene-roster__name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.cs-scene-roster__status {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.cs-scene-roster__status--active {
+    color: #7ee787;
+}
+
+.cs-scene-roster__badge {
+    background: rgba(156, 125, 255, 0.25);
+    color: rgba(255, 255, 255, 0.9);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.cs-scene-roster__meta,
+.cs-scene-roster__analysis {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.cs-scene-roster__analysis {
+    font-family: "JetBrains Mono", "Fira Code", monospace;
+    white-space: normal;
+}
+
+.cs-scene-active__card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.cs-scene-active__card[data-roster="true"] {
+    border-color: rgba(126, 231, 135, 0.35);
+}
+
+.cs-scene-active__name {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.cs-scene-active__details,
+.cs-scene-active__event {
+    margin: 0;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.cs-scene-log__metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.cs-scene-log__metric {
+    display: inline-flex;
+    gap: 4px;
+    font-size: 0.72rem;
+    background: rgba(255, 255, 255, 0.05);
+    padding: 4px 8px;
+    border-radius: 999px;
+}
+
+.cs-scene-log__metric-label {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.cs-scene-log__metric-value {
+    font-weight: 600;
+}
+
+.cs-scene-log__stats {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 6px;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.cs-scene-log__events {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.cs-scene-log__event {
+    padding: 8px 10px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.cs-scene-log__event[data-event-type="switch"] {
+    border-color: rgba(126, 231, 135, 0.35);
+}
+
+.cs-scene-log__event[data-event-type="skipped"] {
+    border-color: rgba(255, 196, 86, 0.35);
+}
+
+.cs-scene-log__event[data-event-type="veto"] {
+    border-color: rgba(255, 102, 102, 0.4);
+}
+
+.cs-scene-log__event-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.cs-scene-log__event-meta {
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
 .cs-scene-panel__footer {
     margin-top: auto;
     padding-top: 8px;


### PR DESCRIPTION
## Summary
- add render utilities and modules to populate scene roster, active character cards, and live log panels
- integrate scene panel render scheduling into stream, tester, and settings state updates
- style the roster, active card, and live log sections for the scene panel

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110b9b7c3c8325ac7dda43d415f8d7)