### PR TITLE
Handle resolved scene panel containers when rendering roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.6.0 (Unreleased)
+
+### Fixed
+- **Scene panel mounting.** Resolving pre-fetched container references no longer breaks roster rendering, fixing the empty panel and console error triggered when the UI initializes.
+
 ## v3.5.0
 
 ### Added

--- a/src/ui/render/utils.js
+++ b/src/ui/render/utils.js
@@ -14,6 +14,33 @@ export function resolveContainer(target) {
         return result;
     }
 
+    if (typeof target === "object" && target !== null) {
+        const hasJQuery = Object.prototype.hasOwnProperty.call(target, "$") && target.$;
+        const hasElement = Object.prototype.hasOwnProperty.call(target, "el") && target.el;
+
+        if (hasJQuery || hasElement) {
+            if (hasJQuery) {
+                result.$ = target.$;
+                if (!result.el && target.$ && typeof target.$.length === "number" && target.$.length > 0) {
+                    result.el = target.$[0] || null;
+                }
+            }
+
+            if (hasElement && !result.el) {
+                result.el = target.el;
+            }
+
+            if (result.el && !result.$ && typeof window !== "undefined" && typeof window.jQuery === "function") {
+                const $instance = window.jQuery(result.el);
+                if ($instance && $instance.length) {
+                    result.$ = $instance;
+                }
+            }
+
+            return result;
+        }
+    }
+
     if (isJQueryLike(target)) {
         result.$ = target;
         result.el = target[0] || null;


### PR DESCRIPTION
## Summary
- allow render helpers to accept pre-resolved container objects when manipulating the DOM
- document the fix in the v3.6.0 (Unreleased) changelog section

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110f60d6f8832598f045a3fec2bdf1)