### PR TITLE
Stop shifting SillyTavern layout for scene panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -1949,12 +1949,9 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 }
 
 @media (min-width: 1401px) {
-    body:has(#cs-scene-panel) #sheld {
-        margin-right: calc(var(--cs-scene-panel-width) + var(--cs-scene-panel-gap));
-    }
-
+    body:has(#cs-scene-panel) #sheld,
     body:has(#cs-scene-panel[data-cs-collapsed="true"]) #sheld {
-        margin-right: calc(var(--cs-scene-panel-collapsed-width) + var(--cs-scene-panel-gap));
+        margin-right: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- keep the scene panel overlay from adjusting the main SillyTavern layout

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691122eb11d88325b2a5cedcb1cd84e9)