### PR TITLE
Remove scene panel margin overrides on SillyTavern layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1948,16 +1948,6 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     border: 0 !important;
 }
 
-@media (min-width: 1401px) {
-    body:has(#cs-scene-panel) #sheld {
-        margin-right: calc(var(--cs-scene-panel-width) + var(--cs-scene-panel-gap));
-    }
-
-    body:has(#cs-scene-panel[data-cs-collapsed="true"]) #sheld {
-        margin-right: calc(var(--cs-scene-panel-collapsed-width) + var(--cs-scene-panel-gap));
-    }
-}
-
 @media (max-width: 1400px) {
     .cs-scene-panel {
         left: auto;
@@ -1976,10 +1966,6 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
         border-radius: 12px;
     }
 
-    body:has(#cs-scene-panel) #sheld,
-    body:has(#cs-scene-panel[data-cs-collapsed="true"]) #sheld {
-        margin-right: 0;
-    }
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- remove the scene panel's overrides that modified SillyTavern's #sheld layout so the chat stays centered

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691122eb11d88325b2a5cedcb1cd84e9)