### PR TITLE
Fix scene panel state reset after chat changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.
 - **Scene panel mounting.** Resolving pre-fetched container references no longer breaks roster rendering, fixing the empty panel and console error triggered when the UI initializes.
+- **Scene panel rehydration.** Switching chats or waiting for autosaves now restores the latest assistant message so the roster, active characters, and live log remain populated instead of clearing after a few seconds.
 
 ## v3.5.0
 


### PR DESCRIPTION
## Summary
- add a helper that reloads the latest assistant outcome so roster, active characters, and logs survive chat changes
- rehydrate the scene panel on load and after chat change events while avoiding redundant reset renders
- document the scene panel rehydration fix in the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114b3fe9748325a0c1d0d47c6706b0)