### PR TITLE
Fix live log placeholder flicker when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.
 - **Scene panel mounting.** Resolving pre-fetched container references no longer breaks roster rendering, fixing the empty panel and console error triggered when the UI initializes.
 - **Scene panel rehydration.** Switching chats or waiting for autosaves now restores the latest assistant message so the roster, active characters, and live log remain populated instead of clearing after a few seconds.
+- **Live log stability.** The live diagnostics panel keeps the prior message data visible until the next stream produces detections, so it no longer flickers "Awaiting detections" while idle.
 
 ## v3.5.0
 


### PR DESCRIPTION
## Summary
- delay switching the scene panel analytics to a new stream until it has detections or buffer content
- ensure recent events are matched using normalized message keys and mark the panel streaming state only when live data is shown
- document the live log stability fix in the changelog and add a regression test for the deferred switch behavior

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691153396c0083258260825fbcbb557d)