### PR TITLE
Fix scene panel refresh hooks for new SillyTavern events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Scene panel rehydration.** Switching chats or waiting for autosaves now restores the latest assistant message so the roster, active characters, and live log remain populated instead of clearing after a few seconds.
 - **Live log stability.** The live diagnostics panel keeps the prior message data visible until the next stream produces detections, so it no longer flickers "Awaiting detections" while idle.
 - **Scene panel hide toggle.** Hiding the command center now removes the panel entirely so no translucent shell remains on screen.
+- **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
 
 ## v3.5.0
 

--- a/test/integration-sillytavern.test.js
+++ b/test/integration-sillytavern.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { __testing } from "../src/systems/integration/sillytavern.js";
+
+const { resolveEventIdentifiers } = __testing;
+
+test("resolveEventIdentifiers matches regex-based candidates", () => {
+    const eventTypes = {
+        GENERATION_STOPPED: "generation_stopped",
+        STREAM_TOKEN_EVENT: "stream_token_event",
+    };
+    const result = resolveEventIdentifiers(eventTypes, [
+        { match: /(GENERATION|STREAM).*STOP/i },
+    ]);
+    assert.deepEqual(result, ["generation_stopped"], "should map matching keys to resolved event names");
+});
+
+test("resolveEventIdentifiers falls back to provided names when no matches", () => {
+    const eventTypes = {};
+    const result = resolveEventIdentifiers(eventTypes, [
+        { match: /(GENERATION|STREAM).*STOP/i, fallback: ["GENERATION_STOPPED", "STREAM_STOPPED"] },
+    ]);
+    assert.deepEqual(result, ["GENERATION_STOPPED", "STREAM_STOPPED"], "should return fallback names when no mapping exists");
+});
+
+test("resolveEventIdentifiers still accepts explicit string candidates", () => {
+    const eventTypes = {
+        STREAM_TOKEN: "stream_token",
+    };
+    const result = resolveEventIdentifiers(eventTypes, ["STREAM_TOKEN", "GENERATION_TOKEN"]);
+    assert.deepEqual(result.sort(), ["GENERATION_TOKEN", "stream_token"].sort(), "should include mapped and literal names");
+});


### PR DESCRIPTION
## Summary
- expand the SillyTavern integration to subscribe to additional generation and stream events
- add unit coverage for the regex-based event resolver and document the fix in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911650ecb0083258fc3450e54dea34d)