### PR TITLE
Handle SillyTavern symbol events for streaming detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Live log stability.** The live diagnostics panel keeps the prior message data visible until the next stream produces detections, so it no longer flickers "Awaiting detections" while idle.
 - **Scene panel hide toggle.** Hiding the command center now removes the panel entirely so no translucent shell remains on screen.
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
+- **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
 
 ## v3.5.0
 

--- a/test/integration-sillytavern.test.js
+++ b/test/integration-sillytavern.test.js
@@ -57,3 +57,18 @@ test("resolveEventIdentifiers resolves nested keys by name", () => {
     const result = resolveEventIdentifiers(eventTypes, ["deleted", "history.message.deleted"]);
     assert.deepEqual(result.sort(), ["history.message.deleted", "message_deleted"].sort(), "should match nested keys by name");
 });
+
+test("resolveEventIdentifiers returns symbol values when available", () => {
+    const streamStarted = Symbol("generation_stream_started");
+    const eventTypes = {
+        generation: {
+            stream: {
+                started: streamStarted,
+            },
+        },
+    };
+    const [result] = resolveEventIdentifiers(eventTypes, [
+        { match: /(GENERATION|STREAM).*START/i },
+    ]);
+    assert.equal(result, streamStarted, "should preserve symbol identifiers for registration");
+});


### PR DESCRIPTION
## Summary
- update the SillyTavern integration resolver to return symbol-valued event identifiers so streaming hooks fire again
- add a regression test that exercises symbol-based generation events
- document the restored streaming behaviour in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691169a80f288325bee599207df3e190)