### PR TITLE
Fix pattern slot auto-save regression and restore panel glows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - **Scene panel hide toggle.** Hiding the command center now removes the panel entirely so no translucent shell remains on screen.
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
+- **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.
+- **Scene panel glow overflow.** The aurora backdrop and interactive button glows now render without being clipped by the panel frame.
 
 ## v3.5.0
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ import {
     normalizePatternSlot,
     preparePatternSlotsForSave,
     flattenPatternSlots,
+    reconcilePatternSlotReferences,
 } from "./profile-utils.js";
 import {
     setScenePanelContainer,
@@ -4138,6 +4139,10 @@ function commitProfileChanges({
     const normalized = normalizeProfile(saveCurrentProfileData(), PROFILE_DEFAULTS);
     const mappings = Array.isArray(normalized.mappings) ? normalized.mappings : [];
     mappings.forEach(ensureMappingCardId);
+    if (Array.isArray(normalized.patternSlots)) {
+        const existingSlots = Array.isArray(profile.patternSlots) ? profile.patternSlots : [];
+        normalized.patternSlots = reconcilePatternSlotReferences(existingSlots, normalized.patternSlots);
+    }
     Object.assign(profile, normalized);
     profile.mappings = mappings;
     if (recompile) {

--- a/style.css
+++ b/style.css
@@ -1482,7 +1482,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     border-radius: 16px;
     box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
     color: var(--SmartThemeBodyColor, #f3f3f3);
-    overflow: hidden;
+    overflow: visible;
     backdrop-filter: blur(16px);
     z-index: 1040;
     isolation: isolate;
@@ -1492,6 +1492,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     content: "";
     position: absolute;
     inset: 0;
+    border-radius: inherit;
     background:
         radial-gradient(circle at 20% -10%, rgba(151, 109, 255, 0.28), transparent 55%),
         radial-gradient(circle at 110% 20%, rgba(64, 207, 255, 0.25), transparent 50%);
@@ -1517,7 +1518,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     gap: 16px;
     padding: 20px;
     height: 100%;
-    overflow: hidden;
+    overflow: visible;
 }
 
 .cs-scene-panel__sections {

--- a/test/profile-utils.test.js
+++ b/test/profile-utils.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    normalizePatternSlot,
+    preparePatternSlotsForSave,
+    reconcilePatternSlotReferences,
+} from '../profile-utils.js';
+
+test('reconcilePatternSlotReferences reuses existing slot objects and updates fields', () => {
+    const existingSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al'] });
+    Object.defineProperty(existingSlot, '__slotId', {
+        value: 'slot-1',
+        enumerable: false,
+        configurable: true,
+        writable: true,
+    });
+
+    const existingSlots = [existingSlot];
+    const prepared = preparePatternSlotsForSave(existingSlots, new Set());
+    assert.equal(prepared.length, 1);
+
+    const nextSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al', 'Aly'] });
+    Object.defineProperty(nextSlot, '__slotId', {
+        value: 'slot-1',
+        enumerable: false,
+        configurable: true,
+        writable: true,
+    });
+
+    const reconciled = reconcilePatternSlotReferences(existingSlots, [nextSlot]);
+    assert.equal(reconciled[0], existingSlot, 'existing reference should be reused');
+    assert.deepEqual(reconciled[0].aliases, ['Al', 'Aly']);
+    assert.notEqual(reconciled[0].aliases, nextSlot.aliases, 'aliases should be cloned');
+
+    const updatedPrepared = preparePatternSlotsForSave(reconciled, new Set());
+    assert.deepEqual(updatedPrepared[0].aliases, ['Al', 'Aly']);
+});
+
+test('reconcilePatternSlotReferences returns new objects for unseen slots', () => {
+    const existingSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al'] });
+    Object.defineProperty(existingSlot, '__slotId', {
+        value: 'slot-1',
+        enumerable: false,
+        configurable: true,
+        writable: true,
+    });
+
+    const newSlot = normalizePatternSlot({ name: 'Bob', aliases: ['Bobby'] });
+    Object.defineProperty(newSlot, '__slotId', {
+        value: 'slot-2',
+        enumerable: false,
+        configurable: true,
+        writable: true,
+    });
+
+    const reconciled = reconcilePatternSlotReferences([existingSlot], [newSlot]);
+    assert.notEqual(reconciled[0], existingSlot, 'new slot should not reuse unrelated reference');
+    assert.equal(reconciled[0], newSlot, 'new slot should be returned as provided');
+});


### PR DESCRIPTION
## Summary
- keep pattern slot cards bound to the active profile when committing changes so edits persist after auto-save
- add unit tests around the new pattern slot reconciliation helper
- let the scene panel aurora and button glows render without clipping and document the fixes in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117821e6308325a30bcd5fd34900d7)