### PR TITLE
Remove collapse toggle and contain aurora animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Improved
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
 - **Live log export parity.** Copying the live log now produces a full report with detection summaries, switch analytics, skip reasons, and roster state—matching the fidelity of the live pattern tester output.
+- **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.
@@ -22,7 +23,7 @@
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
 - **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.
-- **Scene panel glow overflow.** The aurora backdrop and interactive button glows now render without being clipped by the panel frame.
+- **Scene panel glow overflow.** The aurora backdrop now animates entirely inside the frame and keeps a generous bleed so no hard edges peek through mid-cycle.
 
 ## v3.5.0
 

--- a/src/ui/scenePanelState.js
+++ b/src/ui/scenePanelState.js
@@ -28,7 +28,11 @@ export function getScenePanelContent() {
 }
 
 export function setSceneCollapseToggle($element) {
-    $sceneCollapseToggle = $element;
+    if ($element && typeof $element.length === "number" && $element.length === 0) {
+        $sceneCollapseToggle = null;
+        return;
+    }
+    $sceneCollapseToggle = $element || null;
 }
 
 export function getSceneCollapseToggle() {

--- a/src/ui/templates/scenePanel.html
+++ b/src/ui/templates/scenePanel.html
@@ -1,8 +1,4 @@
 <div id="cs-scene-panel" class="cs-scene-panel" data-scene-panel-root>
-    <button id="cs-scene-panel-collapse" class="cs-scene-panel__collapse-toggle" type="button" data-scene-panel="collapse-toggle" aria-expanded="true" aria-controls="cs-scene-panel-content" title="Collapse scene roster">
-        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
-        <span class="visually-hidden">Toggle scene panel</span>
-    </button>
     <div id="cs-scene-panel-content" class="cs-scene-panel__content" data-scene-panel="content">
         <header class="cs-scene-panel__header">
             <div class="cs-scene-panel__title">

--- a/style.css
+++ b/style.css
@@ -1482,7 +1482,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     border-radius: 16px;
     box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
     color: var(--SmartThemeBodyColor, #f3f3f3);
-    overflow: visible;
+    overflow: hidden;
     backdrop-filter: blur(16px);
     z-index: 1040;
     isolation: isolate;
@@ -1500,6 +1500,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     pointer-events: none;
     mix-blend-mode: screen;
     animation: cs-scene-panel-aurora 14s ease-in-out infinite alternate;
+    transform-origin: center;
     z-index: -1;
 }
 
@@ -2118,16 +2119,16 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 
 @keyframes cs-scene-panel-aurora {
     0% {
-        transform: translate3d(-6%, -4%, 0) scale(1.05);
-        opacity: 0.6;
+        transform: translate3d(-2%, -1%, 0) scale(1.14);
+        opacity: 0.68;
     }
     50% {
-        transform: translate3d(4%, 2%, 0) scale(1.08);
-        opacity: 0.9;
+        transform: translate3d(2%, 3%, 0) scale(1.2);
+        opacity: 0.92;
     }
     100% {
-        transform: translate3d(-2%, 6%, 0) scale(1.02);
-        opacity: 0.7;
+        transform: translate3d(-1%, 4%, 0) scale(1.15);
+        opacity: 0.75;
     }
 }
 
@@ -2507,41 +2508,6 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     margin-top: 4px;
 }
 
-.cs-scene-panel__collapse-toggle {
-    position: absolute;
-    top: 18px;
-    left: -44px;
-    width: 40px;
-    height: 80px;
-    border-radius: 12px 0 0 12px;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    background: rgba(0, 0, 0, 0.5);
-    color: var(--primary-color, #9c7dff);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease;
-    z-index: 2;
-}
-
-.cs-scene-panel__collapse-toggle:hover,
-.cs-scene-panel__collapse-toggle:focus-visible {
-    background: rgba(255, 255, 255, 0.12);
-    color: var(--SmartThemeBodyColor, #f3f3f3);
-}
-
-.cs-scene-panel__collapse-toggle--notify {
-    animation: cs-scene-panel-toggle-pulse 1.4s ease-in-out 3;
-    color: #ffe9a8;
-    box-shadow: 0 0 0 2px rgba(255, 185, 96, 0.45);
-}
-
-.cs-scene-panel__collapse-toggle--notify i {
-    animation: cs-scene-panel-toggle-wiggle 1.4s ease-in-out 3;
-    text-shadow: 0 0 12px rgba(255, 210, 140, 0.85);
-}
-
 .cs-scene-panel--collapsed,
 .cs-scene-panel[data-cs-collapsed="true"] {
     width: var(--cs-scene-panel-collapsed-width);
@@ -2554,11 +2520,6 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
-}
-
-.cs-scene-panel--collapsed .cs-scene-panel__collapse-toggle i,
-.cs-scene-panel[data-cs-collapsed="true"] .cs-scene-panel__collapse-toggle i {
-    transform: rotate(180deg);
 }
 
 .cs-scene-panel .visually-hidden {
@@ -2581,14 +2542,6 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
         bottom: 16px;
         width: min(380px, 88vw);
         max-height: calc(100vh - calc(var(--topBarBlockSize, 3.25rem) + 28px));
-    }
-
-    .cs-scene-panel__collapse-toggle {
-        left: auto;
-        right: 16px;
-        top: auto;
-        bottom: 16px;
-        border-radius: 12px;
     }
 
     .cs-scene-panel__summon[data-panel-visible="true"] {

--- a/ui/templates/scenePanel.html
+++ b/ui/templates/scenePanel.html
@@ -1,8 +1,4 @@
 <div id="cs-scene-panel" class="cs-scene-panel" data-scene-panel-root>
-    <button id="cs-scene-panel-collapse" class="cs-scene-panel__collapse-toggle" type="button" data-scene-panel="collapse-toggle" aria-expanded="true" aria-controls="cs-scene-panel-content" title="Collapse scene roster">
-        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
-        <span class="visually-hidden">Toggle scene panel</span>
-    </button>
     <div id="cs-scene-panel-content" class="cs-scene-panel__content" data-scene-panel="content">
         <header class="cs-scene-panel__header">
             <div class="cs-scene-panel__headline">


### PR DESCRIPTION
## Summary
- remove the legacy collapse toggle button from the scene panel templates and guard the stored reference when no control exists
- contain the aurora backdrop inside the panel frame and adjust the animation to prevent visible edges
- update the changelog to reflect the layout cleanup and refreshed aurora behavior

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117d4cc45883258679558def606bae)