### PR TITLE
Adjust scene roster scroll behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -1734,6 +1734,15 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     gap: 10px;
 }
 
+.cs-scene-panel__section[data-scene-panel="roster"] {
+    flex: 0 0 auto;
+}
+
+.cs-scene-panel__section[data-scene-panel="roster"] > .cs-scene-panel__scrollable {
+    max-height: min(420px, 45vh);
+    padding-right: 6px;
+}
+
 .cs-scene-panel__card-list {
     max-height: 260px;
 }


### PR DESCRIPTION
## Summary
- keep the roster section from shrinking by locking its flex sizing
- give the roster list a taller scrollable viewport so it can comfortably hold more entries

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691181b9e5ac83259002371f37ccfcbf)