### PR TITLE
Fix first-stream detection fallback and roster scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **First-stream detection fallback.** Streaming tokens now capture their message key when the generation-start hook fires too early, restoring roster updates for the first outputs after loading a chat.
+- **Scene roster scrolling.** The roster list keeps its scrollbox active so large casts remain accessible without shifting the entire panel.
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.
 - **Scene panel mounting.** Resolving pre-fetched container references no longer breaks roster rendering, fixing the empty panel and console error triggered when the UI initializes.
 - **Scene panel rehydration.** Switching chats or waiting for autosaves now restores the latest assistant message so the roster, active characters, and live log remain populated instead of clearing after a few seconds.

--- a/index.js
+++ b/index.js
@@ -8120,6 +8120,21 @@ const handleStream = (...args) => {
             return;
         }
 
+        if (!state.currentGenerationKey) {
+            let fallbackKey = null;
+            for (const arg of args) {
+                const { key } = parseMessageReference(arg);
+                if (key) {
+                    fallbackKey = key;
+                    break;
+                }
+            }
+            if (fallbackKey) {
+                state.currentGenerationKey = fallbackKey;
+                debugLog(`Adopted ${fallbackKey} as stream key from token payload.`);
+            }
+        }
+
         const profile = getActiveProfile();
         if (!profile) return;
 

--- a/style.css
+++ b/style.css
@@ -1732,10 +1732,12 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     display: flex;
     flex-direction: column;
     gap: 10px;
+    min-height: 0;
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] {
     flex: 0 0 auto;
+    min-height: 0;
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] > .cs-scene-panel__scrollable {


### PR DESCRIPTION
## Summary
- adopt message keys from stream token payloads when the generation start hook is unavailable so the side panel detects the first streamed message after loading a chat
- keep the scene roster list's scroll container responsive and document the fixes in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911858516b08325b54b9c0ec5eef7cd)