### PR TITLE
Fix roster scrollbox height in scene panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -1737,18 +1737,21 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] {
-    flex: 1 1 auto;
+    --cs-scene-roster-scroll-height: 96px;
+    flex: 0 0 auto;
     min-height: 0;
     display: flex;
     flex-direction: column;
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] > .cs-scene-panel__scrollable {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-height: 0;
-    max-height: none;
+    max-height: var(--cs-scene-roster-scroll-height);
     padding-right: 6px;
     overflow-y: auto;
+    scroll-behavior: smooth;
+    scrollbar-gutter: stable both-edges;
 }
 
 .cs-scene-panel__card-list {


### PR DESCRIPTION
## Summary
- constrain the scene roster list to a single-card scroll viewport so entries no longer stretch the panel
- ensure the roster scrollbox maintains spacing and a stable scrollbar gutter when populated

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118e848c808325ba7e0533ce02ec2a)