### PR TITLE
Stabilize scene roster scroll viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 - **First-stream detection fallback.** Streaming tokens now capture their message key when the generation-start hook fires too early, restoring roster updates for the first outputs after loading a chat.
-- **Scene roster scrolling.** The roster list keeps its scrollbox active so large casts remain accessible without shifting the entire panel.
+- **Scene roster scrolling.** The roster list keeps its scrollbox active with a single-card viewport so large casts remain accessible without crushing entry layouts or shifting the entire panel.
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.
 - **Scene panel mounting.** Resolving pre-fetched container references no longer breaks roster rendering, fixing the empty panel and console error triggered when the UI initializes.
 - **Scene panel rehydration.** Switching chats or waiting for autosaves now restores the latest assistant message so the roster, active characters, and live log remain populated instead of clearing after a few seconds.

--- a/style.css
+++ b/style.css
@@ -1737,18 +1737,25 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] {
-    flex: 1 1 auto;
+    --cs-scene-roster-scroll-height: 128px;
+    flex: 0 0 auto;
     min-height: 0;
     display: flex;
     flex-direction: column;
 }
 
 .cs-scene-panel__section[data-scene-panel="roster"] > .cs-scene-panel__scrollable {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     min-height: 0;
-    max-height: none;
+    max-height: var(--cs-scene-roster-scroll-height);
     padding-right: 6px;
     overflow-y: auto;
+    scroll-behavior: smooth;
+    scrollbar-gutter: stable both-edges;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-bottom: 4px;
 }
 
 .cs-scene-panel__card-list {
@@ -1819,6 +1826,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     overflow: hidden;
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
     box-shadow: 0 10px 24px rgba(15, 19, 30, 0.18);
+    flex: 0 0 auto;
 }
 
 .cs-scene-roster__row::before {


### PR DESCRIPTION
## Summary
- expand the roster scroll viewport so a single entry fits without compression
- keep the roster list flex children from shrinking so every card maintains its layout
- document the single-card roster scrollbox behaviour in the changelog

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118e848c808325ba7e0533ce02ec2a)