### PR TITLE
Add coverage suggestions to the scene panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Inline scene roster settings.** The footer button now opens an in-panel settings sheet with quick toggles for auto-open behavior, section visibility, and roster avatars.
 - **Roster expiry counter.** Every roster entry now displays the remaining message count before it expires, making it easy to spot characters that are about to drop from the scene.
 - **Aurora side panel finish.** The roster workspace picked up animated lighting, hover glows, and a responsive section scaffold so the settings footer stays anchored and never falls off-screen.
+- **Coverage suggestions in the scene panel.** Vocabulary guidance from the live tester now appears alongside the roster with quick-add pills that update in real time as chats roll in.
 
 ### Improved
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
@@ -27,6 +28,7 @@
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
 - **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.
 - **Scene panel glow overflow.** The aurora backdrop now animates entirely inside the frame and keeps a generous bleed so no hard edges peek through mid-cycle.
+- **Live tester isolation.** Running pattern simulations no longer injects tester roster data or log events into the side panel.
 
 ## v3.5.0
 

--- a/settings.html
+++ b/settings.html
@@ -317,6 +317,11 @@
                       <span class="cs-toggle-indicator"></span>
                       <span>Live log</span>
                     </label>
+                    <label class="cs-toggle cs-toggle--inline" title="Show or hide the coverage suggestions inside the scene panel.">
+                      <input id="cs-scene-section-coverage" type="checkbox" data-change-notice="Coverage suggestions section will be toggled in the panel." />
+                      <span class="cs-toggle-indicator"></span>
+                      <span>Coverage</span>
+                    </label>
                   </div>
                   <small class="cs-helper-text">Experimental: The scene panel mirrors the live tester timeline for actual chat replies and may evolve as we refine it.</small>
                 </div>

--- a/src/ui/render/coverage.js
+++ b/src/ui/render/coverage.js
@@ -1,0 +1,80 @@
+import {
+    resolveContainer,
+    clearContainer,
+    createElement,
+} from "./utils.js";
+
+function renderPlaceholder(target, message, tone = "muted") {
+    const container = resolveContainer(target);
+    if (!container.$ && !container.el) {
+        return;
+    }
+    clearContainer(container);
+    const wrapper = createElement("div", "cs-scene-panel__placeholder");
+    if (!wrapper) {
+        return;
+    }
+    if (tone) {
+        wrapper.dataset.tone = tone;
+    }
+    wrapper.textContent = message;
+    if (container.$ && typeof container.$.append === "function") {
+        container.$.append(wrapper);
+    } else if (container.el) {
+        container.el.appendChild(wrapper);
+    }
+}
+
+function renderList(target, values = [], type, { hasBuffer }) {
+    const container = resolveContainer(target);
+    if (!container.$ && !container.el) {
+        return;
+    }
+    clearContainer(container);
+    if (!Array.isArray(values) || values.length === 0) {
+        const message = hasBuffer
+            ? "No gaps detected."
+            : "Awaiting an assistant message.";
+        renderPlaceholder(container, message);
+        return;
+    }
+    const list = createElement("div", "cs-coverage-list");
+    if (!list) {
+        return;
+    }
+    values.forEach((value) => {
+        if (typeof value !== "string" || !value.trim()) {
+            return;
+        }
+        const pill = createElement("button", "cs-coverage-pill");
+        if (!pill) {
+            return;
+        }
+        pill.type = "button";
+        pill.dataset.type = type;
+        pill.dataset.value = value;
+        pill.textContent = value;
+        list.appendChild(pill);
+    });
+    if (container.$ && typeof container.$.append === "function") {
+        container.$.append(list);
+    } else if (container.el) {
+        container.el.appendChild(list);
+    }
+}
+
+export function renderCoverageSuggestions(targets = {}, panelState = {}) {
+    const coverage = panelState.coverage || {};
+    const hasBuffer = typeof panelState.analytics?.buffer === "string"
+        ? panelState.analytics.buffer.trim().length > 0
+        : false;
+    const wrapper = resolveContainer(targets.section);
+    if (wrapper.el) {
+        wrapper.el.setAttribute("data-has-content", hasBuffer ? "true" : "false");
+    } else if (wrapper.$ && typeof wrapper.$.attr === "function") {
+        wrapper.$.attr("data-has-content", hasBuffer ? "true" : "false");
+    }
+    renderList(targets.pronouns, coverage.missingPronouns, "pronoun", { hasBuffer });
+    renderList(targets.attribution, coverage.missingAttributionVerbs, "attribution", { hasBuffer });
+    renderList(targets.action, coverage.missingActionVerbs, "action", { hasBuffer });
+}

--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -8,10 +8,15 @@ import {
     getSceneActiveSection,
     getSceneLiveLogSection,
     getSceneStatusText,
+    getSceneCoverageSection,
+    getSceneCoveragePronouns,
+    getSceneCoverageAttribution,
+    getSceneCoverageAction,
 } from "../scenePanelState.js";
 import { renderSceneRoster } from "./sceneRoster.js";
 import { renderActiveCharacters } from "./activeCharacters.js";
 import { renderLiveLog } from "./liveLog.js";
+import { renderCoverageSuggestions } from "./coverage.js";
 import { resolveContainer, clearContainer, createElement } from "./utils.js";
 
 let scenePanelSummonButton = null;
@@ -215,10 +220,12 @@ export function renderScenePanel(panelState = {}) {
     const showRoster = enabled && sections.roster !== false;
     const showActive = enabled && sections.activeCharacters !== false;
     const showLog = enabled && sections.liveLog !== false;
+    const showCoverage = enabled && sections.coverage !== false;
 
     applySectionVisibility(getSceneRosterSection?.(), showRoster);
     applySectionVisibility(getSceneActiveSection?.(), showActive);
     applySectionVisibility(getSceneLiveLogSection?.(), showLog);
+    applySectionVisibility(getSceneCoverageSection?.(), showCoverage);
 
     updateToolbarToggleState("cs-scene-panel-toggle", enabled, {
         pressedTitle: "Hide scene panel",
@@ -235,6 +242,10 @@ export function renderScenePanel(panelState = {}) {
     updateToolbarToggleState("cs-scene-section-toggle-log", showLog, {
         pressedTitle: "Hide live log section",
         unpressedTitle: "Show live log section",
+    });
+    updateToolbarToggleState("cs-scene-section-toggle-coverage", showCoverage, {
+        pressedTitle: "Hide coverage suggestions section",
+        unpressedTitle: "Show coverage suggestions section",
     });
     updateToolbarToggleState("cs-scene-panel-toggle-auto-open", settings.autoOpenOnResults !== false, {
         pressedTitle: "Disable auto-open on new results",
@@ -260,5 +271,28 @@ export function renderScenePanel(panelState = {}) {
         renderLiveLog(liveLogTarget, panelState);
     } else if (liveLogTarget) {
         clearContainer(liveLogTarget);
+    }
+
+    const coverageSection = getSceneCoverageSection?.();
+    const coveragePronouns = getSceneCoveragePronouns?.();
+    const coverageAttribution = getSceneCoverageAttribution?.();
+    const coverageAction = getSceneCoverageAction?.();
+    if (coverageSection && showCoverage) {
+        renderCoverageSuggestions({
+            section: coverageSection,
+            pronouns: coveragePronouns,
+            attribution: coverageAttribution,
+            action: coverageAction,
+        }, panelState);
+    } else {
+        if (coveragePronouns) {
+            clearContainer(coveragePronouns);
+        }
+        if (coverageAttribution) {
+            clearContainer(coverageAttribution);
+        }
+        if (coverageAction) {
+            clearContainer(coverageAction);
+        }
     }
 }

--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -266,16 +266,6 @@ function mergeRosterData(scene, membership, testers, now) {
                 return;
             }
             testerMap.set(normalized, entry);
-            if (!map.has(normalized)) {
-                map.set(normalized, {
-                    name: entry.name || normalized,
-                    normalized,
-                    joinedAt: Number.isFinite(entry.updatedAt) ? entry.updatedAt : null,
-                    lastSeenAt: Number.isFinite(entry.updatedAt) ? entry.updatedAt : null,
-                    lastLeftAt: null,
-                    active: Boolean(entry.activeInRoster),
-                });
-            }
         });
     }
 

--- a/src/ui/scenePanelState.js
+++ b/src/ui/scenePanelState.js
@@ -10,6 +10,10 @@ let $sceneRosterSection = null;
 let $sceneActiveSection = null;
 let $sceneLogSection = null;
 let $sceneStatusText = null;
+let $sceneCoverageSection = null;
+let $sceneCoveragePronouns = null;
+let $sceneCoverageAttribution = null;
+let $sceneCoverageAction = null;
 
 export function setScenePanelContainer($element) {
     $scenePanelContainer = $element;
@@ -93,6 +97,38 @@ export function setSceneLiveLogSection($element) {
 
 export function getSceneLiveLogSection() {
     return $sceneLogSection;
+}
+
+export function setSceneCoverageSection($element) {
+    $sceneCoverageSection = $element;
+}
+
+export function getSceneCoverageSection() {
+    return $sceneCoverageSection;
+}
+
+export function setSceneCoveragePronouns($element) {
+    $sceneCoveragePronouns = $element;
+}
+
+export function getSceneCoveragePronouns() {
+    return $sceneCoveragePronouns;
+}
+
+export function setSceneCoverageAttribution($element) {
+    $sceneCoverageAttribution = $element;
+}
+
+export function getSceneCoverageAttribution() {
+    return $sceneCoverageAttribution;
+}
+
+export function setSceneCoverageAction($element) {
+    $sceneCoverageAction = $element;
+}
+
+export function getSceneCoverageAction() {
+    return $sceneCoverageAction;
 }
 
 export function setSceneFooterButton($element) {

--- a/src/ui/templates/scenePanel.html
+++ b/src/ui/templates/scenePanel.html
@@ -30,6 +30,10 @@
                     <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
                     <span class="visually-hidden">Toggle live log section</span>
                 </button>
+                <button id="cs-scene-section-toggle-coverage" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-coverage" aria-pressed="true" title="Hide coverage suggestions section">
+                    <i class="fa-solid fa-language" aria-hidden="true"></i>
+                    <span class="visually-hidden">Toggle coverage suggestions section</span>
+                </button>
                 <button id="cs-scene-refresh" class="cs-scene-panel__icon-button" type="button" data-scene-panel="refresh">
                     <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                     <span class="visually-hidden">Refresh roster</span>
@@ -74,6 +78,31 @@
                 </header>
                 <div id="cs-scene-live-log" class="cs-scene-panel__log" data-scene-panel="log-viewport">
                     <!-- Live detection results will be appended here -->
+                </div>
+            </section>
+            <section class="cs-scene-panel__section" data-scene-panel="coverage">
+                <header class="cs-scene-panel__section-header">
+                    <h4>Coverage suggestions</h4>
+                </header>
+                <div class="cs-coverage-panel" data-scene-panel="coverage-container">
+                    <div>
+                        <h5>Pronouns</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-pronouns">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                        </div>
+                    </div>
+                    <div>
+                        <h5>Attribution verbs</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-attribution">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                        </div>
+                    </div>
+                    <div>
+                        <h5>Action verbs</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-action">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                        </div>
+                    </div>
                 </div>
             </section>
         </div>

--- a/style.css
+++ b/style.css
@@ -1758,6 +1758,43 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     padding-bottom: 4px;
 }
 
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-panel {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-panel h5 {
+    margin: 0 0 4px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-pill {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-color);
+    border-radius: 999px;
+    padding: 4px 12px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-pill:hover,
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-pill:focus-visible {
+    background: color-mix(in srgb, var(--accent) 30%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    transform: translateY(-1px);
+}
+
 .cs-scene-panel__card-list {
     max-height: 260px;
 }

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -298,7 +298,7 @@ test("collectScenePanelState analytics updatedAt reflects latest scene activity"
 
     state.recentDecisionEvents = [];
     const panelWithoutEvents = collectScenePanelState();
-    assert.equal(panelWithoutEvents.analytics.updatedAt, testerTimestamp);
+    assert.equal(panelWithoutEvents.analytics.updatedAt, rankingTimestamp);
 });
 
 test("collectScenePanelState defers stream switch until new data is available", () => {


### PR DESCRIPTION
## Summary
- add a coverage suggestions section to the scene panel with toolbar and settings toggles
- compute panel coverage from live chat buffers and render quick-add vocabulary pills
- keep live tester output from mutating scene panel analytics and update tests accordingly

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911924e21348325becee3c2af97811d)