### PR TITLE
Fix coverage fallback, skip spam, and roster inactivity in scene panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Coverage fallback in the scene panel.** The side panel now reuses the latest tester coverage analysis when no live buffer is
+  streaming so vocabulary suggestions stay visible between messages.
+- **Skip reason flood control.** Live diagnostics cap repeated skip notices to keep recent switch and veto activity surfaced in
+  the event list.
+- **Roster inactivity detection.** Characters drop to an inactive state when they are missing from the latest detection pass,
+  preventing message counters from stalling at their initial values.
 - **First-stream detection fallback.** Streaming tokens now capture their message key when the generation-start hook fires too early, restoring roster updates for the first outputs after loading a chat.
 - **Scene roster scrolling.** The roster list keeps its scrollbox active so large casts remain accessible without shifting the entire panel.
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.

--- a/index.js
+++ b/index.js
@@ -1529,7 +1529,14 @@ function collectScenePanelState() {
     });
 
     const profileForCoverage = getActiveProfile();
-    const coverage = analyzeCoverageDiagnostics(buffer, profileForCoverage);
+    const hasBufferText = typeof buffer === "string" && buffer.trim().length > 0;
+    let coverage;
+    if (hasBufferText) {
+        coverage = analyzeCoverageDiagnostics(buffer, profileForCoverage);
+    } else {
+        const fallbackCoverage = state.lastTesterReport?.coverage || state.coverageDiagnostics;
+        coverage = cloneCoverageDiagnostics(fallbackCoverage);
+    }
 
     const rankingSource = ranking.length ? ranking : rankingForMessage.slice(0, 4);
     const preparedRanking = rankingSource.map((entry) => {
@@ -5689,6 +5696,18 @@ function analyzeCoverageDiagnostics(text, profile = getActiveProfile()) {
         missingAttributionVerbs: Array.from(missingAttribution).sort(),
         missingActionVerbs: Array.from(missingAction).sort(),
         totalTokens: tokens.length,
+    };
+}
+
+function cloneCoverageDiagnostics(value) {
+    if (!value || typeof value !== "object") {
+        return { missingPronouns: [], missingAttributionVerbs: [], missingActionVerbs: [], totalTokens: 0 };
+    }
+    return {
+        missingPronouns: Array.isArray(value.missingPronouns) ? [...value.missingPronouns] : [],
+        missingAttributionVerbs: Array.isArray(value.missingAttributionVerbs) ? [...value.missingAttributionVerbs] : [],
+        missingActionVerbs: Array.isArray(value.missingActionVerbs) ? [...value.missingActionVerbs] : [],
+        totalTokens: Number.isFinite(value.totalTokens) ? value.totalTokens : 0,
     };
 }
 

--- a/src/ui/render/liveLog.js
+++ b/src/ui/render/liveLog.js
@@ -61,6 +61,29 @@ function renderStatsList(stats, displayNames) {
     return list;
 }
 
+function selectEventsForDisplay(events, { limit = 25, maxSkips = 8 } = {}) {
+    if (!Array.isArray(events) || events.length === 0) {
+        return [];
+    }
+    const selected = [];
+    let skipped = 0;
+    for (let index = events.length - 1; index >= 0 && selected.length < limit; index -= 1) {
+        const event = events[index];
+        if (!event || typeof event !== "object") {
+            continue;
+        }
+        if (event.type === "skipped") {
+            if (skipped >= maxSkips) {
+                continue;
+            }
+            skipped += 1;
+        }
+        selected.push(event);
+    }
+    selected.reverse();
+    return selected;
+}
+
 function renderEvent(entry, displayNames, now) {
     if (!entry || typeof entry !== "object") {
         return null;
@@ -174,7 +197,8 @@ export function renderLiveLog(target, panelState = {}) {
         return;
     }
 
-    events.slice(-25).forEach((event) => {
+    const displayable = selectEventsForDisplay(events, { limit: 25, maxSkips: 8 });
+    displayable.forEach((event) => {
         const item = renderEvent(event, panelState.displayNames, now);
         if (item) {
             list.appendChild(item);

--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -228,6 +228,7 @@ function mergeRosterData(scene, membership, testers, now) {
         });
     }
 
+    const sceneActive = new Set();
     if (scene && Array.isArray(scene.roster)) {
         scene.roster.forEach((entry) => {
             const normalized = normalizeMember(entry);
@@ -247,8 +248,20 @@ function mergeRosterData(scene, membership, testers, now) {
                     ? Math.min(existing.turnsRemaining, normalized.turnsRemaining)
                     : normalized.turnsRemaining;
             }
+            existing.lastLeftAt = null;
+            sceneActive.add(existing.normalized);
             map.set(normalized.normalized, existing);
         });
+    }
+
+    for (const [normalized, entry] of map.entries()) {
+        if (!sceneActive.has(normalized)) {
+            entry.active = false;
+            entry.turnsRemaining = null;
+            if (!Number.isFinite(entry.lastLeftAt) && Number.isFinite(entry.lastSeenAt)) {
+                entry.lastLeftAt = entry.lastSeenAt;
+            }
+        }
     }
 
     const testerMap = new Map();


### PR DESCRIPTION
## Summary
- ensure the scene panel reuses stored tester coverage diagnostics when no live buffer is available so suggestions remain visible
- limit skipped-event spam in the live log to keep recent switches and vetoes in view
- mark roster members inactive when they are absent from the latest detection results and reset their TTL copy

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691196b3c51c83258ae003e2b99d220f)