### PR TITLE
Fix live diagnostics display and coverage section setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -8637,6 +8637,10 @@ async function mountScenePanelTemplate() {
             setSceneActiveSection($existingPanel.find('[data-scene-panel="active-characters"]'));
             setSceneLiveLog($existingPanel.find('[data-scene-panel="log-viewport"]'));
             setSceneLiveLogSection($existingPanel.find('[data-scene-panel="live-log"]'));
+            setSceneCoverageSection($existingPanel.find('[data-scene-panel="coverage"]'));
+            setSceneCoveragePronouns($existingPanel.find('[data-scene-panel="coverage-pronouns"]'));
+            setSceneCoverageAttribution($existingPanel.find('[data-scene-panel="coverage-attribution"]'));
+            setSceneCoverageAction($existingPanel.find('[data-scene-panel="coverage-action"]'));
             setSceneFooterButton($existingPanel.find('[data-scene-panel="open-settings"]'));
             setSceneStatusText($existingPanel.find('[data-scene-panel="status-text"]'));
             initializeScenePanelUI();

--- a/src/ui/render/liveLog.js
+++ b/src/ui/render/liveLog.js
@@ -61,22 +61,18 @@ function renderStatsList(stats, displayNames) {
     return list;
 }
 
-function selectEventsForDisplay(events, { limit = 25, maxSkips = 8 } = {}) {
+function selectEventsForDisplay(events, { limit = 25 } = {}) {
     if (!Array.isArray(events) || events.length === 0) {
         return [];
     }
     const selected = [];
-    let skipped = 0;
     for (let index = events.length - 1; index >= 0 && selected.length < limit; index -= 1) {
         const event = events[index];
         if (!event || typeof event !== "object") {
             continue;
         }
         if (event.type === "skipped") {
-            if (skipped >= maxSkips) {
-                continue;
-            }
-            skipped += 1;
+            continue;
         }
         selected.push(event);
     }
@@ -197,7 +193,7 @@ export function renderLiveLog(target, panelState = {}) {
         return;
     }
 
-    const displayable = selectEventsForDisplay(events, { limit: 25, maxSkips: 8 });
+    const displayable = selectEventsForDisplay(events, { limit: 25 });
     displayable.forEach((event) => {
         const item = renderEvent(event, panelState.displayNames, now);
         if (item) {


### PR DESCRIPTION
## Summary
- filter skipped events out of the live diagnostics feed so only switches remain
- wire existing scene panel instances to the coverage section elements so suggestions render

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119b41ee688325b1a06362e583316b)