### PR TITLE
Fix auto-open to reshow hidden scene panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Scene panel auto-open triggers.** Auto-open on streaming or new results now re-enables the side panel when it was hidden, so updates bring the workspace back instead of staying out of view.
 - **Buffer window trimming.** Streaming keeps matching after the max buffer limit trims older text, so outfit switching and live diagnostics continue instead of stalling at the limit.
 - **Coverage fallback in the scene panel.** The side panel now reuses the latest tester coverage analysis when no live buffer is
   streaming so vocabulary suggestions stay visible between messages.

--- a/index.js
+++ b/index.js
@@ -1303,13 +1303,20 @@ function maybeAutoExpandScenePanel(reason = "result") {
     }
     const settings = getSettings?.();
     const panelSettings = ensureScenePanelSettings(settings || {});
+    const shouldAutoOpen = reason === "stream"
+        ? panelSettings.autoOpenOnStream
+        : panelSettings.autoOpenOnResults;
+
+    if (!shouldAutoOpen) {
+        return;
+    }
+
     if (!panelSettings.enabled) {
-        return;
-    }
-    if (reason === "stream" && !panelSettings.autoOpenOnStream) {
-        return;
-    }
-    if (reason === "result" && !panelSettings.autoOpenOnResults) {
+        panelSettings.enabled = true;
+        updateScenePanelSettingControls(panelSettings);
+        setScenePanelCollapsed(false);
+        requestScenePanelRender("auto-open-enable", { immediate: true });
+        persistSettings(null, "info");
         return;
     }
     if (!isScenePanelCollapsed()) {


### PR DESCRIPTION
## Summary
- re-enable the scene panel when auto-open triggers fire and the panel was previously hidden
- document the auto-open regression fix in the changelog for v3.6.0

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912004538108325b2ec337635460abd)