### PR TITLE
Fix side panel section resizing when modules are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Improved
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
-- **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space whenever you hide a module, so rosters, active cards, and logs stay legible without manual resizing.
+- **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space as soon as any module is hidden, so two-up layouts immediately expand instead of waiting until only a single section remains.
 - **Live log export parity.** Copying the live log now produces a full report with detection summaries, switch analytics, skip reasons, and roster state—matching the fidelity of the live pattern tester output.
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 

--- a/style.css
+++ b/style.css
@@ -1760,10 +1760,16 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 
 .cs-scene-panel__sections[data-sections-expanded="true"] {
     --cs-scene-section-max-height: none;
+    --cs-scene-section-gap-size: 16px;
+    --cs-scene-section-flex-basis: calc(
+        (100% - (var(--cs-scene-visible-section-count, 1) - 1) * var(--cs-scene-section-gap-size, 16px))
+        / var(--cs-scene-visible-section-count, 1)
+    );
 }
 
 .cs-scene-panel__sections[data-sections-expanded="true"] .cs-scene-panel__section {
-    flex: 1 1 0%;
+    flex: 1 1 var(--cs-scene-section-flex-basis);
+    min-height: var(--cs-scene-section-flex-basis);
 }
 
 .cs-scene-panel__sections[data-sections-expanded="true"] .cs-scene-panel__scrollable,


### PR DESCRIPTION
## Summary
- derive the visible section count from the rendered DOM before toggling the expanded layout state
- use a custom flex-basis calculation so remaining sections stretch to fill reclaimed vertical space
- update the changelog entry to reflect the immediate expansion fix

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912048b725c8325808049dc72a4037d)