### PR TITLE
Fix scene roster TTL countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   the event list.
 - **Roster inactivity detection.** Characters drop to an inactive state when they are missing from the latest detection pass,
   preventing message counters from stalling at their initial values.
+- **Scene roster TTL countdown.** Remaining message counters now inherit the previous turn balance, so entries tick down each message instead of freezing at the initial value.
 - **First-stream detection fallback.** Streaming tokens now capture their message key when the generation-start hook fires too early, restoring roster updates for the first outputs after loading a chat.
 - **Scene roster scrolling.** The roster list keeps its scrollbox active so large casts remain accessible without shifting the entire panel.
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -146,6 +146,34 @@ test("handleStream logs focus lock status when locked", () => {
     assert.equal(noticeSnapshot.event.matchKind, "focus-lock");
 });
 
+test("createMessageState carries roster TTL forward between messages", () => {
+    resetSceneState();
+    clearLiveTesterOutputs();
+
+    state.perMessageStates = new Map();
+    state.perMessageBuffers = new Map();
+    state.currentGenerationKey = null;
+
+    const profile = { sceneRosterTTL: 5 };
+    const previousState = {
+        lastSubject: null,
+        pendingSubject: null,
+        pendingSubjectNormalized: null,
+        sceneRoster: new Set(["kotori"]),
+        outfitRoster: new Map([["kotori", { outfit: "casual" }]]),
+        rosterTTL: 3,
+        outfitTTL: 2,
+    };
+
+    state.perMessageStates.set("m0", previousState);
+
+    const newState = __testables.createMessageState(profile, "m1");
+
+    assert.equal(newState.rosterTTL, 2, "roster TTL should decrement from previous message");
+    assert.equal(newState.outfitTTL, 1, "outfit TTL should decrement from previous message");
+    assert.deepEqual(Array.from(newState.sceneRoster), ["kotori"]);
+});
+
 test("handleStream infers message key from token event payloads", () => {
     resetSceneState();
     clearLiveTesterOutputs();


### PR DESCRIPTION
## Summary
- ensure scene roster TTL carries over between messages instead of resetting
- expose the helper for testing and add a regression test for the countdown logic
- document the countdown fix in the changelog for the upcoming release

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912106fbbe4832590208ea7eeaa9a3f)