### PR TITLE
Fix scene roster hover overlay and TTL calculations

### DIFF
--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -205,6 +205,9 @@ function normalizeMember(member) {
     if (!normalized) {
         return null;
     }
+    const turnsRemaining = Number.isFinite(member.turnsRemaining)
+        ? Math.max(0, Math.floor(member.turnsRemaining))
+        : null;
     return {
         name: member.name || normalized,
         normalized,
@@ -212,7 +215,7 @@ function normalizeMember(member) {
         lastSeenAt: Number.isFinite(member.lastSeenAt) ? member.lastSeenAt : null,
         lastLeftAt: Number.isFinite(member.lastLeftAt) ? member.lastLeftAt : null,
         active: Boolean(member.active),
-        turnsRemaining: Number.isFinite(member.turnsRemaining) ? member.turnsRemaining : null,
+        turnsRemaining,
     };
 }
 
@@ -243,10 +246,13 @@ function mergeRosterData(scene, membership, testers, now) {
             if (Number.isFinite(normalized.joinedAt)) {
                 existing.joinedAt = existing.joinedAt || normalized.joinedAt;
             }
-            if (Number.isFinite(normalized.turnsRemaining)) {
-                existing.turnsRemaining = Number.isFinite(existing.turnsRemaining)
-                    ? Math.min(existing.turnsRemaining, normalized.turnsRemaining)
-                    : normalized.turnsRemaining;
+            const normalizedTurns = Number.isFinite(normalized.turnsRemaining)
+                ? Math.max(0, Math.floor(normalized.turnsRemaining))
+                : null;
+            if (normalizedTurns != null) {
+                existing.turnsRemaining = normalizedTurns;
+            } else if (!Number.isFinite(existing.turnsRemaining)) {
+                existing.turnsRemaining = null;
             }
             existing.lastLeftAt = null;
             sceneActive.add(existing.normalized);

--- a/style.css
+++ b/style.css
@@ -1887,6 +1887,8 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     border: 1px solid rgba(255, 255, 255, 0.04);
     position: relative;
     overflow: hidden;
+    isolation: isolate;
+    z-index: 0;
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
     box-shadow: 0 10px 24px rgba(15, 19, 30, 0.18);
     flex: 0 0 auto;
@@ -1902,6 +1904,12 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     transform: translateY(60%);
     transition: opacity 0.35s ease, transform 0.35s ease;
     pointer-events: none;
+    z-index: 0;
+}
+
+.cs-scene-roster__row > * {
+    position: relative;
+    z-index: 1;
 }
 
 .cs-scene-roster__row:hover,


### PR DESCRIPTION
## Summary
- ensure roster rows create their own stacking context so the hover gradient renders above the card background
- normalize roster membership TTL values and keep existing counts when new data omits turns remaining information

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69137a3f04c08325b88a46f57b4855fd)