### PR TITLE
Add organic flow animation to header card

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -7,6 +7,16 @@
     <div class="inline-drawer-content">
       <div class="cs-shell">
     <section class="cs-card cs-header-card">
+      <div class="cs-header-ambient organic-flow" aria-hidden="true">
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+        <div class="flow-element"></div>
+      </div>
       <div class="cs-header-intro">
         <h2 class="cs-title">Costume Switcher</h2>
       </div>

--- a/style.css
+++ b/style.css
@@ -549,11 +549,23 @@
   align-items: stretch;
   gap: 20px;
   padding: 20px 24px;
-  background: linear-gradient(135deg, rgba(108, 92, 231, 0.26), rgba(46, 213, 115, 0.18));
-  background: linear-gradient(135deg,
-      color-mix(in srgb, var(--accent) 35%, transparent),
-      color-mix(in srgb, var(--accent-secondary) 24%, transparent));
+  min-height: clamp(220px, 28vw, 280px);
+  background: linear-gradient(135deg, #1a2a3a, #2d1b3d, #3d2b4d);
   color: var(--header-text);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-intro,
+#costume-switcher-settings.cs-theme .cs-header-meta {
+  position: relative;
+  z-index: 3;
 }
 
 #costume-switcher-settings.cs-theme .cs-tabs {
@@ -626,6 +638,114 @@
 
 #costume-switcher-settings.cs-theme .cs-header-card::before {
   border-color: rgba(255, 255, 255, 0.18);
+  z-index: 2;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element {
+  position: absolute;
+  border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+  background: linear-gradient(45deg, rgba(255, 255, 255, 0.15), transparent);
+  animation: organic-morph 8s infinite ease-in-out;
+  opacity: 0.7;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element::before {
+  content: "";
+  position: absolute;
+  inset: 20%;
+  background: inherit;
+  border-radius: inherit;
+  animation: organic-morph-inner 6s infinite ease-in-out reverse;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(1) {
+  width: clamp(220px, 32vw, 360px);
+  height: clamp(220px, 32vw, 360px);
+  top: -18%;
+  left: -14%;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(2) {
+  width: clamp(180px, 28vw, 320px);
+  height: clamp(180px, 28vw, 320px);
+  top: -26%;
+  left: 54%;
+  animation-delay: -2s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(3) {
+  width: clamp(160px, 22vw, 280px);
+  height: clamp(160px, 22vw, 280px);
+  top: 46%;
+  left: -12%;
+  animation-delay: -4s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(4) {
+  width: clamp(200px, 26vw, 320px);
+  height: clamp(200px, 26vw, 320px);
+  top: 40%;
+  left: 52%;
+  animation-delay: -6s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(5) {
+  width: clamp(140px, 20vw, 240px);
+  height: clamp(140px, 20vw, 240px);
+  top: 12%;
+  left: 20%;
+  animation-delay: -3s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(6) {
+  width: clamp(160px, 24vw, 260px);
+  height: clamp(160px, 24vw, 260px);
+  top: 68%;
+  left: 74%;
+  animation-delay: -5s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(7) {
+  width: clamp(120px, 18vw, 220px);
+  height: clamp(120px, 18vw, 220px);
+  top: 22%;
+  left: 78%;
+  animation-delay: -1s;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element:nth-child(8) {
+  width: clamp(120px, 18vw, 200px);
+  height: clamp(120px, 18vw, 200px);
+  top: 76%;
+  left: 18%;
+  animation-delay: -7s;
+}
+
+@keyframes organic-morph {
+  0%,
+  100% {
+    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+    transform: translate(0, 0) scale(1) rotate(0deg);
+  }
+  33% {
+    border-radius: 70% 30% 40% 60% / 60% 40% 50% 40%;
+    transform: translate(50px, -30px) scale(1.2) rotate(120deg);
+  }
+  66% {
+    border-radius: 30% 70% 60% 40% / 50% 60% 40% 60%;
+    transform: translate(-30px, 50px) scale(0.8) rotate(240deg);
+  }
+}
+
+@keyframes organic-morph-inner {
+  0%,
+  100% {
+    border-radius: inherit;
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.3);
+  }
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro {


### PR DESCRIPTION
## Summary
- replace the settings header card gradient with the Organic Flow animated theme
- inject the animated flow element container into the header markup
- port the Organic Flow styling and keyframes with responsive sizing for the header layout

## Testing
- Not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139abdba808325a42c27d67c1ce1e9)