### PR TITLE
Reduce organic flow header element sizing

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -7,6 +7,7 @@
     <div class="inline-drawer-content">
       <div class="cs-shell">
     <section class="cs-card cs-header-card">
+      <div class="cs-header-ambient organic-flow" aria-hidden="true"></div>
       <div class="cs-header-intro">
         <h2 class="cs-title">Costume Switcher</h2>
       </div>
@@ -628,3 +629,61 @@
     </div>
   </div>
 </div>
+
+<script>
+    (function generateOrganicFlowAmbient() {
+        const ambient = document.querySelector("#costume-switcher-settings.cs-theme .cs-header-ambient");
+
+        if (!ambient || ambient.dataset.flowInitialized === "true") {
+            return;
+        }
+
+        ambient.dataset.flowInitialized = "true";
+
+        const randomBetween = (min, max) => Math.random() * (max - min) + min;
+        const flowCount = 8;
+        let resizeFrameId = 0;
+
+        const populateAmbient = () => {
+            ambient.innerHTML = "";
+
+            const { width, height } = ambient.getBoundingClientRect();
+            const fallbackMetrics = ambient.parentElement?.getBoundingClientRect() ?? { width: 640, height: 240 };
+            const effectiveWidth = width || fallbackMetrics.width || 640;
+            const effectiveHeight = height || fallbackMetrics.height || 240;
+            const minSize = Math.max(90, Math.min(effectiveHeight * 0.45, effectiveWidth * 0.28));
+            const maxSize = Math.max(130, Math.min(effectiveHeight * 0.65, effectiveWidth * 0.38));
+
+            for (let index = 0; index < flowCount; index += 1) {
+                const flow = document.createElement("div");
+                flow.className = "flow-element";
+
+                const size = randomBetween(minSize, maxSize);
+                flow.style.width = `${size}px`;
+                flow.style.height = `${size}px`;
+                flow.style.left = `${randomBetween(5, 95)}%`;
+                flow.style.top = `${randomBetween(-5, 105)}%`;
+                flow.style.animationDelay = `${randomBetween(0, 8)}s`;
+
+                ambient.appendChild(flow);
+            }
+        };
+
+        const schedulePopulate = () => {
+            if (resizeFrameId) {
+                cancelAnimationFrame(resizeFrameId);
+            }
+
+            resizeFrameId = requestAnimationFrame(populateAmbient);
+        };
+
+        populateAmbient();
+
+        if (typeof ResizeObserver === "function") {
+            const observer = new ResizeObserver(schedulePopulate);
+            observer.observe(ambient);
+        } else {
+            window.addEventListener("resize", schedulePopulate, { passive: true });
+        }
+    })();
+</script>

--- a/style.css
+++ b/style.css
@@ -545,15 +545,31 @@
 }
 
 #costume-switcher-settings.cs-theme .cs-header-card {
-  flex-direction: row;
-  align-items: stretch;
-  gap: 20px;
-  padding: 20px 24px;
-  background: linear-gradient(135deg, rgba(108, 92, 231, 0.26), rgba(46, 213, 115, 0.18));
-  background: linear-gradient(135deg,
-      color-mix(in srgb, var(--accent) 35%, transparent),
-      color-mix(in srgb, var(--accent-secondary) 24%, transparent));
-  color: var(--header-text);
+    flex-direction: row;
+    align-items: stretch;
+    gap: 20px;
+    padding: 20px 24px;
+    min-height: clamp(220px, 28vw, 280px);
+    background: transparent;
+    color: var(--header-text);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient.organic-flow {
+    background: linear-gradient(135deg, #1a2a3a, #2d1b3d, #3d2b4d);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-intro,
+#costume-switcher-settings.cs-theme .cs-header-meta {
+  position: relative;
+  z-index: 3;
 }
 
 #costume-switcher-settings.cs-theme .cs-tabs {
@@ -626,6 +642,51 @@
 
 #costume-switcher-settings.cs-theme .cs-header-card::before {
   border-color: rgba(255, 255, 255, 0.18);
+  z-index: 2;
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element {
+    position: absolute;
+    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+    background: linear-gradient(45deg, rgba(255, 255, 255, 0.15), transparent);
+    animation: organic-morph 8s infinite ease-in-out;
+    transform: translate(-50%, -50%);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element::before {
+    content: "";
+    position: absolute;
+    inset: 20%;
+    background: inherit;
+    border-radius: inherit;
+    animation: organic-morph-inner 6s infinite ease-in-out reverse;
+}
+
+@keyframes organic-morph {
+  0%,
+  100% {
+    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
+    transform: translate(0, 0) scale(1) rotate(0deg);
+  }
+  33% {
+    border-radius: 70% 30% 40% 60% / 60% 40% 50% 40%;
+    transform: translate(50px, -30px) scale(1.2) rotate(120deg);
+  }
+  66% {
+    border-radius: 30% 70% 60% 40% / 50% 60% 40% 60%;
+    transform: translate(-30px, 50px) scale(0.8) rotate(240deg);
+  }
+}
+
+@keyframes organic-morph-inner {
+  0%,
+  100% {
+    border-radius: inherit;
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.3);
+  }
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro {


### PR DESCRIPTION
## Summary
- base the organic flow ambient element sizing on measured card dimensions with tighter clamps to keep blobs smaller
- limit random placement ranges so the animated blobs stay within the header bounds

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139abdba808325a42c27d67c1ce1e9)