### PR TITLE
Reduce size of header ambient flow blobs

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -641,15 +641,15 @@
         ambient.dataset.flowInitialized = "true";
 
         const randomBetween = (min, max) => Math.random() * (max - min) + min;
-        const flowCount = 8;
+        const flowCount = 6;
         let resizeFrameId = 0;
 
         const populateAmbient = () => {
             ambient.innerHTML = "";
 
             const referenceHeight = ambient.offsetHeight || 240;
-            const minSize = Math.max(referenceHeight * 0.7, 200);
-            const maxSize = Math.max(referenceHeight * 1.2, 340);
+            const minSize = Math.max(referenceHeight * 0.45, 120);
+            const maxSize = Math.max(referenceHeight * 0.75, 180);
 
             for (let index = 0; index < flowCount; index += 1) {
                 const flow = document.createElement("div");
@@ -658,8 +658,8 @@
                 const size = randomBetween(minSize, maxSize);
                 flow.style.width = `${size}px`;
                 flow.style.height = `${size}px`;
-                flow.style.left = `${randomBetween(0, 100)}%`;
-                flow.style.top = `${randomBetween(-10, 110)}%`;
+                flow.style.left = `${randomBetween(5, 95)}%`;
+                flow.style.top = `${randomBetween(-5, 105)}%`;
                 flow.style.animationDelay = `${randomBetween(0, 8)}s`;
 
                 ambient.appendChild(flow);


### PR DESCRIPTION
## Summary
- shrink the generated ambient flow blobs in the header card so they no longer overwhelm the layout
- tweak positioning and quantity of blobs to keep the animation within frame

## Testing
- Not run (UI change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139f2412cc83259cc7b17dad3e0bbf)