### PR TITLE
Shorten header card height

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -641,15 +641,15 @@
         ambient.dataset.flowInitialized = "true";
 
         const randomBetween = (min, max) => Math.random() * (max - min) + min;
-        const flowCount = 8;
+        const flowCount = 6;
         let resizeFrameId = 0;
 
         const populateAmbient = () => {
             ambient.innerHTML = "";
 
             const referenceHeight = ambient.offsetHeight || 240;
-            const minSize = Math.max(referenceHeight * 0.7, 200);
-            const maxSize = Math.max(referenceHeight * 1.2, 340);
+            const minSize = Math.max(referenceHeight * 0.45, 120);
+            const maxSize = Math.max(referenceHeight * 0.75, 180);
 
             for (let index = 0; index < flowCount; index += 1) {
                 const flow = document.createElement("div");
@@ -658,8 +658,8 @@
                 const size = randomBetween(minSize, maxSize);
                 flow.style.width = `${size}px`;
                 flow.style.height = `${size}px`;
-                flow.style.left = `${randomBetween(0, 100)}%`;
-                flow.style.top = `${randomBetween(-10, 110)}%`;
+                flow.style.left = `${randomBetween(5, 95)}%`;
+                flow.style.top = `${randomBetween(-5, 105)}%`;
                 flow.style.animationDelay = `${randomBetween(0, 8)}s`;
 
                 ambient.appendChild(flow);

--- a/style.css
+++ b/style.css
@@ -548,8 +548,8 @@
     flex-direction: row;
     align-items: stretch;
     gap: 20px;
-    padding: 20px 24px;
-    min-height: clamp(220px, 28vw, 280px);
+    padding: 18px 22px;
+    min-height: clamp(180px, 22vw, 230px);
     background: transparent;
     color: var(--header-text);
 }


### PR DESCRIPTION
## Summary
- decrease the header card padding and minimum height so the hero block wastes less space

## Testing
- Not run (UI change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139f2412cc83259cc7b17dad3e0bbf)