### PR TITLE
Stop scene panel refresh on non-assistant chat updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Scene panel idle refresh.** Chat-change hooks now ignore updates that don't alter the latest assistant message, so editing system prompts or sending player chatter no longer clears or replays roster detections.
 - **Scene panel auto-open triggers.** Auto-open on streaming or new results now re-enables the side panel when it was hidden, so updates bring the workspace back instead of staying out of view.
 - **Buffer window trimming.** Streaming keeps matching after the max buffer limit trims older text, so outfit switching and live diagnostics continue instead of stalling at the limit.
 - **Coverage fallback in the scene panel.** The side panel now reuses the latest tester coverage analysis when no live buffer is


### PR DESCRIPTION
## Summary
- track the latest assistant message swipe and digest so scene state knows which outcome is active
- gate chat-change refreshes unless the newest assistant message actually changed, while still allowing forced reloads
- document the scene panel idle refresh fix in the unreleased changelog

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913bbee6b1c832583c05e177e227ef4)