### PR TITLE
Fix scene roster TTL countdown and stop redundant panel refreshes

### DIFF
--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -169,8 +169,10 @@ test("createMessageState carries roster TTL forward between messages", () => {
 
     state.perMessageStates.set("m0", previousState);
 
-    const newState = __testables.createMessageState(profile, "m1");
+    const { state: newState, initialized, rosterCleared } = __testables.createMessageState(profile, "m1");
 
+    assert.equal(initialized, true, "creating a fresh message state should flag initialization");
+    assert.equal(rosterCleared, false, "roster should remain populated when TTL remains positive");
     assert.equal(newState.rosterTTL, 2, "roster TTL should decrement from previous message");
     assert.equal(newState.outfitTTL, 1, "outfit TTL should decrement from previous message");
     assert.deepEqual(Array.from(newState.sceneRoster), ["kotori"]);


### PR DESCRIPTION
## Summary
- ensure message state initialization reuses existing data, normalizes keys, and only clears the roster when TTL actually expires so characters keep their turns
- avoid triggering scene panel renders when a new generation begins and normalize key handling across streaming helpers to prevent user messages from refreshing the roster widgets
- update analytics helpers and tests to cover the new message state metadata and key normalization

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c2f1d8988325a65e712e09632735)