### PR TITLE
Fix scene panel completion triggers and roster activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 - **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.
 - **Scene panel glow overflow.** The aurora backdrop now animates entirely inside the frame and keeps a generous bleed so no hard edges peek through mid-cycle.
 - **Live tester isolation.** Running pattern simulations no longer injects tester roster data or log events into the side panel.
+- **Scene completion gating.** Live tester streams no longer trigger the command center's completion handlers, so roster capture waits for real assistant messages to finish.
+- **Roster activation regression.** Freshly detected characters now mark as active again when they enter the roster instead of staying flagged as inactive.
+- **Manual refresh recovery.** The refresh control reloads the latest assistant outcome so the side panel actually updates instead of simply re-rendering stale data.
 
 ## v3.5.0
 

--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -261,8 +261,13 @@ function mergeRosterData(scene, membership, testers, now) {
     }
 
     for (const [normalized, entry] of map.entries()) {
-        if (!sceneActive.has(normalized)) {
-            entry.active = false;
+        const inScene = sceneActive.has(normalized);
+        if (inScene) {
+            entry.active = true;
+            entry.lastLeftAt = null;
+            continue;
+        }
+        if (!entry.active) {
             entry.turnsRemaining = null;
             if (!Number.isFinite(entry.lastLeftAt) && Number.isFinite(entry.lastSeenAt)) {
                 entry.lastLeftAt = entry.lastSeenAt;


### PR DESCRIPTION
## Summary
- guard the message-finished integration hook so only tracked assistant generations finalize the scene panel
- keep roster entries marked active when membership reports them active instead of forcing them inactive when no scene data arrives
- have the scene panel refresh control reload the latest assistant outcome and document the fixes in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914815a0b5883258131aaeb5524a13c)