### PR TITLE
Fix scene panel roster TTL handling and ignore user generation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
-- **Scene panel user message handling.** User-authored chat updates no longer trigger roster wipes or analytics refreshes, so the control center stays stable while players talk.
+- **Scene panel user message handling.** User-authored chat updates no longer trigger roster wipes or scene panel refreshes, so the control center stays stable and message counters persist while players talk.
 - **Scene panel idle refresh.** Chat-change hooks now ignore updates that don't alter the latest assistant message, so editing system prompts or sending player chatter no longer clears or replays roster detections.
 - **Scene panel auto-open triggers.** Auto-open on streaming or new results now re-enables the side panel when it was hidden, so updates bring the workspace back instead of staying out of view.
 - **Buffer window trimming.** Streaming keeps matching after the max buffer limit trims older text, so outfit switching and live diagnostics continue instead of stalling at the limit.
@@ -27,7 +27,7 @@
   the event list.
 - **Roster inactivity detection.** Characters drop to an inactive state when they are missing from the latest detection pass,
   preventing message counters from stalling at their initial values.
-- **Scene roster TTL countdown.** Remaining message counters now inherit the previous turn balance, so entries tick down each message instead of freezing at the initial value.
+- **Scene roster TTL countdown.** Remaining message counters now inherit their prior balance per character, so each roster entry ticks down independently instead of every slot sharing the same timer.
 - **First-stream detection fallback.** Streaming tokens now capture their message key when the generation-start hook fires too early, restoring roster updates for the first outputs after loading a chat.
 - **Scene roster scrolling.** The roster list keeps its scrollbox active so large casts remain accessible without shifting the entire panel.
 - **Scene panel analytics remapping.** Detection events recorded during streaming now follow the rendered message key, restoring roster/results feeds that previously appeared empty after generation finished.

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -163,7 +163,8 @@ test("createMessageState carries roster TTL forward between messages", () => {
         pendingSubjectNormalized: null,
         sceneRoster: new Set(["kotori"]),
         outfitRoster: new Map([["kotori", { outfit: "casual" }]]),
-        rosterTTL: 3,
+        rosterTurns: new Map([["kotori", 3]]),
+        defaultRosterTTL: 5,
         outfitTTL: 2,
     };
 
@@ -173,7 +174,9 @@ test("createMessageState carries roster TTL forward between messages", () => {
 
     assert.equal(initialized, true, "creating a fresh message state should flag initialization");
     assert.equal(rosterCleared, false, "roster should remain populated when TTL remains positive");
-    assert.equal(newState.rosterTTL, 2, "roster TTL should decrement from previous message");
+    assert.ok(newState.rosterTurns instanceof Map, "roster turns should be tracked per member");
+    assert.equal(newState.rosterTurns.get("kotori"), 2, "roster turns should decrement from previous message");
+    assert.equal(newState.defaultRosterTTL, 5, "default roster TTL should persist from the profile");
     assert.equal(newState.outfitTTL, 1, "outfit TTL should decrement from previous message");
     assert.deepEqual(Array.from(newState.sceneRoster), ["kotori"]);
 });
@@ -300,7 +303,8 @@ test("handleStream records veto phrase and recent events", () => {
         pendingSubjectNormalized: null,
         sceneRoster: new Set(),
         outfitRoster: new Map(),
-        rosterTTL: 5,
+        rosterTurns: new Map(),
+        defaultRosterTTL: 5,
         outfitTTL: 5,
         processedLength: 0,
         lastAcceptedIndex: -1,


### PR DESCRIPTION
## Summary
- prevent the generation-start hook from running for user-authored events so the scene panel no longer wipes the roster on player chat
- track scene roster TTL per member, propagate the counts through streaming, history restore, and stored outcomes, and expose helpers for cloning the map
- update the scene panel changelog entry and adjust the stream window tests for the new per-member countdowns

## Testing
- node --test test/stream-window.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148829d9e08325b9f261ee7a2018c5)