### PR TITLE
Refresh header card ambient with ripple effects

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -631,102 +631,134 @@
 </div>
 
 <script>
-    (function generateOrganicFlowAmbient() {
+    (function initHeaderRippleAmbient() {
         const ambient = document.querySelector("#costume-switcher-settings.cs-theme .cs-header-ambient");
 
-        if (!ambient || ambient.dataset.flowInitialized === "true") {
+        if (!ambient || ambient.dataset.ripplesInitialized === "true") {
             return;
         }
 
-        ambient.dataset.flowInitialized = "true";
+        ambient.dataset.ripplesInitialized = "true";
 
-        const randomBetween = (min, max) => Math.random() * (max - min) + min;
-        const flowCount = 6;
-        let resizeFrameId = 0;
+        ambient.textContent = "";
 
-        const populateAmbient = () => {
-            ambient.innerHTML = "";
+        const rippleBlueprints = [
+            {
+                sizeRatio: 1.35,
+                left: 32,
+                top: 58,
+                duration: 22,
+                delay: 0,
+                scaleStart: 0.52,
+                scaleEnd: 1.4,
+                opacity: 0.58,
+                blur: 12,
+            },
+            {
+                sizeRatio: 1.05,
+                left: 66,
+                top: 44,
+                duration: 18,
+                delay: -7.2,
+                scaleStart: 0.45,
+                scaleEnd: 1.32,
+                opacity: 0.54,
+                blur: 8,
+            },
+            {
+                sizeRatio: 1.6,
+                left: 50,
+                top: 66,
+                duration: 26,
+                delay: -13.4,
+                scaleStart: 0.65,
+                scaleEnd: 1.5,
+                opacity: 0.48,
+                blur: 16,
+            },
+            {
+                sizeRatio: 0.86,
+                left: 26,
+                top: 38,
+                duration: 16,
+                delay: -4.6,
+                scaleStart: 0.38,
+                scaleEnd: 1.2,
+                opacity: 0.62,
+                blur: 6,
+            },
+        ];
 
-            const referenceHeight = ambient.offsetHeight || 240;
-            const minSize = Math.max(referenceHeight * 0.45, 120);
-            const maxSize = Math.max(referenceHeight * 0.75, 180);
-            const placements = [];
+        const sparkBlueprints = [
+            {
+                sizeRatio: 0.6,
+                left: 58,
+                top: 52,
+                duration: 12,
+                delay: -5.5,
+                opacity: 0.55,
+            },
+            {
+                sizeRatio: 0.46,
+                left: 40,
+                top: 36,
+                duration: 10,
+                delay: -8.2,
+                opacity: 0.42,
+            },
+        ];
 
-            const scoreCandidate = (leftPercent, topPercent, influenceRadius) => {
-                if (!placements.length) {
-                    return Infinity;
-                }
+        const ripples = rippleBlueprints.map((blueprint) => {
+            const layer = document.createElement("div");
+            layer.className = "ripple-layer";
+            layer.dataset.sizeRatio = String(blueprint.sizeRatio);
+            layer.style.setProperty("--ripple-left", `${blueprint.left}%`);
+            layer.style.setProperty("--ripple-top", `${blueprint.top}%`);
+            layer.style.setProperty("--ripple-duration", `${blueprint.duration}s`);
+            layer.style.setProperty("--ripple-delay", `${blueprint.delay}s`);
+            layer.style.setProperty("--ripple-scale-start", `${blueprint.scaleStart}`);
+            layer.style.setProperty("--ripple-scale-end", `${blueprint.scaleEnd}`);
+            layer.style.setProperty("--ripple-opacity", `${blueprint.opacity}`);
+            layer.style.setProperty("--ripple-blur", `${blueprint.blur}px`);
+            ambient.appendChild(layer);
+            return { element: layer, blueprint };
+        });
 
-                return placements.reduce((closest, { left, top, influence }) => {
-                    const dx = leftPercent - left;
-                    const dy = topPercent - top;
-                    const distance = Math.hypot(dx, dy);
-                    const bufferedDistance = distance - Math.max(influenceRadius, influence);
-                    return Math.min(closest, bufferedDistance);
-                }, Infinity);
-            };
+        const sparks = sparkBlueprints.map((blueprint) => {
+            const spark = document.createElement("div");
+            spark.className = "ripple-spark";
+            spark.dataset.sizeRatio = String(blueprint.sizeRatio);
+            spark.style.setProperty("--spark-left", `${blueprint.left}%`);
+            spark.style.setProperty("--spark-top", `${blueprint.top}%`);
+            spark.style.setProperty("--spark-duration", `${blueprint.duration}s`);
+            spark.style.setProperty("--spark-delay", `${blueprint.delay}s`);
+            spark.style.setProperty("--spark-opacity", `${blueprint.opacity}`);
+            ambient.appendChild(spark);
+            return { element: spark, blueprint };
+        });
 
-            for (let index = 0; index < flowCount; index += 1) {
-                const flow = document.createElement("div");
-                flow.className = "flow-element";
+        const updateDimensions = () => {
+            const { width, height } = ambient.getBoundingClientRect();
+            const reference = Math.max(width, height, 1);
 
-                const size = randomBetween(minSize, maxSize);
-                flow.style.width = `${size}px`;
-                flow.style.height = `${size}px`;
-                flow.style.animationDelay = `${randomBetween(0, 8)}s`;
+            ripples.forEach(({ element, blueprint }) => {
+                const baseSize = reference * blueprint.sizeRatio;
+                element.style.setProperty("--ripple-size", `${baseSize}px`);
+            });
 
-                const influenceRadius = Math.max(18, (size / Math.max(referenceHeight, 1)) * 55);
-                const maxAttempts = 24;
-                let bestPlacement = null;
-                let bestScore = -Infinity;
-
-                for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-                    const leftPercent = randomBetween(8, 92);
-                    const topPercent = randomBetween(-10, 110);
-                    const score = scoreCandidate(leftPercent, topPercent, influenceRadius);
-
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestPlacement = { leftPercent, topPercent };
-                    }
-
-                    if (score >= influenceRadius) {
-                        break;
-                    }
-                }
-
-                if (!bestPlacement) {
-                    bestPlacement = { leftPercent: randomBetween(12, 88), topPercent: randomBetween(-5, 105) };
-                }
-
-                placements.push({
-                    left: bestPlacement.leftPercent,
-                    top: bestPlacement.topPercent,
-                    influence: influenceRadius,
-                });
-
-                flow.style.left = `${bestPlacement.leftPercent}%`;
-                flow.style.top = `${bestPlacement.topPercent}%`;
-
-                ambient.appendChild(flow);
-            }
+            sparks.forEach(({ element, blueprint }) => {
+                const baseSize = reference * blueprint.sizeRatio;
+                element.style.setProperty("--spark-size", `${baseSize}px`);
+            });
         };
 
-        const schedulePopulate = () => {
-            if (resizeFrameId) {
-                cancelAnimationFrame(resizeFrameId);
-            }
-
-            resizeFrameId = requestAnimationFrame(populateAmbient);
-        };
-
-        populateAmbient();
+        updateDimensions();
 
         if (typeof ResizeObserver === "function") {
-            const observer = new ResizeObserver(schedulePopulate);
+            const observer = new ResizeObserver(updateDimensions);
             observer.observe(ambient);
         } else {
-            window.addEventListener("resize", schedulePopulate, { passive: true });
+            window.addEventListener("resize", updateDimensions, { passive: true });
         }
     })();
 </script>

--- a/style.css
+++ b/style.css
@@ -563,7 +563,7 @@
 }
 
 #costume-switcher-settings.cs-theme .cs-header-ambient.organic-flow {
-    background: linear-gradient(135deg, #1a2a3a, #2d1b3d, #3d2b4d);
+    background: linear-gradient(140deg, rgba(156, 125, 255, 0.32), rgba(64, 180, 255, 0.2));
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro,
@@ -645,48 +645,118 @@
   z-index: 2;
 }
 
-#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element {
-    position: absolute;
-    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
-    background: linear-gradient(45deg, rgba(255, 255, 255, 0.15), transparent);
-    animation: organic-morph 8s infinite ease-in-out;
-    transform: translate(-50%, -50%);
-}
-
-#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element::before {
+#costume-switcher-settings.cs-theme .cs-header-ambient::after {
     content: "";
     position: absolute;
-    inset: 20%;
-    background: inherit;
-    border-radius: inherit;
-    animation: organic-morph-inner 6s infinite ease-in-out reverse;
+    inset: -25% -10% 10% -10%;
+    background: radial-gradient(circle at 30% 40%, rgba(255, 255, 255, 0.22), transparent 62%),
+        radial-gradient(circle at 70% 60%, rgba(126, 213, 255, 0.18), transparent 68%);
+    opacity: 0.8;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    filter: blur(12px);
+    z-index: 1;
 }
 
-@keyframes organic-morph {
-  0%,
-  100% {
-    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
-    transform: translate(0, 0) scale(1) rotate(0deg);
-  }
-  33% {
-    border-radius: 70% 30% 40% 60% / 60% 40% 50% 40%;
-    transform: translate(50px, -30px) scale(1.2) rotate(120deg);
-  }
-  66% {
-    border-radius: 30% 70% 60% 40% / 50% 60% 40% 60%;
-    transform: translate(-30px, 50px) scale(0.8) rotate(240deg);
-  }
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer {
+    position: absolute;
+    width: var(--ripple-size, 320px);
+    height: var(--ripple-size, 320px);
+    left: var(--ripple-left, 50%);
+    top: var(--ripple-top, 50%);
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    overflow: hidden;
+    opacity: var(--ripple-opacity, 0.65);
+    filter: blur(var(--ripple-blur, 0px));
+    mix-blend-mode: screen;
+    animation: ripple-wave var(--ripple-duration, 18s) ease-in-out infinite;
+    animation-delay: var(--ripple-delay, 0s);
 }
 
-@keyframes organic-morph-inner {
-  0%,
-  100% {
-    border-radius: inherit;
-    transform: rotate(0deg) scale(1);
-  }
-  50% {
-    transform: rotate(180deg) scale(1.3);
-  }
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 45%, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0.15) 38%, rgba(255, 255, 255, 0.05) 56%, transparent 72%),
+        radial-gradient(circle at 30% 65%, rgba(120, 205, 255, 0.32), transparent 68%),
+        radial-gradient(circle at 72% 32%, rgba(177, 156, 255, 0.36), transparent 65%);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::after {
+    content: "";
+    position: absolute;
+    inset: -18%;
+    border-radius: 50%;
+    background: conic-gradient(from 180deg at 50% 50%, rgba(255, 255, 255, 0) 0deg, rgba(255, 255, 255, 0.25) 82deg, rgba(255, 255, 255, 0) 160deg, rgba(64, 180, 255, 0.22) 220deg, rgba(255, 255, 255, 0) 360deg);
+    mix-blend-mode: screen;
+    opacity: 0.8;
+    animation: ripple-sheen calc(var(--ripple-duration, 18s) * 1.15) linear infinite;
+    animation-delay: calc(var(--ripple-delay, 0s) * 1.05);
+}
+
+@keyframes ripple-wave {
+    0% {
+        transform: translate(-50%, -50%) scale(var(--ripple-scale-start, 0.45));
+        opacity: 0;
+    }
+    20% {
+        opacity: var(--ripple-opacity, 0.65);
+    }
+    55% {
+        opacity: calc(var(--ripple-opacity, 0.65) + 0.08);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(var(--ripple-scale-end, 1.4));
+        opacity: 0;
+    }
+}
+
+@keyframes ripple-sheen {
+    0% {
+        transform: rotate(0deg) scale(0.92);
+    }
+    50% {
+        transform: rotate(180deg) scale(1);
+    }
+    100% {
+        transform: rotate(360deg) scale(0.92);
+    }
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-spark {
+    position: absolute;
+    width: var(--spark-size, 180px);
+    height: var(--spark-size, 180px);
+    left: var(--spark-left, 52%);
+    top: var(--spark-top, 48%);
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0.12) 48%, transparent 75%);
+    mix-blend-mode: screen;
+    filter: blur(18px);
+    opacity: var(--spark-opacity, 0.5);
+    animation: ripple-sparkle var(--spark-duration, 10s) ease-in-out infinite;
+    animation-delay: var(--spark-delay, 0s);
+}
+
+@keyframes ripple-sparkle {
+    0% {
+        transform: translate(-50%, -50%) scale(0.85);
+        opacity: 0;
+    }
+    25% {
+        opacity: var(--spark-opacity, 0.5);
+    }
+    55% {
+        transform: translate(-48%, -52%) scale(1.05);
+        opacity: calc(var(--spark-opacity, 0.5) * 0.6);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(1.25);
+        opacity: 0;
+    }
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro {


### PR DESCRIPTION
## Summary
- align the header card gradient with the scene control center palette for a consistent hero treatment
- replace the organic blob overlay with layered water ripples and caustic spark highlights
- rebuild the ambient generator to size and animate ripple layers responsively via ResizeObserver

## Testing
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162463a1d4832588381ff7b8fae1f1)