### PR TITLE
Soften header ripples and restore scene gradient

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -631,102 +631,134 @@
 </div>
 
 <script>
-    (function generateOrganicFlowAmbient() {
+    (function initHeaderRippleAmbient() {
         const ambient = document.querySelector("#costume-switcher-settings.cs-theme .cs-header-ambient");
 
-        if (!ambient || ambient.dataset.flowInitialized === "true") {
+        if (!ambient || ambient.dataset.ripplesInitialized === "true") {
             return;
         }
 
-        ambient.dataset.flowInitialized = "true";
+        ambient.dataset.ripplesInitialized = "true";
 
-        const randomBetween = (min, max) => Math.random() * (max - min) + min;
-        const flowCount = 6;
-        let resizeFrameId = 0;
+        ambient.textContent = "";
 
-        const populateAmbient = () => {
-            ambient.innerHTML = "";
+        const rippleBlueprints = [
+            {
+                sizeRatio: 1.28,
+                left: 34,
+                top: 60,
+                duration: 28,
+                delay: 0,
+                scaleStart: 0.48,
+                scaleEnd: 1.34,
+                opacity: 0.4,
+                blur: 14,
+            },
+            {
+                sizeRatio: 1.58,
+                left: 58,
+                top: 46,
+                duration: 36,
+                delay: -12.5,
+                scaleStart: 0.42,
+                scaleEnd: 1.46,
+                opacity: 0.34,
+                blur: 18,
+            },
+            {
+                sizeRatio: 0.9,
+                left: 24,
+                top: 40,
+                duration: 24,
+                delay: -6.8,
+                scaleStart: 0.36,
+                scaleEnd: 1.22,
+                opacity: 0.38,
+                blur: 10,
+            },
+            {
+                sizeRatio: 0.66,
+                left: 70,
+                top: 70,
+                duration: 32,
+                delay: -18,
+                scaleStart: 0.44,
+                scaleEnd: 1.28,
+                opacity: 0.32,
+                blur: 12,
+            },
+        ];
 
-            const referenceHeight = ambient.offsetHeight || 240;
-            const minSize = Math.max(referenceHeight * 0.45, 120);
-            const maxSize = Math.max(referenceHeight * 0.75, 180);
-            const placements = [];
+        const sparkBlueprints = [
+            {
+                sizeRatio: 0.54,
+                left: 60,
+                top: 52,
+                duration: 16,
+                delay: -6.2,
+                opacity: 0.42,
+            },
+            {
+                sizeRatio: 0.38,
+                left: 38,
+                top: 34,
+                duration: 14,
+                delay: -9.6,
+                opacity: 0.28,
+            },
+        ];
 
-            const scoreCandidate = (leftPercent, topPercent, influenceRadius) => {
-                if (!placements.length) {
-                    return Infinity;
-                }
+        const ripples = rippleBlueprints.map((blueprint) => {
+            const layer = document.createElement("div");
+            layer.className = "ripple-layer";
+            layer.dataset.sizeRatio = String(blueprint.sizeRatio);
+            layer.style.setProperty("--ripple-left", `${blueprint.left}%`);
+            layer.style.setProperty("--ripple-top", `${blueprint.top}%`);
+            layer.style.setProperty("--ripple-duration", `${blueprint.duration}s`);
+            layer.style.setProperty("--ripple-delay", `${blueprint.delay}s`);
+            layer.style.setProperty("--ripple-scale-start", `${blueprint.scaleStart}`);
+            layer.style.setProperty("--ripple-scale-end", `${blueprint.scaleEnd}`);
+            layer.style.setProperty("--ripple-opacity", `${blueprint.opacity}`);
+            layer.style.setProperty("--ripple-blur", `${blueprint.blur}px`);
+            ambient.appendChild(layer);
+            return { element: layer, blueprint };
+        });
 
-                return placements.reduce((closest, { left, top, influence }) => {
-                    const dx = leftPercent - left;
-                    const dy = topPercent - top;
-                    const distance = Math.hypot(dx, dy);
-                    const bufferedDistance = distance - Math.max(influenceRadius, influence);
-                    return Math.min(closest, bufferedDistance);
-                }, Infinity);
-            };
+        const sparks = sparkBlueprints.map((blueprint) => {
+            const spark = document.createElement("div");
+            spark.className = "ripple-spark";
+            spark.dataset.sizeRatio = String(blueprint.sizeRatio);
+            spark.style.setProperty("--spark-left", `${blueprint.left}%`);
+            spark.style.setProperty("--spark-top", `${blueprint.top}%`);
+            spark.style.setProperty("--spark-duration", `${blueprint.duration}s`);
+            spark.style.setProperty("--spark-delay", `${blueprint.delay}s`);
+            spark.style.setProperty("--spark-opacity", `${blueprint.opacity}`);
+            ambient.appendChild(spark);
+            return { element: spark, blueprint };
+        });
 
-            for (let index = 0; index < flowCount; index += 1) {
-                const flow = document.createElement("div");
-                flow.className = "flow-element";
+        const updateDimensions = () => {
+            const { width, height } = ambient.getBoundingClientRect();
+            const reference = Math.max(width, height, 1);
 
-                const size = randomBetween(minSize, maxSize);
-                flow.style.width = `${size}px`;
-                flow.style.height = `${size}px`;
-                flow.style.animationDelay = `${randomBetween(0, 8)}s`;
+            ripples.forEach(({ element, blueprint }) => {
+                const baseSize = reference * blueprint.sizeRatio;
+                element.style.setProperty("--ripple-size", `${baseSize}px`);
+            });
 
-                const influenceRadius = Math.max(18, (size / Math.max(referenceHeight, 1)) * 55);
-                const maxAttempts = 24;
-                let bestPlacement = null;
-                let bestScore = -Infinity;
-
-                for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-                    const leftPercent = randomBetween(8, 92);
-                    const topPercent = randomBetween(-10, 110);
-                    const score = scoreCandidate(leftPercent, topPercent, influenceRadius);
-
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestPlacement = { leftPercent, topPercent };
-                    }
-
-                    if (score >= influenceRadius) {
-                        break;
-                    }
-                }
-
-                if (!bestPlacement) {
-                    bestPlacement = { leftPercent: randomBetween(12, 88), topPercent: randomBetween(-5, 105) };
-                }
-
-                placements.push({
-                    left: bestPlacement.leftPercent,
-                    top: bestPlacement.topPercent,
-                    influence: influenceRadius,
-                });
-
-                flow.style.left = `${bestPlacement.leftPercent}%`;
-                flow.style.top = `${bestPlacement.topPercent}%`;
-
-                ambient.appendChild(flow);
-            }
+            sparks.forEach(({ element, blueprint }) => {
+                const baseSize = reference * blueprint.sizeRatio;
+                element.style.setProperty("--spark-size", `${baseSize}px`);
+            });
         };
 
-        const schedulePopulate = () => {
-            if (resizeFrameId) {
-                cancelAnimationFrame(resizeFrameId);
-            }
-
-            resizeFrameId = requestAnimationFrame(populateAmbient);
-        };
-
-        populateAmbient();
+        updateDimensions();
 
         if (typeof ResizeObserver === "function") {
-            const observer = new ResizeObserver(schedulePopulate);
+            const observer = new ResizeObserver(updateDimensions);
             observer.observe(ambient);
         } else {
-            window.addEventListener("resize", schedulePopulate, { passive: true });
+            window.addEventListener("resize", updateDimensions, { passive: true });
         }
     })();
 </script>

--- a/style.css
+++ b/style.css
@@ -1,19 +1,21 @@
 #costume-switcher-settings.cs-theme {
-  --card-radius: 14px;
-  --card-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
-  --card-shadow-soft: 0 6px 18px rgba(0, 0, 0, 0.12);
-  --accent: var(--primary-color, #6c5ce7);
-  --accent-soft: rgba(108, 92, 231, 0.15);
-  --accent-strong: rgba(108, 92, 231, 0.35);
-  --accent-secondary: var(--secondary-color, #2ed573);
-  --danger: var(--red, #e74c3c);
-  --surface: var(--bg1);
-  --surface-soft: var(--bg2);
-  --surface-contrast: var(--bg0);
-  --text-muted: var(--text-color-soft);
-  --text-subtle: var(--text-color-soft-extra, rgba(255, 255, 255, 0.6));
-  --header-text: rgba(248, 249, 255, 0.95);
-  --header-text-subtle: rgba(248, 249, 255, 0.75);
+    --card-radius: 14px;
+    --card-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+    --card-shadow-soft: 0 6px 18px rgba(0, 0, 0, 0.12);
+    --accent: var(--primary-color, #6c5ce7);
+    --accent-soft: rgba(108, 92, 231, 0.15);
+    --accent-strong: rgba(108, 92, 231, 0.35);
+    --accent-secondary: var(--secondary-color, #2ed573);
+    --danger: var(--red, #e74c3c);
+    --surface: var(--bg1);
+    --surface-soft: var(--bg2);
+    --surface-contrast: var(--bg0);
+    --text-muted: var(--text-color-soft);
+    --text-subtle: var(--text-color-soft-extra, rgba(255, 255, 255, 0.6));
+    --header-text: rgba(248, 249, 255, 0.95);
+    --header-text-subtle: rgba(248, 249, 255, 0.75);
+    --cs-hero-gradient: linear-gradient(140deg, rgba(156, 125, 255, 0.48), rgba(64, 180, 255, 0.28));
+    --cs-hero-base: linear-gradient(155deg, rgba(18, 30, 54, 0.94), rgba(15, 24, 44, 0.96));
 }
 
 #costume-switcher-settings.cs-theme .inline-drawer {
@@ -550,7 +552,13 @@
     gap: 20px;
     padding: 18px 22px;
     min-height: clamp(180px, 22vw, 230px);
-    background: transparent;
+    background: var(
+        --cs-hero-gradient,
+        linear-gradient(140deg, rgba(156, 125, 255, 0.48), rgba(64, 180, 255, 0.28))
+    ), var(
+        --cs-hero-base,
+        linear-gradient(155deg, rgba(18, 30, 54, 0.94), rgba(15, 24, 44, 0.96))
+    );
     color: var(--header-text);
 }
 
@@ -563,7 +571,19 @@
 }
 
 #costume-switcher-settings.cs-theme .cs-header-ambient.organic-flow {
-    background: linear-gradient(135deg, #1a2a3a, #2d1b3d, #3d2b4d);
+    background: var(--cs-hero-gradient);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient::before {
+    content: "";
+    position: absolute;
+    inset: -14% -12%;
+    background: radial-gradient(circle at 24% 22%, rgba(132, 176, 255, 0.22), transparent 62%),
+        radial-gradient(circle at 78% 68%, rgba(173, 146, 255, 0.18), transparent 74%);
+    opacity: 0.85;
+    filter: blur(16px);
+    pointer-events: none;
+    z-index: 0;
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro,
@@ -645,48 +665,124 @@
   z-index: 2;
 }
 
-#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element {
-    position: absolute;
-    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
-    background: linear-gradient(45deg, rgba(255, 255, 255, 0.15), transparent);
-    animation: organic-morph 8s infinite ease-in-out;
-    transform: translate(-50%, -50%);
-}
-
-#costume-switcher-settings.cs-theme .cs-header-ambient .flow-element::before {
+#costume-switcher-settings.cs-theme .cs-header-ambient::after {
     content: "";
     position: absolute;
-    inset: 20%;
-    background: inherit;
-    border-radius: inherit;
-    animation: organic-morph-inner 6s infinite ease-in-out reverse;
+    inset: -18% -8% 16% -8%;
+    background: radial-gradient(circle at 32% 36%, rgba(255, 255, 255, 0.2), transparent 60%),
+        radial-gradient(circle at 74% 62%, rgba(114, 205, 255, 0.16), transparent 68%);
+    opacity: 0.55;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    filter: blur(14px);
+    z-index: 2;
 }
 
-@keyframes organic-morph {
-  0%,
-  100% {
-    border-radius: 40% 60% 70% 30% / 40% 50% 60% 50%;
-    transform: translate(0, 0) scale(1) rotate(0deg);
-  }
-  33% {
-    border-radius: 70% 30% 40% 60% / 60% 40% 50% 40%;
-    transform: translate(50px, -30px) scale(1.2) rotate(120deg);
-  }
-  66% {
-    border-radius: 30% 70% 60% 40% / 50% 60% 40% 60%;
-    transform: translate(-30px, 50px) scale(0.8) rotate(240deg);
-  }
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer {
+    position: absolute;
+    width: var(--ripple-size, 320px);
+    height: var(--ripple-size, 320px);
+    left: var(--ripple-left, 50%);
+    top: var(--ripple-top, 50%);
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    overflow: hidden;
+    opacity: var(--ripple-opacity, 0.45);
+    filter: blur(var(--ripple-blur, 0px));
+    mix-blend-mode: screen;
+    animation: ripple-wave var(--ripple-duration, 18s) ease-in-out infinite;
+    animation-delay: var(--ripple-delay, 0s);
+    z-index: 3;
+    will-change: transform, opacity;
 }
 
-@keyframes organic-morph-inner {
-  0%,
-  100% {
-    border-radius: inherit;
-    transform: rotate(0deg) scale(1);
-  }
-  50% {
-    transform: rotate(180deg) scale(1.3);
-  }
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: radial-gradient(circle at 52% 46%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 38%, rgba(255, 255, 255, 0.03) 56%, transparent 74%),
+        radial-gradient(circle at 28% 68%, rgba(128, 205, 255, 0.18), transparent 70%),
+        radial-gradient(circle at 74% 34%, rgba(173, 156, 255, 0.2), transparent 68%);
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::after {
+    content: "";
+    position: absolute;
+    inset: -18%;
+    border-radius: 50%;
+    background: conic-gradient(from 190deg at 50% 50%, rgba(255, 255, 255, 0) 0deg, rgba(255, 255, 255, 0.18) 78deg, rgba(255, 255, 255, 0) 164deg, rgba(74, 182, 255, 0.18) 230deg, rgba(255, 255, 255, 0) 360deg);
+    mix-blend-mode: screen;
+    opacity: 0.38;
+    animation: ripple-sheen calc(var(--ripple-duration, 18s) * 1.2) linear infinite;
+    animation-delay: calc(var(--ripple-delay, 0s) * 1.05);
+}
+
+@keyframes ripple-wave {
+    0% {
+        transform: translate(-50%, -50%) scale(var(--ripple-scale-start, 0.45));
+        opacity: 0;
+    }
+    18% {
+        opacity: var(--ripple-opacity, 0.45);
+    }
+    48% {
+        opacity: calc(var(--ripple-opacity, 0.45) + 0.02);
+    }
+    78% {
+        opacity: calc(var(--ripple-opacity, 0.45) * 0.4);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(var(--ripple-scale-end, 1.4));
+        opacity: 0;
+    }
+}
+
+@keyframes ripple-sheen {
+    0% {
+        transform: rotate(0deg) scale(0.92);
+    }
+    50% {
+        transform: rotate(180deg) scale(1);
+    }
+    100% {
+        transform: rotate(360deg) scale(0.92);
+    }
+}
+
+#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-spark {
+    position: absolute;
+    width: var(--spark-size, 180px);
+    height: var(--spark-size, 180px);
+    left: var(--spark-left, 52%);
+    top: var(--spark-top, 48%);
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.26) 0%, rgba(255, 255, 255, 0.08) 48%, transparent 75%);
+    mix-blend-mode: screen;
+    filter: blur(16px);
+    opacity: var(--spark-opacity, 0.35);
+    animation: ripple-sparkle var(--spark-duration, 10s) ease-in-out infinite;
+    animation-delay: var(--spark-delay, 0s);
+    z-index: 4;
+}
+
+@keyframes ripple-sparkle {
+    0% {
+        transform: translate(-50%, -50%) scale(0.85);
+        opacity: 0;
+    }
+    25% {
+        opacity: var(--spark-opacity, 0.35);
+    }
+    55% {
+        transform: translate(-48%, -52%) scale(1.05);
+        opacity: calc(var(--spark-opacity, 0.35) * 0.6);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(1.25);
+        opacity: 0;
+    }
 }
 
 #costume-switcher-settings.cs-theme .cs-header-intro {
@@ -1621,7 +1717,13 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     flex: 1 1 auto;
     padding: 14px 16px;
     border-radius: 16px;
-    background: linear-gradient(140deg, rgba(156, 125, 255, 0.32), rgba(64, 180, 255, 0.2));
+    background: var(
+        --cs-hero-gradient,
+        linear-gradient(140deg, rgba(156, 125, 255, 0.48), rgba(64, 180, 255, 0.28))
+    ), var(
+        --cs-hero-base,
+        linear-gradient(155deg, rgba(18, 30, 54, 0.94), rgba(15, 24, 44, 0.96))
+    );
     border: 1px solid rgba(255, 255, 255, 0.16);
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }


### PR DESCRIPTION
## Summary
- reduce the header ripple layer and spark opacities so the water effect is subtler and the gradient shows through
- add fallback gradients for shared hero colors so the scene control center keeps its intended backdrop even outside the settings shell

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162463a1d4832588381ff7b8fae1f1)