### PR TITLE
Soften header nebula overlay to match scene control center

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -631,124 +631,127 @@
 </div>
 
 <script>
-    (function initHeaderRippleAmbient() {
+    (function initHeaderNebulaAmbient() {
         const ambient = document.querySelector("#costume-switcher-settings.cs-theme .cs-header-ambient");
 
-        if (!ambient || ambient.dataset.ripplesInitialized === "true") {
+        if (!ambient || ambient.dataset.nebulaInitialized === "true") {
             return;
         }
 
-        ambient.dataset.ripplesInitialized = "true";
+        ambient.dataset.nebulaInitialized = "true";
 
         ambient.textContent = "";
 
-        const rippleBlueprints = [
+        const cloudBlueprints = [
             {
-                sizeRatio: 1.28,
-                left: 34,
+                sizeRatio: 1.44,
+                left: 30,
                 top: 60,
-                duration: 28,
+                duration: 52,
                 delay: 0,
-                scaleStart: 0.48,
-                scaleEnd: 1.34,
-                opacity: 0.4,
-                blur: 14,
+                opacity: 0.46,
+                blur: 42,
+                rotationStart: "-18deg",
+                rotationMid: "4deg",
+                rotationEnd: "26deg",
+                scaleStart: 0.92,
+                scaleMid: 1.18,
+                scaleEnd: 0.9,
+                colorPrimary: "rgba(138, 214, 255, 0.45)",
+                colorSecondary: "rgba(238, 168, 255, 0.32)",
             },
             {
-                sizeRatio: 1.58,
-                left: 58,
+                sizeRatio: 1.12,
+                left: 64,
                 top: 46,
-                duration: 36,
+                duration: 46,
                 delay: -12.5,
-                scaleStart: 0.42,
-                scaleEnd: 1.46,
-                opacity: 0.34,
-                blur: 18,
+                opacity: 0.4,
+                blur: 36,
+                rotationStart: "14deg",
+                rotationMid: "36deg",
+                rotationEnd: "58deg",
+                scaleStart: 0.88,
+                scaleMid: 1.1,
+                scaleEnd: 0.94,
+                colorPrimary: "rgba(118, 255, 214, 0.32)",
+                colorSecondary: "rgba(122, 198, 255, 0.38)",
             },
             {
-                sizeRatio: 0.9,
-                left: 24,
-                top: 40,
-                duration: 24,
-                delay: -6.8,
-                scaleStart: 0.36,
-                scaleEnd: 1.22,
-                opacity: 0.38,
-                blur: 10,
-            },
-            {
-                sizeRatio: 0.66,
-                left: 70,
-                top: 70,
-                duration: 32,
-                delay: -18,
-                scaleStart: 0.44,
-                scaleEnd: 1.28,
-                opacity: 0.32,
-                blur: 12,
-            },
-        ];
-
-        const sparkBlueprints = [
-            {
-                sizeRatio: 0.54,
-                left: 60,
-                top: 52,
-                duration: 16,
-                delay: -6.2,
+                sizeRatio: 0.94,
+                left: 22,
+                top: 38,
+                duration: 38,
+                delay: -7.5,
                 opacity: 0.42,
-            },
-            {
-                sizeRatio: 0.38,
-                left: 38,
-                top: 34,
-                duration: 14,
-                delay: -9.6,
-                opacity: 0.28,
+                blur: 28,
+                rotationStart: "-8deg",
+                rotationMid: "18deg",
+                rotationEnd: "32deg",
+                scaleStart: 0.9,
+                scaleMid: 1.16,
+                scaleEnd: 0.96,
+                colorPrimary: "rgba(244, 178, 255, 0.36)",
+                colorSecondary: "rgba(118, 210, 255, 0.34)",
             },
         ];
 
-        const ripples = rippleBlueprints.map((blueprint) => {
+        const starBlueprints = [
+            { sizeRatio: 0.06, left: 18, top: 34, duration: 14, delay: -4, opacity: 0.9 },
+            { sizeRatio: 0.08, left: 46, top: 28, duration: 18, delay: -9, opacity: 0.78 },
+            { sizeRatio: 0.05, left: 64, top: 62, duration: 16, delay: -6, opacity: 0.86 },
+            { sizeRatio: 0.07, left: 74, top: 38, duration: 20, delay: -10, opacity: 0.74 },
+            { sizeRatio: 0.05, left: 36, top: 58, duration: 17, delay: -3.2, opacity: 0.82 },
+            { sizeRatio: 0.04, left: 54, top: 72, duration: 22, delay: -12.6, opacity: 0.7 },
+        ];
+
+        const clouds = cloudBlueprints.map((blueprint) => {
             const layer = document.createElement("div");
-            layer.className = "ripple-layer";
+            layer.className = "nebula-cloud";
             layer.dataset.sizeRatio = String(blueprint.sizeRatio);
-            layer.style.setProperty("--ripple-left", `${blueprint.left}%`);
-            layer.style.setProperty("--ripple-top", `${blueprint.top}%`);
-            layer.style.setProperty("--ripple-duration", `${blueprint.duration}s`);
-            layer.style.setProperty("--ripple-delay", `${blueprint.delay}s`);
-            layer.style.setProperty("--ripple-scale-start", `${blueprint.scaleStart}`);
-            layer.style.setProperty("--ripple-scale-end", `${blueprint.scaleEnd}`);
-            layer.style.setProperty("--ripple-opacity", `${blueprint.opacity}`);
-            layer.style.setProperty("--ripple-blur", `${blueprint.blur}px`);
+            layer.style.setProperty("--cloud-left", `${blueprint.left}%`);
+            layer.style.setProperty("--cloud-top", `${blueprint.top}%`);
+            layer.style.setProperty("--cloud-duration", `${blueprint.duration}s`);
+            layer.style.setProperty("--cloud-delay", `${blueprint.delay}s`);
+            layer.style.setProperty("--cloud-opacity", `${blueprint.opacity}`);
+            layer.style.setProperty("--cloud-blur", `${blueprint.blur}px`);
+            layer.style.setProperty("--cloud-rotation-start", blueprint.rotationStart);
+            layer.style.setProperty("--cloud-rotation-mid", blueprint.rotationMid);
+            layer.style.setProperty("--cloud-rotation-end", blueprint.rotationEnd);
+            layer.style.setProperty("--cloud-scale-start", `${blueprint.scaleStart}`);
+            layer.style.setProperty("--cloud-scale-mid", `${blueprint.scaleMid}`);
+            layer.style.setProperty("--cloud-scale-end", `${blueprint.scaleEnd}`);
+            layer.style.setProperty("--cloud-color-primary", blueprint.colorPrimary);
+            layer.style.setProperty("--cloud-color-secondary", blueprint.colorSecondary);
             ambient.appendChild(layer);
             return { element: layer, blueprint };
         });
 
-        const sparks = sparkBlueprints.map((blueprint) => {
-            const spark = document.createElement("div");
-            spark.className = "ripple-spark";
-            spark.dataset.sizeRatio = String(blueprint.sizeRatio);
-            spark.style.setProperty("--spark-left", `${blueprint.left}%`);
-            spark.style.setProperty("--spark-top", `${blueprint.top}%`);
-            spark.style.setProperty("--spark-duration", `${blueprint.duration}s`);
-            spark.style.setProperty("--spark-delay", `${blueprint.delay}s`);
-            spark.style.setProperty("--spark-opacity", `${blueprint.opacity}`);
-            ambient.appendChild(spark);
-            return { element: spark, blueprint };
+        const stars = starBlueprints.map((blueprint) => {
+            const star = document.createElement("div");
+            star.className = "nebula-star";
+            star.dataset.sizeRatio = String(blueprint.sizeRatio);
+            star.style.setProperty("--star-left", `${blueprint.left}%`);
+            star.style.setProperty("--star-top", `${blueprint.top}%`);
+            star.style.setProperty("--star-duration", `${blueprint.duration}s`);
+            star.style.setProperty("--star-delay", `${blueprint.delay}s`);
+            star.style.setProperty("--star-opacity", `${blueprint.opacity}`);
+            ambient.appendChild(star);
+            return { element: star, blueprint };
         });
 
         const updateDimensions = () => {
             const { width, height } = ambient.getBoundingClientRect();
             const reference = Math.max(width, height, 1);
 
-            ripples.forEach(({ element, blueprint }) => {
+            clouds.forEach(({ element, blueprint }) => {
                 const baseSize = reference * blueprint.sizeRatio;
-                element.style.setProperty("--ripple-size", `${baseSize}px`);
+                element.style.setProperty("--cloud-size", `${baseSize}px`);
             });
 
-            sparks.forEach(({ element, blueprint }) => {
+            stars.forEach(({ element, blueprint }) => {
                 const baseSize = reference * blueprint.sizeRatio;
-                element.style.setProperty("--spark-size", `${baseSize}px`);
+                element.style.setProperty("--star-size", `${baseSize}px`);
             });
         };
 

--- a/style.css
+++ b/style.css
@@ -26,6 +26,8 @@
         rgba(34, 12, 63, 0.96) 45%,
         rgba(6, 10, 26, 0.99) 100%
     );
+    --cs-hero-aurora: radial-gradient(circle at 20% -10%, rgba(151, 109, 255, 0.28), transparent 55%),
+        radial-gradient(circle at 110% 20%, rgba(64, 207, 255, 0.25), transparent 50%);
 }
 
 #costume-switcher-settings.cs-theme .inline-drawer {
@@ -597,13 +599,12 @@
 #costume-switcher-settings.cs-theme .cs-header-ambient::before {
     content: "";
     position: absolute;
-    inset: -14% -12%;
-    background: radial-gradient(circle at 22% 30%, rgba(255, 141, 255, 0.4), transparent 64%),
-        radial-gradient(circle at 76% 24%, rgba(118, 210, 255, 0.32), transparent 72%),
-        radial-gradient(circle at 60% 82%, rgba(120, 255, 214, 0.26), transparent 70%);
-    opacity: 0.9;
-    filter: blur(18px);
+    inset: -16% -14%;
+    background: var(--cs-hero-aurora);
+    opacity: 0.72;
+    filter: blur(20px);
     pointer-events: none;
+    mix-blend-mode: screen;
     z-index: 0;
 }
 
@@ -689,136 +690,163 @@
 #costume-switcher-settings.cs-theme .cs-header-ambient::after {
     content: "";
     position: absolute;
-    inset: -18% -8% 16% -8%;
-    background: radial-gradient(circle at 32% 34%, rgba(255, 182, 255, 0.4), transparent 62%),
-        radial-gradient(circle at 74% 62%, rgba(138, 214, 255, 0.28), transparent 70%),
+    inset: -20% -12% 18% -12%;
+    background:
+        radial-gradient(circle at 26% 32%, rgba(151, 109, 255, 0.22), transparent 64%),
+        radial-gradient(circle at 72% 68%, rgba(64, 207, 255, 0.18), transparent 72%),
         conic-gradient(
-            from 180deg at 50% 50%,
+            from 160deg at 50% 52%,
             rgba(255, 255, 255, 0) 0deg,
-            rgba(255, 163, 255, 0.28) 120deg,
-            rgba(122, 222, 255, 0.25) 220deg,
+            rgba(171, 139, 255, 0.18) 118deg,
+            rgba(126, 218, 255, 0.16) 214deg,
             rgba(255, 255, 255, 0) 360deg
         );
-    opacity: 0.62;
+    opacity: 0.48;
     mix-blend-mode: screen;
     pointer-events: none;
-    filter: blur(16px);
+    filter: blur(18px);
     z-index: 2;
 }
 
-#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer {
+#costume-switcher-settings.cs-theme .cs-header-ambient .nebula-cloud {
     position: absolute;
-    width: var(--ripple-size, 320px);
-    height: var(--ripple-size, 320px);
-    left: var(--ripple-left, 50%);
-    top: var(--ripple-top, 50%);
+    width: var(--cloud-size, 320px);
+    height: var(--cloud-size, 320px);
+    left: var(--cloud-left, 50%);
+    top: var(--cloud-top, 50%);
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    overflow: hidden;
-    opacity: var(--ripple-opacity, 0.5);
-    filter: blur(var(--ripple-blur, 2px));
+    background:
+        radial-gradient(circle at 32% 38%, var(--cloud-color-primary, rgba(118, 210, 255, 0.38)) 0%, transparent 66%),
+        radial-gradient(circle at 70% 64%, var(--cloud-color-secondary, rgba(238, 168, 255, 0.28)) 0%, transparent 72%);
+    opacity: var(--cloud-opacity, 0.48);
+    filter: blur(var(--cloud-blur, 32px));
     mix-blend-mode: screen;
-    animation: ripple-wave var(--ripple-duration, 18s) ease-in-out infinite;
-    animation-delay: var(--ripple-delay, 0s);
+    animation: nebula-drift var(--cloud-duration, 46s) ease-in-out infinite;
+    animation-delay: var(--cloud-delay, 0s);
     z-index: 3;
     will-change: transform, opacity;
 }
 
-#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::before {
+#costume-switcher-settings.cs-theme .cs-header-ambient .nebula-cloud::before {
     content: "";
     position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    background: radial-gradient(circle at 48% 42%, rgba(255, 195, 255, 0.32) 0%, rgba(255, 195, 255, 0.12) 36%, rgba(255, 195, 255, 0.04) 58%, transparent 78%),
-        radial-gradient(circle at 28% 70%, rgba(132, 222, 255, 0.28), transparent 70%),
-        radial-gradient(circle at 76% 30%, rgba(164, 143, 255, 0.32), transparent 68%);
-}
-
-#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-layer::after {
-    content: "";
-    position: absolute;
-    inset: -18%;
-    border-radius: 50%;
+    inset: -22%;
+    border-radius: inherit;
     background: conic-gradient(
-        from 200deg at 50% 50%,
+        from 140deg at 50% 50%,
         rgba(255, 255, 255, 0) 0deg,
-        rgba(255, 189, 255, 0.32) 82deg,
-        rgba(108, 205, 255, 0.28) 162deg,
-        rgba(255, 255, 255, 0) 240deg,
-        rgba(123, 255, 219, 0.22) 310deg,
+        color-mix(in srgb, var(--cloud-color-primary, rgba(118, 210, 255, 0.38)) 70%, transparent) 110deg,
+        color-mix(in srgb, var(--cloud-color-secondary, rgba(238, 168, 255, 0.28)) 65%, transparent) 220deg,
         rgba(255, 255, 255, 0) 360deg
     );
+    opacity: 0.65;
+    filter: blur(18px);
     mix-blend-mode: screen;
-    opacity: 0.48;
-    animation: ripple-sheen calc(var(--ripple-duration, 18s) * 1.2) linear infinite;
-    animation-delay: calc(var(--ripple-delay, 0s) * 1.05);
+    animation: nebula-shimmer calc(var(--cloud-duration, 46s) * 1.4) linear infinite;
+    animation-delay: var(--cloud-delay, 0s);
+    will-change: transform, opacity;
 }
 
-@keyframes ripple-wave {
+@keyframes nebula-drift {
     0% {
-        transform: translate(-50%, -50%) scale(var(--ripple-scale-start, 0.45));
-        opacity: 0;
-    }
-    18% {
-        opacity: var(--ripple-opacity, 0.5);
+        transform: translate(-50%, -50%) rotate(var(--cloud-rotation-start, -6deg)) scale(var(--cloud-scale-start, 0.96));
+        opacity: calc(var(--cloud-opacity, 0.48) * 0.8);
     }
     48% {
-        opacity: calc(var(--ripple-opacity, 0.5) + 0.02);
-    }
-    78% {
-        opacity: calc(var(--ripple-opacity, 0.5) * 0.4);
+        transform: translate(calc(-50% + 3%), calc(-50% - 2%)) rotate(var(--cloud-rotation-mid, 18deg)) scale(var(--cloud-scale-mid, 1.12));
+        opacity: calc(var(--cloud-opacity, 0.48) * 1.1);
     }
     100% {
-        transform: translate(-50%, -50%) scale(var(--ripple-scale-end, 1.4));
-        opacity: 0;
+        transform: translate(-50%, -50%) rotate(var(--cloud-rotation-end, 32deg)) scale(var(--cloud-scale-end, 0.94));
+        opacity: calc(var(--cloud-opacity, 0.48) * 0.86);
     }
 }
 
-@keyframes ripple-sheen {
+@keyframes nebula-shimmer {
     0% {
-        transform: rotate(0deg) scale(0.92);
+        transform: rotate(0deg) scale(0.96);
+        opacity: 0.55;
     }
     50% {
-        transform: rotate(180deg) scale(1);
+        transform: rotate(180deg) scale(1.04);
+        opacity: 0.85;
     }
     100% {
-        transform: rotate(360deg) scale(0.92);
+        transform: rotate(360deg) scale(0.96);
+        opacity: 0.55;
     }
 }
 
-#costume-switcher-settings.cs-theme .cs-header-ambient .ripple-spark {
+#costume-switcher-settings.cs-theme .cs-header-ambient .nebula-star {
     position: absolute;
-    width: var(--spark-size, 180px);
-    height: var(--spark-size, 180px);
-    left: var(--spark-left, 52%);
-    top: var(--spark-top, 48%);
+    width: var(--star-size, 12px);
+    height: var(--star-size, 12px);
+    left: var(--star-left, 50%);
+    top: var(--star-top, 50%);
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    background: radial-gradient(circle at 46% 42%, rgba(255, 205, 255, 0.45) 0%, rgba(255, 205, 255, 0.16) 42%, transparent 78%),
-        radial-gradient(circle at 60% 68%, rgba(134, 234, 255, 0.32) 0%, rgba(134, 234, 255, 0.1) 48%, transparent 80%);
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.96) 0%, rgba(255, 255, 255, 0.4) 36%, transparent 74%);
+    opacity: var(--star-opacity, 0.82);
     mix-blend-mode: screen;
-    filter: blur(16px);
-    opacity: var(--spark-opacity, 0.35);
-    animation: ripple-sparkle var(--spark-duration, 10s) ease-in-out infinite;
-    animation-delay: var(--spark-delay, 0s);
+    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.7));
+    animation: nebula-star-twinkle var(--star-duration, 18s) ease-in-out infinite;
+    animation-delay: var(--star-delay, 0s);
     z-index: 4;
+    will-change: transform, opacity;
 }
 
-@keyframes ripple-sparkle {
+#costume-switcher-settings.cs-theme .cs-header-ambient .nebula-star::after {
+    content: "";
+    position: absolute;
+    inset: -60%;
+    background:
+        radial-gradient(circle, rgba(255, 255, 255, 0.45) 0%, transparent 60%),
+        linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.55) 50%, rgba(255, 255, 255, 0) 100%),
+        linear-gradient(0deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.45) 50%, rgba(255, 255, 255, 0) 100%);
+    mix-blend-mode: screen;
+    opacity: 0.55;
+    transform: rotate(15deg);
+    animation: nebula-star-glint calc(var(--star-duration, 18s) * 0.65) ease-in-out infinite;
+    animation-delay: calc(var(--star-delay, 0s) * 0.85);
+    pointer-events: none;
+}
+
+@keyframes nebula-star-twinkle {
     0% {
-        transform: translate(-50%, -50%) scale(0.85);
-        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.8);
+        opacity: calc(var(--star-opacity, 0.82) * 0.4);
     }
-    25% {
-        opacity: var(--spark-opacity, 0.35);
+    35% {
+        transform: translate(calc(-50% - 6px), calc(-50% - 4px)) scale(1.05);
+        opacity: calc(var(--star-opacity, 0.82) * 0.85);
     }
     55% {
-        transform: translate(-48%, -52%) scale(1.05);
-        opacity: calc(var(--spark-opacity, 0.35) * 0.6);
+        transform: translate(calc(-50% + 5px), calc(-50% + 3px)) scale(1.28);
+        opacity: var(--star-opacity, 0.82);
+    }
+    78% {
+        transform: translate(calc(-50% + 1px), calc(-50% - 2px)) scale(1.02);
+        opacity: calc(var(--star-opacity, 0.82) * 0.7);
     }
     100% {
-        transform: translate(-50%, -50%) scale(1.25);
-        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.88);
+        opacity: calc(var(--star-opacity, 0.82) * 0.45);
+    }
+}
+
+@keyframes nebula-star-glint {
+    0% {
+        opacity: 0.2;
+        transform: rotate(0deg) scale(0.75);
+    }
+    50% {
+        opacity: 0.8;
+        transform: rotate(180deg) scale(1.05);
+    }
+    100% {
+        opacity: 0.2;
+        transform: rotate(360deg) scale(0.75);
     }
 }
 
@@ -1687,9 +1715,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    background:
-        radial-gradient(circle at 20% -10%, rgba(151, 109, 255, 0.28), transparent 55%),
-        radial-gradient(circle at 110% 20%, rgba(64, 207, 255, 0.25), transparent 50%);
+    background: var(--cs-hero-aurora);
     opacity: 0.7;
     pointer-events: none;
     mix-blend-mode: screen;


### PR DESCRIPTION
## Summary
- introduce a shared `--cs-hero-aurora` gradient that matches the scene control center aurora effect
- reuse that aurora gradient for the header ambient layer to tone down its brightness and mirror the control center palette
- keep the scene control center using the shared aurora gradient for consistent nebula accents

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162d42ab10832588735180a7bc32fb)