### PR TITLE
Adjust master toggle vertical spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -956,6 +956,7 @@
     transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
     padding: 4px;
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
+    margin-top: 2px;
 }
 
 #costume-switcher-settings.cs-theme .cs-switch-thumb::before {


### PR DESCRIPTION
## Summary
- add a small top margin to the master switch thumb so the toggle sits slightly lower within its card

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691633d3a71c8325bc822c5d1705c58a)