### PR TITLE
Lower master switch toggle alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -958,6 +958,11 @@
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.15);
 }
 
+#costume-switcher-settings.cs-theme .cs-master-toggle .cs-switch-thumb {
+    align-self: start;
+    margin-top: 6px;
+}
+
 #costume-switcher-settings.cs-theme .cs-switch-thumb::before {
     content: "";
     inline-size: 20px;


### PR DESCRIPTION
## Summary
- adjust the master toggle thumb to align itself from the top of the card
- add vertical offset so the master switch thumb sits a bit lower without affecting other toggles

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691633d3a71c8325bc822c5d1705c58a)