### PR TITLE
Reposition scene panel master toggle and isolate button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Improved
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
+- **Scene panel master toggle placement.** The hide/show switch now anchors to the base of the hero card so it stays visually connected to the gradient header instead of floating above it.
 - **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space as soon as any module is hidden, so two-up layouts immediately expand instead of waiting until only a single section remains.
 - **Live log export parity.** Copying the live log now produces a full report with detection summaries, switch analytics, skip reasons, and roster state—matching the fidelity of the live pattern tester output.
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
@@ -38,6 +39,7 @@
 - **Live log stability.** The live diagnostics panel keeps the prior message data visible until the next stream produces detections, so it no longer flickers "Awaiting detections" while idle.
 - **Live diagnostics retention.** Streaming preserves the full switch history for the active message instead of trimming entries mid-stream, so the log no longer empties before generation ends.
 - **Scene panel hide toggle.** Hiding the command center now removes the panel entirely so no translucent shell remains on screen.
+- **Scene control center button resilience.** Panel and summon buttons now reset their visual styles within the extension so conflicting theme overrides from other mods can no longer hide or neutralize them.
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
 - **Stream start detection resiliency.** Hidden and symbol-keyed SillyTavern events are now recognised when wiring the integration, keeping the side panel aware of streaming starts even when the host app reshuffles its hooks.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.

--- a/style.css
+++ b/style.css
@@ -1882,6 +1882,11 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     color: var(--header-text, rgba(248, 249, 255, 0.95));
 }
 
+.cs-scene-panel__headline {
+    position: relative;
+    padding-bottom: calc(14px + 38px + 12px);
+}
+
 .cs-scene-panel__headline > *:not(.cs-scene-panel__ambient),
 .cs-scene-panel__title > *:not(.cs-scene-panel__ambient) {
     position: relative;
@@ -1917,18 +1922,21 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: rgba(255, 255, 255, 0.66);
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
 }
 
 .cs-scene-panel__title-copy h3 {
     margin: 0;
     font-size: 1.35rem;
     color: var(--SmartThemeBodyColor, #f3f3f3);
+    text-shadow: 0 4px 18px rgba(0, 0, 0, 0.55);
 }
 
 .cs-scene-panel__subtitle {
     margin: 0;
     font-size: 0.88rem;
     color: var(--text-color-soft, rgba(255, 255, 255, 0.75));
+    text-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
 }
 
 .cs-scene-panel__toolbar {
@@ -1936,6 +1944,43 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+}
+
+.cs-scene-panel__icon-button,
+.cs-scene-panel__text-button,
+.cs-scene-panel__footer-button,
+.cs-scene-panel__summon {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    min-width: 0;
+    appearance: none;
+}
+
+.cs-scene-panel__master-toggle {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    display: flex;
+    justify-content: flex-end;
+    pointer-events: none;
+}
+
+.cs-scene-panel__master-toggle .cs-scene-panel__icon-button {
+    pointer-events: auto;
+    width: 38px;
+    height: 38px;
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
 }
 
 .cs-scene-panel__icon-button {
@@ -1968,6 +2013,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     font-size: 0.75rem;
     color: rgba(255, 255, 255, 0.75);
     margin-top: 2px;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
 }
 
 .cs-scene-panel__toggle {

--- a/ui/templates/scenePanel.html
+++ b/ui/templates/scenePanel.html
@@ -12,12 +12,14 @@
                     <p class="cs-scene-panel__subtitle">Live roster, focus tools, and result analytics in one place.</p>
                     <p class="cs-scene-panel__helper" data-scene-panel="status-text" aria-live="polite">Mirrors the live tester timeline while tracking actual chat results.</p>
                 </div>
+                <div class="cs-scene-panel__master-toggle">
+                    <button id="cs-scene-panel-toggle" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-panel" aria-pressed="true" title="Hide scene panel">
+                        <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle scene panel visibility</span>
+                    </button>
+                </div>
             </div>
             <div class="cs-scene-panel__toolbar" data-scene-panel="toolbar">
-                <button id="cs-scene-panel-toggle" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-panel" aria-pressed="true" title="Hide scene panel">
-                    <i class="fa-solid fa-eye" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle scene panel visibility</span>
-                </button>
                 <button id="cs-scene-panel-toggle-auto-open" class="cs-scene-panel__icon-button" type="button" data-scene-panel="auto-open-results" aria-pressed="true" title="Disable auto-open on new results">
                     <i class="fa-solid fa-bolt" aria-hidden="true"></i>
                     <span class="visually-hidden">Toggle auto-open on new results</span>


### PR DESCRIPTION
## Summary
- move the scene panel master toggle into the gradient hero card and anchor it along the bottom edge
- add drop shadows to the hero copy to improve contrast inside the scene control center header
- harden scene panel button styles against external overrides and note the changes in the changelog

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163baaa4b08325a1cda15cfb2d3fa4)