### PR TITLE
Gate scene panel updates from tester events

### DIFF
--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -442,8 +442,11 @@ function updateStatusCopy(enabled) {
     }
 }
 
-export function renderScenePanel(panelState = {}) {
+export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
     if (typeof document === "undefined") {
+        return;
+    }
+    if (source === "tester") {
         return;
     }
     const container = getScenePanelContainer?.();


### PR DESCRIPTION
## Summary
- add render source tracking so tester-triggered scene panel refreshes are ignored while preserving the last collected state
- guard the panel renderer against tester sources and pass the flag from tester workflows
- cover the regression with a unit test that exercises tester-tagged panel state collection

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916412203ac8325aa900a4d2496b424)