### PR TITLE
Avoid clearing roster state when manually refreshing scene panel

### DIFF
--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -595,3 +595,33 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
         }
     }
 }
+
+export function createScenePanelRefreshHandler({
+    restoreLatestSceneOutcome,
+    requestScenePanelRender,
+    rerenderScenePanelLayer,
+    showStatus,
+} = {}) {
+    return function handleScenePanelRefresh(event) {
+        event?.preventDefault?.();
+
+        const restored = typeof restoreLatestSceneOutcome === "function"
+            ? restoreLatestSceneOutcome({
+                immediateRender: true,
+                preserveStateOnFailure: true,
+            })
+            : false;
+
+        if (!restored && typeof requestScenePanelRender === "function") {
+            requestScenePanelRender("manual-refresh", { immediate: true });
+        }
+
+        if (typeof showStatus === "function") {
+            showStatus("Scene panel refreshed.", "info");
+        }
+
+        if (typeof rerenderScenePanelLayer === "function") {
+            rerenderScenePanelLayer();
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- expose a createScenePanelRefreshHandler helper in the panel renderer so refresh clicks can be centralized
- update the manual refresh handler to reuse the helper and preserve roster state when no latest outcome is found
- allow history restoration functions to skip clearing roster data when told to preserve existing state

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916439ca2408325aad8f862ae39a14b)