### PR TITLE
Fix roster TTL history window handling

### DIFF
--- a/test/scene-roster-history.test.js
+++ b/test/scene-roster-history.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { __testables as rosterTestables } from "../src/ui/render/sceneRoster.js";
+
+const { mergeRosterData } = rosterTestables;
+
+test("mergeRosterData infers turns remaining from history counts within the TTL window", () => {
+    const now = Date.now();
+    const history = {
+        ttlWindow: 5,
+        messages: [
+            { key: "m1", roster: ["Kotori"], turnsByMember: [["kotori", 0]] },
+            { key: "m2", roster: ["Kotori"] },
+            { key: "m3", roster: ["Kotori"] },
+            { key: "m4", roster: [] },
+            { key: "m5", roster: ["Kotori"] },
+            { key: "m6", roster: [] },
+            { key: "m7", roster: [] },
+        ],
+    };
+
+    const membership = {
+        members: [
+            {
+                name: "Kotori",
+                normalized: "kotori",
+                joinedAt: now - 1000,
+                lastSeenAt: now,
+                active: true,
+                turnsRemaining: null,
+            },
+        ],
+        history,
+    };
+
+    const scene = {
+        roster: [
+            {
+                name: "Kotori",
+                normalized: "kotori",
+                joinedAt: now - 1000,
+                lastSeenAt: now,
+                active: true,
+            },
+        ],
+        history,
+    };
+
+    const entries = mergeRosterData(scene, membership, null, now);
+    const kotori = entries.find((entry) => entry.normalized === "kotori");
+    assert.ok(kotori, "expected Kotori to appear in merged roster");
+    assert.equal(kotori.turnsRemaining, 3, "turns remaining should reflect only the last five messages");
+});
+
+test("mergeRosterData prefers per-member turn values from history when available", () => {
+    const now = Date.now();
+    const history = {
+        ttlWindow: 5,
+        messages: [
+            { key: "m1", roster: ["Kotori"], turnsByMember: [["kotori", 2]] },
+            { key: "m2", roster: ["Kotori"], turnsByMember: [["kotori", 4]] },
+        ],
+    };
+
+    const membership = {
+        members: [
+            {
+                name: "Kotori",
+                normalized: "kotori",
+                joinedAt: now - 2000,
+                lastSeenAt: now - 1000,
+                active: true,
+                turnsRemaining: null,
+            },
+        ],
+        history,
+    };
+
+    const scene = {
+        roster: [
+            {
+                name: "Kotori",
+                normalized: "kotori",
+                joinedAt: now - 2000,
+                lastSeenAt: now - 1000,
+                active: true,
+            },
+        ],
+        history,
+    };
+
+    const entries = mergeRosterData(scene, membership, null, now);
+    const kotori = entries.find((entry) => entry.normalized === "kotori");
+    assert.ok(kotori, "expected Kotori to appear in merged roster");
+    assert.equal(kotori.turnsRemaining, 4, "per-member turn history should override count-based fallback");
+});


### PR DESCRIPTION
## Summary
- collect per-message roster history for the scene panel so TTL logic can reference trimmed history windows
- normalize roster history when merging scene data to respect TTL windows and derive turns remaining from recent messages
- add regression tests that ensure TTL stays within the window and prefers explicit per-member turn data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916477642ac8325a94e6e0fd16c0cc4)