### PR TITLE
Render coverage section with real suggestion data

### DIFF
--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -17,7 +17,7 @@ import {
 import { renderSceneRoster } from "./sceneRoster.js";
 import { renderActiveCharacters } from "./activeCharacters.js";
 import { renderLiveLog } from "./liveLog.js";
-import { renderCoverageSuggestions } from "./coverage.js";
+import { renderCoverageSection } from "./coverage.js";
 import { resolveContainer, clearContainer, createElement } from "./utils.js";
 
 let scenePanelSummonButton = null;
@@ -567,17 +567,23 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
     const coveragePronouns = getSceneCoveragePronouns?.();
     const coverageAttribution = getSceneCoverageAttribution?.();
     const coverageAction = getSceneCoverageAction?.();
+    const hasCoverageBuffer = typeof panelState.analytics?.buffer === "string"
+        ? panelState.analytics.buffer.trim().length > 0
+        : false;
     const coverageRevision = showCoverage
-        ? JSON.stringify(panelState.coverage || null)
+        ? JSON.stringify({
+            coverage: panelState.coverage || null,
+            hasBuffer: hasCoverageBuffer,
+        })
         : null;
     if (coverageSection && showCoverage) {
         if (lastCoverageRevision !== coverageRevision) {
-            renderCoverageSuggestions({
+            renderCoverageSection({
                 section: coverageSection,
                 pronouns: coveragePronouns,
                 attribution: coverageAttribution,
                 action: coverageAction,
-            }, panelState);
+            }, panelState.coverage || {}, { hasBuffer: hasCoverageBuffer });
             lastCoverageRevision = coverageRevision;
         }
     } else {
@@ -590,6 +596,17 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
             }
             if (coverageAction) {
                 clearContainer(coverageAction);
+            }
+            if (coverageSection) {
+                const wrapper = resolveContainer(coverageSection);
+                if (wrapper.el) {
+                    wrapper.el.removeAttribute("data-state");
+                    wrapper.el.setAttribute("data-has-content", "false");
+                }
+                if (wrapper.$ && typeof wrapper.$.attr === "function") {
+                    wrapper.$.removeAttr?.("data-state");
+                    wrapper.$.attr("data-has-content", "false");
+                }
             }
             lastCoverageRevision = null;
         }

--- a/test/render-coverage-section.test.js
+++ b/test/render-coverage-section.test.js
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderCoverageSection } from "../src/ui/render/coverage.js";
+
+class StubElement {
+    constructor(tagName) {
+        this.tagName = String(tagName || "div").toUpperCase();
+        this.childNodes = [];
+        this.firstChild = null;
+        this.parentNode = null;
+        this.dataset = {};
+        this.attributes = new Map();
+        this.className = "";
+        this._textContent = "";
+        this.style = {
+            setProperty: () => {},
+            removeProperty: () => {},
+        };
+        this.classList = {
+            add: () => {},
+            remove: () => {},
+            contains: () => false,
+        };
+    }
+
+    appendChild(node) {
+        if (!node) {
+            return node;
+        }
+        this.childNodes.push(node);
+        node.parentNode = this;
+        this.firstChild = this.childNodes[0] || null;
+        return node;
+    }
+
+    removeChild(node) {
+        const index = this.childNodes.indexOf(node);
+        if (index === -1) {
+            return node;
+        }
+        this.childNodes.splice(index, 1);
+        node.parentNode = null;
+        this.firstChild = this.childNodes[0] || null;
+        return node;
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+    }
+
+    set textContent(value) {
+        this._textContent = String(value ?? "");
+        this.childNodes = [];
+        this.firstChild = null;
+    }
+
+    get textContent() {
+        return this._textContent;
+    }
+
+    get children() {
+        return this.childNodes;
+    }
+}
+
+function withDomEnvironment(callback) {
+    const previousDocument = globalThis.document;
+    const previousElement = globalThis.Element;
+    globalThis.Element = StubElement;
+    globalThis.document = {
+        createElement: (tagName) => new StubElement(tagName),
+    };
+    try {
+        callback();
+    } finally {
+        if (previousDocument === undefined) {
+            delete globalThis.document;
+        } else {
+            globalThis.document = previousDocument;
+        }
+        if (previousElement === undefined) {
+            delete globalThis.Element;
+        } else {
+            globalThis.Element = previousElement;
+        }
+    }
+}
+
+test("renderCoverageSection renders suggestions and updates state", () => {
+    withDomEnvironment(() => {
+        const section = new StubElement("section");
+        const pronouns = new StubElement("div");
+        const attribution = new StubElement("div");
+        const action = new StubElement("div");
+
+        renderCoverageSection({
+            section,
+            pronouns,
+            attribution,
+            action,
+        }, {
+            missingPronouns: ["ze", "hir"],
+            missingAttributionVerbs: ["intoned"],
+            missingActionVerbs: [],
+        }, { hasBuffer: true });
+
+        assert.equal(section.getAttribute("data-has-content"), "true");
+        assert.equal(section.dataset.state, "ready");
+
+        const pronounList = pronouns.children[0];
+        assert.ok(pronounList, "pronoun list should be rendered");
+        assert.equal(pronounList.children.length, 2);
+        assert.equal(pronounList.children[0].textContent, "ze");
+
+        const attributionList = attribution.children[0];
+        assert.ok(attributionList, "attribution list should be rendered");
+        assert.equal(attributionList.children.length, 1);
+        assert.equal(attributionList.children[0].dataset.value, "intoned");
+
+        const actionPlaceholder = action.children[0];
+        assert.ok(actionPlaceholder, "action placeholder should render when empty");
+        assert.equal(actionPlaceholder.textContent, "No gaps detected.");
+    });
+});
+
+test("renderCoverageSection shows awaiting message when no buffer", () => {
+    withDomEnvironment(() => {
+        const section = new StubElement("section");
+        const pronouns = new StubElement("div");
+        const attribution = new StubElement("div");
+        const action = new StubElement("div");
+
+        renderCoverageSection({
+            section,
+            pronouns,
+            attribution,
+            action,
+        }, {}, { hasBuffer: false });
+
+        assert.equal(section.getAttribute("data-has-content"), "false");
+        assert.equal(section.dataset.state, "pending");
+
+        const pronounPlaceholder = pronouns.children[0];
+        assert.ok(pronounPlaceholder, "pronoun placeholder should render when waiting");
+        assert.equal(pronounPlaceholder.textContent, "Awaiting an assistant message.");
+
+        const attributionPlaceholder = attribution.children[0];
+        assert.equal(attributionPlaceholder.textContent, "Awaiting an assistant message.");
+        const actionPlaceholder = action.children[0];
+        assert.equal(actionPlaceholder.textContent, "Awaiting an assistant message.");
+    });
+});


### PR DESCRIPTION
## Summary
- ensure the scene panel passes coverage data and buffer state so the coverage section rerenders with fresh suggestions
- populate `renderCoverageSection` to normalize suggestion lists and expose section state attributes
- add unit tests that verify coverage pills and placeholders render for both populated and empty scenes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164ee1bb248325b7b311f9a808422d)