### PR TITLE
Keep coverage section always visible

### DIFF
--- a/src/ui/render/coverage.js
+++ b/src/ui/render/coverage.js
@@ -43,9 +43,10 @@ function renderList(target, values = [], type, { hasBuffer }) {
     const normalizedValues = normalizeValues(values);
     if (normalizedValues.length === 0) {
         const message = hasBuffer
-            ? "No gaps detected."
-            : "Awaiting an assistant message.";
-        renderPlaceholder(container, message);
+            ? "No coverage gaps detected."
+            : "Coverage suggestions will appear after the next assistant message.";
+        const tone = hasBuffer ? "informative" : "muted";
+        renderPlaceholder(container, message, tone);
         return;
     }
     const list = createElement("div", "cs-coverage-list");

--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -429,6 +429,32 @@ function updateToolbarToggleState(buttonId, pressed, { pressedTitle, unpressedTi
     }
 }
 
+function disableToolbarToggle(buttonId) {
+    if (typeof document === "undefined") {
+        return;
+    }
+    const button = document.getElementById(buttonId);
+    if (!button) {
+        return;
+    }
+    if (typeof button.setAttribute === "function") {
+        button.setAttribute("aria-pressed", "false");
+        button.setAttribute("aria-hidden", "true");
+        button.setAttribute("disabled", "true");
+        button.setAttribute("tabindex", "-1");
+        button.setAttribute("hidden", "");
+    }
+    if (button.classList && typeof button.classList.add === "function") {
+        button.classList.add("cs-scene-panel__icon-button--disabled");
+    }
+    if (button.style) {
+        try {
+            button.style.display = "none";
+        } catch (err) {
+        }
+    }
+}
+
 function updateStatusCopy(enabled) {
     const statusTarget = getSceneStatusText?.();
     const { $, el } = resolveContainer(statusTarget);
@@ -467,7 +493,7 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
     const showRoster = enabled && sections.roster !== false;
     const showActive = enabled && sections.activeCharacters !== false;
     const showLog = enabled && sections.liveLog !== false;
-    const showCoverage = enabled && sections.coverage !== false;
+    const showCoverage = enabled;
 
     applySectionVisibility(getSceneRosterSection?.(), showRoster);
     applySectionVisibility(getSceneActiveSection?.(), showActive);
@@ -492,10 +518,7 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
         pressedTitle: "Hide live log section",
         unpressedTitle: "Show live log section",
     });
-    updateToolbarToggleState("cs-scene-section-toggle-coverage", showCoverage, {
-        pressedTitle: "Hide coverage suggestions section",
-        unpressedTitle: "Show coverage suggestions section",
-    });
+    disableToolbarToggle("cs-scene-section-toggle-coverage");
     updateToolbarToggleState("cs-scene-panel-toggle-auto-open", settings.autoOpenOnResults !== false, {
         pressedTitle: "Disable auto-open on new results",
         unpressedTitle: "Enable auto-open on new results",

--- a/src/ui/templates/scenePanel.html
+++ b/src/ui/templates/scenePanel.html
@@ -89,19 +89,19 @@
                     <div>
                         <h5>Pronouns</h5>
                         <div class="cs-coverage-list" data-scene-panel="coverage-pronouns">
-                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
                         </div>
                     </div>
                     <div>
                         <h5>Attribution verbs</h5>
                         <div class="cs-coverage-list" data-scene-panel="coverage-attribution">
-                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
                         </div>
                     </div>
                     <div>
                         <h5>Action verbs</h5>
                         <div class="cs-coverage-list" data-scene-panel="coverage-action">
-                            <div class="cs-scene-panel__placeholder" data-tone="muted">Awaiting an assistant message.</div>
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
                         </div>
                     </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -2017,6 +2017,10 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     border-color: rgba(255, 255, 255, 0.35) !important;
 }
 
+#cs-scene-panel .cs-scene-panel__icon-button--disabled {
+    display: none !important;
+}
+
 .cs-scene-panel__helper {
     font-size: 0.75rem;
     color: rgba(255, 255, 255, 0.75);
@@ -2162,9 +2166,18 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 }
 
 .cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-panel {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-panel > div {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-panel h5 {
@@ -2177,7 +2190,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 .cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-list {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 8px;
 }
 
 .cs-scene-panel__section[data-scene-panel="coverage"] .cs-coverage-pill {

--- a/test/render-coverage-section.test.js
+++ b/test/render-coverage-section.test.js
@@ -124,7 +124,8 @@ test("renderCoverageSection renders suggestions and updates state", () => {
 
         const actionPlaceholder = action.children[0];
         assert.ok(actionPlaceholder, "action placeholder should render when empty");
-        assert.equal(actionPlaceholder.textContent, "No gaps detected.");
+        assert.equal(actionPlaceholder.textContent, "No coverage gaps detected.");
+        assert.equal(actionPlaceholder.dataset.tone, "informative");
     });
 });
 
@@ -147,11 +148,11 @@ test("renderCoverageSection shows awaiting message when no buffer", () => {
 
         const pronounPlaceholder = pronouns.children[0];
         assert.ok(pronounPlaceholder, "pronoun placeholder should render when waiting");
-        assert.equal(pronounPlaceholder.textContent, "Awaiting an assistant message.");
+        assert.equal(pronounPlaceholder.textContent, "Coverage suggestions will appear after the next assistant message.");
 
         const attributionPlaceholder = attribution.children[0];
-        assert.equal(attributionPlaceholder.textContent, "Awaiting an assistant message.");
+        assert.equal(attributionPlaceholder.textContent, "Coverage suggestions will appear after the next assistant message.");
         const actionPlaceholder = action.children[0];
-        assert.equal(actionPlaceholder.textContent, "Awaiting an assistant message.");
+        assert.equal(actionPlaceholder.textContent, "Coverage suggestions will appear after the next assistant message.");
     });
 });

--- a/test/render-scene-panel.test.js
+++ b/test/render-scene-panel.test.js
@@ -1,0 +1,238 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderScenePanel } from "../src/ui/render/panel.js";
+import {
+    setScenePanelContainer,
+    setSceneSectionsContainer,
+    setSceneRosterSection,
+    setSceneActiveSection,
+    setSceneLiveLogSection,
+    setSceneCoverageSection,
+    setSceneCoveragePronouns,
+    setSceneCoverageAttribution,
+    setSceneCoverageAction,
+    setSceneRosterList,
+    setSceneActiveCards,
+    setSceneLiveLog,
+} from "../src/ui/scenePanelState.js";
+
+class StubElement {
+    constructor(documentRef, tagName) {
+        this._documentRef = documentRef;
+        this.tagName = String(tagName || "div").toUpperCase();
+        this.childNodes = [];
+        this.firstChild = null;
+        this.parentNode = null;
+        this.dataset = {};
+        this.attributes = new Map();
+        this.className = "";
+        this.hidden = false;
+        this.isConnected = false;
+        this._id = "";
+        this._textContent = "";
+        const self = this;
+        this.style = {
+            setProperty: () => {},
+            removeProperty: () => {},
+        };
+        this.classList = {
+            add: (...tokens) => {
+                const set = new Set(self.className.split(/\s+/).filter(Boolean));
+                tokens.filter(Boolean).forEach((token) => set.add(token));
+                self.className = Array.from(set).join(" ");
+            },
+            remove: (...tokens) => {
+                const toRemove = new Set(tokens.filter(Boolean));
+                const remaining = self.className
+                    .split(/\s+/)
+                    .filter((token) => token && !toRemove.has(token));
+                self.className = remaining.join(" ");
+            },
+            contains: (token) => self.className.split(/\s+/).includes(token),
+        };
+        Object.defineProperty(this, "id", {
+            get() {
+                return self._id;
+            },
+            set(value) {
+                self._id = String(value ?? "");
+                if (self._id) {
+                    documentRef._registerElement(self._id, self);
+                }
+            },
+        });
+    }
+
+    appendChild(node) {
+        if (!node) {
+            return node;
+        }
+        if (node.parentNode && typeof node.parentNode.removeChild === "function") {
+            node.parentNode.removeChild(node);
+        }
+        node.parentNode = this;
+        node.isConnected = true;
+        this.childNodes.push(node);
+        this.firstChild = this.childNodes[0] || null;
+        return node;
+    }
+
+    removeChild(node) {
+        const index = this.childNodes.indexOf(node);
+        if (index === -1) {
+            return node;
+        }
+        this.childNodes.splice(index, 1);
+        node.parentNode = null;
+        node.isConnected = false;
+        this.firstChild = this.childNodes[0] || null;
+        return node;
+    }
+
+    setAttribute(name, value) {
+        const normalized = String(value ?? "");
+        this.attributes.set(name, normalized);
+        if (name === "id") {
+            this.id = normalized;
+        } else if (name === "class") {
+            this.className = normalized;
+        } else if (name === "hidden") {
+            this.hidden = true;
+        }
+    }
+
+    getAttribute(name) {
+        return this.attributes.has(name) ? this.attributes.get(name) : null;
+    }
+
+    removeAttribute(name) {
+        this.attributes.delete(name);
+        if (name === "class") {
+            this.className = "";
+        } else if (name === "hidden") {
+            this.hidden = false;
+        }
+    }
+
+    querySelector() {
+        return null;
+    }
+
+    set textContent(value) {
+        this._textContent = String(value ?? "");
+        this.childNodes = [];
+        this.firstChild = null;
+    }
+
+    get textContent() {
+        return this._textContent;
+    }
+
+    get children() {
+        return this.childNodes;
+    }
+}
+
+function withScenePanelDom(callback) {
+    const elements = new Map();
+    let previousDocument = globalThis.document;
+    let previousElement = globalThis.Element;
+    let previousHTMLElement = globalThis.HTMLElement;
+
+    const documentRef = {
+        body: null,
+        createElement: (tagName) => new StubElement(documentRef, tagName),
+        getElementById: (id) => elements.get(id) || null,
+        _registerElement: (id, element) => {
+            elements.set(id, element);
+        },
+    };
+    documentRef.body = new StubElement(documentRef, "body");
+    documentRef.body.isConnected = true;
+
+    globalThis.document = documentRef;
+    globalThis.Element = StubElement;
+    globalThis.HTMLElement = StubElement;
+
+    try {
+        callback({
+            createElement: (tagName) => new StubElement(documentRef, tagName),
+            registerElement: (id, element) => {
+                element.id = id;
+                return element;
+            },
+            elements,
+        });
+    } finally {
+        if (previousDocument === undefined) {
+            delete globalThis.document;
+        } else {
+            globalThis.document = previousDocument;
+        }
+        if (previousElement === undefined) {
+            delete globalThis.Element;
+        } else {
+            globalThis.Element = previousElement;
+        }
+        if (previousHTMLElement === undefined) {
+            delete globalThis.HTMLElement;
+        } else {
+            globalThis.HTMLElement = previousHTMLElement;
+        }
+        setScenePanelContainer(null);
+        setSceneSectionsContainer(null);
+        setSceneRosterSection(null);
+        setSceneActiveSection(null);
+        setSceneLiveLogSection(null);
+        setSceneCoverageSection(null);
+        setSceneCoveragePronouns(null);
+        setSceneCoverageAttribution(null);
+        setSceneCoverageAction(null);
+        setSceneRosterList(null);
+        setSceneActiveCards(null);
+        setSceneLiveLog(null);
+    }
+}
+
+test("renderScenePanel keeps coverage section visible before data arrives", () => {
+    withScenePanelDom(({ createElement, registerElement }) => {
+        const container = createElement("div");
+        const sectionsContainer = createElement("div");
+        const coverageSection = createElement("section");
+        const coveragePronouns = createElement("div");
+        const coverageAttribution = createElement("div");
+        const coverageAction = createElement("div");
+
+        setScenePanelContainer({ el: container });
+        setSceneSectionsContainer({ el: sectionsContainer });
+        setSceneCoverageSection({ el: coverageSection });
+        setSceneCoveragePronouns({ el: coveragePronouns });
+        setSceneCoverageAttribution({ el: coverageAttribution });
+        setSceneCoverageAction({ el: coverageAction });
+
+        registerElement("cs-scene-panel-toggle", createElement("button"));
+        registerElement("cs-scene-section-toggle-roster", createElement("button"));
+        registerElement("cs-scene-section-toggle-active", createElement("button"));
+        registerElement("cs-scene-section-toggle-log", createElement("button"));
+        registerElement("cs-scene-panel-toggle-auto-open", createElement("button"));
+        const coverageToggle = registerElement("cs-scene-section-toggle-coverage", createElement("button"));
+
+        renderScenePanel({
+            settings: {
+                enabled: true,
+                sections: {
+                    roster: false,
+                    activeCharacters: false,
+                    liveLog: false,
+                    coverage: false,
+                },
+            },
+        });
+
+        assert.equal(coverageSection.getAttribute("data-scene-panel-hidden"), "false");
+        assert.equal(coverageToggle.getAttribute("hidden"), "");
+        assert.equal(coverageToggle.getAttribute("aria-hidden"), "true");
+        assert.equal(coverageToggle.getAttribute("disabled"), "true");
+    });
+});


### PR DESCRIPTION
## Summary
- ensure the scene coverage section always renders regardless of section settings and retire the toolbar toggle
- refresh the coverage placeholders and layout to match the live log presentation
- expand tests to cover placeholder messaging and verify the coverage section stays mounted before data arrives

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691666edb7b88325aac5f265b90808a3)