### PR TITLE
Add coverage section to scene control center and filter user events

### DIFF
--- a/ui/templates/scenePanel.html
+++ b/ui/templates/scenePanel.html
@@ -80,6 +80,31 @@
                     <!-- Live detection results will be appended here -->
                 </div>
             </section>
+            <section class="cs-scene-panel__section" data-scene-panel="coverage">
+                <header class="cs-scene-panel__section-header">
+                    <h4>Coverage suggestions</h4>
+                </header>
+                <div class="cs-coverage-panel" data-scene-panel="coverage-container">
+                    <div>
+                        <h5>Pronouns</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-pronouns">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
+                        </div>
+                    </div>
+                    <div>
+                        <h5>Attribution verbs</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-attribution">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
+                        </div>
+                    </div>
+                    <div>
+                        <h5>Action verbs</h5>
+                        <div class="cs-coverage-list" data-scene-panel="coverage-action">
+                            <div class="cs-scene-panel__placeholder" data-tone="muted">Coverage suggestions will appear after the next assistant message.</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
         <footer class="cs-scene-panel__footer" data-scene-panel="footer">
             <button id="cs-scene-open-settings" class="cs-scene-panel__footer-button" type="button" data-scene-panel="open-settings">


### PR DESCRIPTION
## Summary
- add a dedicated coverage suggestions section to the scene control center markup
- tighten message role detection so user-authored events no longer update the scene state

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166a547e6c832592b78af4fdebacb7)