### PR TITLE
Add coverage toggle to scene control center toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Improved
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
+- **Coverage toggle in the control center.** Coverage suggestions now share the toolbar's quick toggles so the panel can hide or restore vocabulary guidance without opening settings.
 - **Scene panel master toggle placement.** The hide/show switch now anchors to the base of the hero card so it stays visually connected to the gradient header instead of floating above it.
 - **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space as soon as any module is hidden, so two-up layouts immediately expand instead of waiting until only a single section remains.
 - **Live log export parity.** Copying the live log now produces a full report with detection summaries, switch analytics, skip reasons, and roster state—matching the fidelity of the live pattern tester output.

--- a/ui/templates/scenePanel.html
+++ b/ui/templates/scenePanel.html
@@ -34,6 +34,10 @@
                     <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
                     <span class="visually-hidden">Toggle live log section</span>
                 </button>
+                <button id="cs-scene-section-toggle-coverage" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-coverage" aria-pressed="true" title="Hide coverage suggestions section">
+                    <i class="fa-solid fa-language" aria-hidden="true"></i>
+                    <span class="visually-hidden">Toggle coverage suggestions section</span>
+                </button>
                 <button id="cs-scene-refresh" class="cs-scene-panel__icon-button" type="button" data-scene-panel="refresh">
                     <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                     <span class="visually-hidden">Refresh roster</span>


### PR DESCRIPTION
## Summary
- add a dedicated coverage suggestions toggle button to the scene control center toolbar
- note the new toolbar control in the unreleased changelog entry

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166b8c01308325840c7062c21a11d8)