### PR TITLE
Simplify scene summon guard to avoid polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - **Live diagnostics retention.** Streaming preserves the full switch history for the active message instead of trimming entries mid-stream, so the log no longer empties before generation ends.
 - **Scene panel hide toggle.** Hiding the command center now removes the panel entirely so no translucent shell remains on screen.
 - **Scene control center button resilience.** Panel and summon buttons now reset their visual styles within the extension so conflicting theme overrides from other mods can no longer hide or neutralize them.
+- **Scene summon toggle stability.** Restored the summon control's inline visibility guard without the heavy polling loop, preventing slowdowns while keeping the button visible when other mods interfere.
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
 - **Stream start detection resiliency.** Hidden and symbol-keyed SillyTavern events are now recognised when wiring the integration, keeping the side panel aware of streaming starts even when the host app reshuffles its hooks.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.

--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -34,6 +34,18 @@ function isHTMLElement(node) {
     return typeof HTMLElement !== "undefined" && node instanceof HTMLElement;
 }
 
+function applyScenePanelSummonInlineStyles(button) {
+    if (!button || !button.style) {
+        return;
+    }
+    try {
+        button.style.setProperty("display", "inline-flex", "important");
+        button.style.setProperty("visibility", "visible", "important");
+        button.style.setProperty("opacity", "1", "important");
+    } catch (err) {
+    }
+}
+
 function getScenePanelSummonParent() {
     if (typeof document === "undefined") {
         return null;
@@ -63,6 +75,7 @@ function restoreScenePanelSummonButton() {
         if (!button.classList.contains("cs-scene-panel__summon")) {
             button.classList.add("cs-scene-panel__summon");
         }
+        applyScenePanelSummonInlineStyles(button);
         updateScenePanelSummonVisibility(lastScenePanelSummonState.enabled, {
             collapsed: lastScenePanelSummonState.collapsed,
         });
@@ -255,14 +268,7 @@ function updateScenePanelSummonVisibility(enabled, { collapsed = false } = {}) {
     button.hidden = false;
     button.removeAttribute("hidden");
     button.removeAttribute("aria-hidden");
-    if (button.style) {
-        try {
-            button.style.setProperty("display", "inline-flex", "important");
-            button.style.setProperty("visibility", "visible", "important");
-            button.style.setProperty("opacity", "1", "important");
-        } catch (err) {
-        }
-    }
+    applyScenePanelSummonInlineStyles(button);
     button.setAttribute("aria-pressed", enabled ? "true" : "false");
     button.setAttribute("aria-label", enabled ? "Hide scene panel" : "Show scene panel");
     button.title = enabled ? "Hide scene panel" : "Show scene panel";


### PR DESCRIPTION
## Summary
- add a focused helper that reapplies inline display/visibility styles to the scene summon button
- restore the summon visibility guard without the recurring polling loop that caused crashes
- document the stability fix in the changelog

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166f8f59b08325bb6b970da86447f9)