### PR TITLE
Refactor scene roster derivation and UI integration

### DIFF
--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -605,7 +605,7 @@ test("collectScenePanelState analytics updatedAt reflects latest scene activity"
 
     state.recentDecisionEvents = [];
     const panelWithoutEvents = collectScenePanelState();
-    assert.equal(panelWithoutEvents.analytics.updatedAt, rankingTimestamp);
+    assert.equal(panelWithoutEvents.analytics.updatedAt, testerTimestamp);
 });
 
 test("collectScenePanelState ignores tester-sourced refresh requests", () => {


### PR DESCRIPTION
## Summary
- derive roster state from message tracking, stored scene data, and tester outputs for a unified snapshot
- update scene panel state collection and roster manager actions to mutate the new store and propagate roster changes
- simplify the roster renderer and refresh unit tests for TTL handling and analytics timestamps

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691791ddf8f883258cbfa9696f976deb)