### PR TITLE
Guard generation start against nested user payloads

### DIFF
--- a/test/generation-start.test.js
+++ b/test/generation-start.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+await register(new URL("./module-mock-loader.js", import.meta.url));
+
+const extensionSettingsStore = {};
+globalThis.__extensionSettingsStore = extensionSettingsStore;
+
+const { state, extensionName, __testables } = await import("../index.js");
+
+const { handleGenerationStart } = __testables;
+
+extensionSettingsStore[extensionName] = {
+    enabled: true,
+    profiles: { Default: {} },
+    activeProfile: "Default",
+    scorePresets: {},
+    activeScorePreset: "",
+    focusLock: { character: null },
+};
+
+test("handleGenerationStart ignores nested user payloads", () => {
+    const previousKey = state.currentGenerationKey;
+    const previousContext = globalThis.__mockContext;
+
+    state.currentGenerationKey = "m42";
+    globalThis.__mockContext = {
+        chat: [
+            {
+                mesId: 101,
+                message_key: "m101",
+                is_user: true,
+            },
+        ],
+    };
+
+    try {
+        handleGenerationStart({ detail: { message: { mesId: 101, message_key: "m101", is_user: true } } });
+        assert.equal(state.currentGenerationKey, null);
+    } finally {
+        state.currentGenerationKey = previousKey;
+        if (typeof previousContext === "undefined") {
+            delete globalThis.__mockContext;
+        } else {
+            globalThis.__mockContext = previousContext;
+        }
+    }
+});
+
+test("handleGenerationStart consults chat history for user-authored messages", () => {
+    const previousKey = state.currentGenerationKey;
+    const previousContext = globalThis.__mockContext;
+
+    state.currentGenerationKey = "m77";
+    globalThis.__mockContext = {
+        chat: [
+            {
+                mesId: 202,
+                message_key: "m202",
+                is_user: true,
+            },
+        ],
+    };
+
+    try {
+        handleGenerationStart({ detail: { message: { mesId: 202 } } });
+        assert.equal(state.currentGenerationKey, null);
+    } finally {
+        state.currentGenerationKey = previousKey;
+        if (typeof previousContext === "undefined") {
+            delete globalThis.__mockContext;
+        } else {
+            globalThis.__mockContext = previousContext;
+        }
+    }
+});

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -15,14 +15,14 @@ export async function load(url, context, defaultLoad) {
     if (url === "node:mock/extensions") {
         return {
             format: "module",
-            source: `const store = globalThis.__extensionSettingsStore || (globalThis.__extensionSettingsStore = {});\nexport const extension_settings = store;\nexport function getContext() {\n    return { extensionSettings: store, saveSettingsDebounced: () => {} };\n}\nexport async function renderExtensionTemplateAsync() {\n    return '<div id="cs-scene-panel"></div>';\n}`,
+            source: `const store = globalThis.__extensionSettingsStore || (globalThis.__extensionSettingsStore = {});\nexport const extension_settings = store;\nexport function getContext() {\n    const extra = globalThis.__mockContext;\n    const base = { extensionSettings: store, saveSettingsDebounced: () => {} };\n    if (extra && typeof extra === "object") {\n        return { ...base, ...extra };\n    }\n    return base;\n}\nexport async function renderExtensionTemplateAsync() {\n    return '<div id="cs-scene-panel"></div>';\n}`,
             shortCircuit: true,
         };
     }
     if (url === "node:mock/script") {
         return {
             format: "module",
-            source: `export const saveSettingsDebounced = () => {};\nexport const saveChatDebounced = () => {};\nexport const event_types = {};\nexport const eventSource = { on: () => {}, off: () => {} };`,
+            source: `export const saveSettingsDebounced = () => {};\nexport const saveChatDebounced = () => {};\nexport const event_types = {};\nexport const eventSource = { on: () => {}, off: () => {} };\nexport const system_message_types = { NARRATOR: "narrator" };`,
             shortCircuit: true,
         };
     }


### PR DESCRIPTION
## Summary
- expand resolveMessageRoleFromArgs to inspect nested message/detail payloads and narrator markers when deriving roles
- make handleGenerationStart adopt chat lookups for ambiguous events and skip generation for user/system/narrator entries
- expose system_message_types in the test harness and add regression tests for nested generation-start payloads

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917993b4f2c832581840bdd41119c3a)