### PR TITLE
Extend role resolver traversal for nested payloads

### DIFF
--- a/test/generation-start.test.js
+++ b/test/generation-start.test.js
@@ -9,7 +9,7 @@ globalThis.__extensionSettingsStore = extensionSettingsStore;
 
 const { state, extensionName, __testables } = await import("../index.js");
 
-const { handleGenerationStart } = __testables;
+const { handleGenerationStart, resolveMessageRoleFromArgs } = __testables;
 
 extensionSettingsStore[extensionName] = {
     enabled: true,
@@ -74,4 +74,33 @@ test("handleGenerationStart consults chat history for user-authored messages", (
             globalThis.__mockContext = previousContext;
         }
     }
+});
+
+test("resolveMessageRoleFromArgs inspects payload containers", () => {
+    const role = resolveMessageRoleFromArgs([
+        { payload: { message: { is_user: true } } },
+    ]);
+    assert.equal(role, "user");
+});
+
+test("resolveMessageRoleFromArgs inspects payload message collections", () => {
+    const role = resolveMessageRoleFromArgs([
+        { payload: { messages: [{ role: "system" }] } },
+    ]);
+    assert.equal(role, "system");
+});
+
+test("resolveMessageRoleFromArgs inspects event and data wrappers", () => {
+    const role = resolveMessageRoleFromArgs([
+        {
+            event: {
+                data: {
+                    messages: [
+                        { is_assistant: true },
+                    ],
+                },
+            },
+        },
+    ]);
+    assert.equal(role, "assistant");
 });


### PR DESCRIPTION
## Summary
- extend `resolveMessageRoleFromArgs` to traverse payload, event, and data containers in addition to detail
- expose the resolver for tests and verify user/system/assistant roles are detected in new wrappers

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a48b05e88325919cc59ec4ed5d82)