### PR TITLE
Add regex script preprocessor pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Roster expiry counter.** Every roster entry now displays the remaining message count before it expires, making it easy to spot characters that are about to drop from the scene.
 - **Aurora side panel finish.** The roster workspace picked up animated lighting, hover glows, and a responsive section scaffold so the settings footer stays anchored and never falls off-screen.
 - **Coverage suggestions in the scene panel.** Vocabulary guidance from the live tester now appears alongside the roster with quick-add pills that update in real time as chats roll in.
+- **Regex preprocessor opt-ins.** Profiles can opt into allowed global, preset, and scoped regex scripts, and the Live Tester now reveals the preprocessed text they run against.
 
 ### Improved
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.

--- a/settings.html
+++ b/settings.html
@@ -521,56 +521,61 @@
                             <p class="cs-summary-help">Use the score, roster, and coverage panes below to focus your next tweaks.</p>
                         </div>
                     </div>
-                  <div class="cs-tester-panels">
+                <div class="cs-tester-panels">
                     <section class="cs-tester-panel cs-tester-panel--flow">
-                      <header class="cs-tester-panel-header">
-                        <h4>Match Flow</h4>
-                        <p>Follow detections through to the costume decision.</p>
-                      </header>
-                      <div class="cs-tester-split">
-                        <div class="cs-tester-pane">
-                          <div class="cs-tester-title">All Detections</div>
-                          <p class="cs-helper-text">Every detection we spotted, in order.</p>
-                          <ul id="cs-test-all-detections" class="cs-tester-list">
-                            <li class="cs-tester-list-placeholder">Results will appear here.</li>
-                          </ul>
+                        <header class="cs-tester-panel-header">
+                            <h4>Match Flow</h4>
+                            <p>Follow detections through to the costume decision.</p>
+                        </header>
+                        <div class="cs-tester-preprocessed">
+                            <div class="cs-tester-title">Preprocessed Text</div>
+                            <p class="cs-helper-text">Buffer after running allowed regex scripts.</p>
+                            <pre id="cs-test-preprocessed" class="cs-tester-preprocessed__output cs-tester-list-placeholder" data-placeholder="No scripts applied yet.">No scripts applied yet.</pre>
                         </div>
-                        <div class="cs-tester-pane">
-                          <div class="cs-tester-title">Live Switch Decisions</div>
-                          <p class="cs-helper-text">Who would have received the costume change.</p>
-                          <ul id="cs-test-winner-list" class="cs-tester-list">
-                            <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
-                          </ul>
+                        <div class="cs-tester-split">
+                            <div class="cs-tester-pane">
+                                <div class="cs-tester-title">All Detections</div>
+                                <p class="cs-helper-text">Every detection we spotted, in order.</p>
+                                <ul id="cs-test-all-detections" class="cs-tester-list">
+                                    <li class="cs-tester-list-placeholder">Results will appear here.</li>
+                                </ul>
+                            </div>
+                            <div class="cs-tester-pane">
+                                <div class="cs-tester-title">Live Switch Decisions</div>
+                                <p class="cs-helper-text">Who would have received the costume change.</p>
+                                <ul id="cs-test-winner-list" class="cs-tester-list">
+                                    <li class="cs-tester-list-placeholder">Stream results will appear here.</li>
+                                </ul>
+                            </div>
                         </div>
-                      </div>
                     </section>
                     <section class="cs-tester-panel cs-tester-panel--roster">
-                      <header class="cs-tester-panel-header">
-                        <h4>Scene Roster</h4>
-                        <p>Check for churn or TTL gaps that could impact switching.</p>
-                      </header>
-                      <div class="cs-tester-stack">
-                        <ul id="cs-test-roster-timeline" class="cs-tester-list">
-                          <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
-                        </ul>
-                        <div class="cs-roster-health">
-                          <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
-                          <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
+                        <header class="cs-tester-panel-header">
+                            <h4>Scene Roster</h4>
+                            <p>Check for churn or TTL gaps that could impact switching.</p>
+                        </header>
+                        <div class="cs-tester-stack">
+                            <ul id="cs-test-roster-timeline" class="cs-tester-list">
+                                <li class="cs-tester-list-placeholder">Run the tester to see roster events.</li>
+                            </ul>
+                            <div class="cs-roster-health">
+                                <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
+                                <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
+                            </div>
                         </div>
-                      </div>
                     </section>
                     <section class="cs-tester-panel cs-tester-panel--score">
-                      <header class="cs-tester-panel-header">
-                        <h4>Score Breakdown</h4>
-                        <p>Scroll to compare how each detection contributed.</p>
-                      </header>
-                      <div class="cs-score-scroll">
-                        <table id="cs-test-score-breakdown" class="cs-score-table">
-                          <tbody>
-                            <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
-                          </tbody>
-                        </table>
-                      </div>
+                        <header class="cs-tester-panel-header">
+                            <h4>Score Breakdown</h4>
+                            <p>Scroll to compare how each detection contributed.</p>
+                        </header>
+                        <div class="cs-score-scroll">
+                            <table id="cs-test-score-breakdown" class="cs-score-table">
+                                <tbody>
+                                    <tr><td colspan="3" class="cs-tester-list-placeholder">Run the tester to see weighted scores.</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </section>
                     <section class="cs-tester-panel cs-tester-panel--coverage">
                       <header class="cs-tester-panel-header">

--- a/src/core/script-preprocessor.js
+++ b/src/core/script-preprocessor.js
@@ -1,0 +1,100 @@
+import { getScriptsByType, runRegexScript, SCRIPT_TYPES } from "../../regex/engine.js";
+
+const SCRIPT_COLLECTION_DEFINITIONS = [
+    { key: "global", type: SCRIPT_TYPES.GLOBAL },
+    { key: "preset", type: SCRIPT_TYPES.PRESET },
+    { key: "scoped", type: SCRIPT_TYPES.SCOPED },
+];
+
+function normalizeCollectionKey(value) {
+    if (typeof value !== "string") {
+        return null;
+    }
+    const normalized = value.trim().toLowerCase();
+    return SCRIPT_COLLECTION_DEFINITIONS.some(entry => entry.key === normalized)
+        ? normalized
+        : null;
+}
+
+export function resolveProfileScriptCollections(source) {
+    const selections = new Set();
+    if (!source) {
+        return [];
+    }
+    if (Array.isArray(source)) {
+        source.forEach((entry) => {
+            const normalized = normalizeCollectionKey(entry);
+            if (normalized) {
+                selections.add(normalized);
+            }
+        });
+    } else if (typeof source === "object") {
+        Object.entries(source).forEach(([key, value]) => {
+            if (!value) {
+                return;
+            }
+            const normalized = normalizeCollectionKey(key);
+            if (normalized) {
+                selections.add(normalized);
+            }
+        });
+    } else {
+        const normalized = normalizeCollectionKey(source);
+        if (normalized) {
+            selections.add(normalized);
+        }
+    }
+    if (!selections.size) {
+        return [];
+    }
+    return SCRIPT_COLLECTION_DEFINITIONS
+        .map(entry => entry.key)
+        .filter(key => selections.has(key));
+}
+
+export function collectProfilePreprocessorScripts(profile) {
+    const selections = resolveProfileScriptCollections(profile?.scriptCollections);
+    if (!selections.length) {
+        return [];
+    }
+    const pipeline = [];
+    selections.forEach((key) => {
+        const definition = SCRIPT_COLLECTION_DEFINITIONS.find(entry => entry.key === key);
+        if (!definition) {
+            return;
+        }
+        const scripts = getScriptsByType(definition.type, { allowedOnly: true }) || [];
+        scripts.forEach((script) => {
+            if (!script || typeof script !== "object") {
+                return;
+            }
+            pipeline.push({ collection: key, script });
+        });
+    });
+    return pipeline;
+}
+
+export function applyPreprocessorScripts(text, pipeline = [], options = {}) {
+    const initial = typeof text === "string" ? text : String(text ?? "");
+    if (!Array.isArray(pipeline) || pipeline.length === 0) {
+        return { text: initial, applied: [] };
+    }
+    const applied = [];
+    let output = initial;
+    pipeline.forEach((entry) => {
+        if (!entry || typeof entry !== "object") {
+            return;
+        }
+        const script = entry.script;
+        if (!script || typeof script !== "object") {
+            return;
+        }
+        try {
+            output = runRegexScript(script, output, options);
+            applied.push({ collection: entry.collection, script });
+        } catch (err) {
+            console.warn("applyPreprocessorScripts: failed to run regex script", err);
+        }
+    });
+    return { text: output, applied };
+}

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -70,6 +70,7 @@ const sceneDisplayNames = new Map();
 let rosterUpdatedAt = 0;
 const liveTesterOutputs = new Map();
 let liveTesterUpdatedAt = 0;
+let liveTesterPreprocessedText = "";
 
 function resolveDisplayName(normalized, displayNames) {
     if (displayNames.has(normalized)) {
@@ -384,6 +385,7 @@ export function replaceLiveTesterOutputs(events = [], {
     roster = [],
     displayNames = null,
     timestamp = Date.now(),
+    preprocessedText = null,
 } = {}) {
     liveTesterOutputs.clear();
     const normalizedDisplayNames = normalizeDisplayNameMap(displayNames);
@@ -455,6 +457,7 @@ export function replaceLiveTesterOutputs(events = [], {
     }
 
     liveTesterUpdatedAt = timestamp;
+    liveTesterPreprocessedText = typeof preprocessedText === "string" ? preprocessedText : "";
     return getLiveTesterOutputsSnapshot();
 }
 
@@ -462,6 +465,7 @@ export function getLiveTesterOutputsSnapshot() {
     return {
         updatedAt: liveTesterUpdatedAt,
         entries: Array.from(liveTesterOutputs.values()).map(cloneTesterOutput),
+        preprocessedText: liveTesterPreprocessedText,
     };
 }
 
@@ -477,6 +481,7 @@ export function getLiveTesterOutput(name) {
 export function clearLiveTesterOutputs() {
     liveTesterOutputs.clear();
     liveTesterUpdatedAt = Date.now();
+    liveTesterPreprocessedText = "";
     return liveTesterUpdatedAt;
 }
 

--- a/style.css
+++ b/style.css
@@ -1305,6 +1305,29 @@
   font-size: 0.95rem;
 }
 
+#costume-switcher-settings.cs-theme .cs-tester-preprocessed {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 14px;
+}
+
+#costume-switcher-settings.cs-theme .cs-tester-preprocessed__output {
+    margin: 0;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    font-family: "JetBrains Mono", "Fira Code", monospace;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 160px;
+    overflow-y: auto;
+    color: var(--text-color);
+}
+
 #costume-switcher-settings.cs-theme .cs-tester-list {
   list-style: none;
   margin: 0;

--- a/test/detector-core.test.js
+++ b/test/detector-core.test.js
@@ -1,10 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-
-import {
-    compileProfileRegexes,
-    collectDetections,
-} from '../src/detector-core.js';
+import { register } from 'node:module';
 import {
     DEFAULT_ACTION_VERBS_PRESENT,
     DEFAULT_ACTION_VERBS_THIRD_PERSON,
@@ -17,6 +13,13 @@ import {
     DEFAULT_ATTRIBUTION_VERBS_PAST_PARTICIPLE,
     DEFAULT_ATTRIBUTION_VERBS_PRESENT_PARTICIPLE,
 } from '../verbs.js';
+
+await register(new URL('./module-mock-loader.js', import.meta.url));
+
+const {
+    compileProfileRegexes,
+    collectDetections,
+} = await import('../src/detector-core.js');
 
 const buildVerbList = (...lists) => Array.from(new Set(lists.flat().filter(Boolean)));
 

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -8,6 +8,9 @@ export async function resolve(specifier, context, defaultResolve) {
     if (specifier === "../../../slash-commands.js") {
         return { url: "node:mock/slash", shortCircuit: true };
     }
+    if (specifier === "../regex/engine.js" || specifier === "../../regex/engine.js") {
+        return { url: "node:mock/regex-engine", shortCircuit: true };
+    }
     return defaultResolve(specifier, context, defaultResolve);
 }
 
@@ -30,6 +33,13 @@ export async function load(url, context, defaultLoad) {
         return {
             format: "module",
             source: `export const executeSlashCommandsOnChatInput = async () => {};\nexport const registerSlashCommand = () => {};`,
+            shortCircuit: true,
+        };
+    }
+    if (url === "node:mock/regex-engine") {
+        return {
+            format: "module",
+            source: `const store = globalThis.__regexMockStore || (globalThis.__regexMockStore = { scripts: {} });\nconst SCRIPT_TYPE_ORDER = [0, 2, 1];\nexport const SCRIPT_TYPES = { GLOBAL: 0, PRESET: 2, SCOPED: 1 };\nfunction readScripts(type) {\n    const key = String(type);\n    const value = store.scripts[key];\n    if (Array.isArray(value)) {\n        return value;\n    }\n    const empty = [];\n    store.scripts[key] = empty;\n    return empty;\n}\nexport function getScriptsByType(scriptType, { allowedOnly } = {}) {\n    const scripts = readScripts(scriptType);\n    if (!allowedOnly) {\n        return scripts.slice();\n    }\n    return scripts.filter(script => script && script.allowed !== false);\n}\nexport function getRegexScripts({ allowedOnly } = {}) {\n    return SCRIPT_TYPE_ORDER.flatMap(type => getScriptsByType(type, { allowedOnly }));\n}\nexport function runRegexScript(script, text) {\n    const input = typeof text === 'string' ? text : String(text ?? '');\n    if (!script) {\n        return input;\n    }\n    if (typeof script.apply === 'function') {\n        return script.apply(input);\n    }\n    if (typeof script.findRegex === 'string') {\n        try {\n            const flags = typeof script.flags === 'string' ? script.flags : 'g';\n            const regex = new RegExp(script.findRegex, flags);\n            const replacement = typeof script.replaceString === 'string' ? script.replaceString : '';\n            return input.replace(regex, replacement);\n        } catch {\n            return input;\n        }\n    }\n    return input;\n}`,
             shortCircuit: true,
         };
     }

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -93,6 +93,15 @@ test('normalizeProfile preserves non-enumerable mapping identifiers', () => {
     assert.ok(descriptor && descriptor.enumerable === false, 'card identifier should remain non-enumerable');
 });
 
+test('normalizeProfile normalizes script collection opt-ins', () => {
+    const normalized = normalizeProfile({
+        scriptCollections: { global: true, preset: true, scoped: false },
+    }, PROFILE_DEFAULTS);
+
+    assert.deepEqual(normalized.scriptCollections, ['global', 'preset'],
+        'script collections should normalize to an ordered opt-in list');
+});
+
 test('mappingHasIdentity accepts partially configured character slots', () => {
     assert.equal(mappingHasIdentity({}), false, 'empty mapping should not persist');
     assert.equal(mappingHasIdentity({ name: 'Draft Character' }), true, 'name-only mapping should persist');

--- a/test/regex-preprocessor.test.js
+++ b/test/regex-preprocessor.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+await register(new URL("./module-mock-loader.js", import.meta.url));
+
+const { compileProfileRegexes, collectDetections } = await import("../src/detector-core.js");
+const { SCRIPT_TYPES } = await import("../regex/engine.js");
+
+function configureScriptsByType(map) {
+    const store = globalThis.__regexMockStore || (globalThis.__regexMockStore = { scripts: {} });
+    store.scripts = {};
+    Object.entries(map || {}).forEach(([type, scripts]) => {
+        const normalizedType = String(type);
+        store.scripts[normalizedType] = Array.isArray(scripts)
+            ? scripts.map(script => ({ ...script }))
+            : [];
+    });
+}
+
+function buildProfile(overrides = {}) {
+    return {
+        patterns: ["Kotori"],
+        ignorePatterns: [],
+        detectGeneral: true,
+        detectAttribution: false,
+        detectAction: false,
+        detectVocative: false,
+        detectPossessive: false,
+        detectPronoun: false,
+        scriptCollections: [],
+        ...overrides,
+    };
+}
+
+function collectNames(text, profile, regexes) {
+    const matches = collectDetections(text, profile, regexes, { priorityWeights: { name: 1 } });
+    return { matches, names: matches.map(entry => entry.name) };
+}
+
+test("preprocessor pipelines scripts in collection priority order", () => {
+    configureScriptsByType({
+        [SCRIPT_TYPES.GLOBAL]: [
+            { id: "global", apply: (text) => `${text} →global` },
+        ],
+        [SCRIPT_TYPES.PRESET]: [
+            { id: "preset", apply: (text) => `${text} →preset` },
+        ],
+        [SCRIPT_TYPES.SCOPED]: [
+            { id: "scoped", apply: (text) => `${text} →scoped` },
+        ],
+    });
+
+    const profile = buildProfile({ scriptCollections: ["scoped", "global", "preset"] });
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\\p{L}\\\p{M}\\\p{N}_]",
+        defaultPronouns: ["she"],
+    });
+    const { matches } = collectNames("Kotori", profile, regexes);
+
+    assert.equal(matches.preprocessedText, "Kotori →global →preset →scoped");
+    assert.ok(matches.length > 0, "expected a detection after preprocessing");
+});
+
+test("preprocessor only runs scripts that are allowed", () => {
+    configureScriptsByType({
+        [SCRIPT_TYPES.GLOBAL]: [
+            {
+                id: "allowed",
+                apply: (text) => text.replace("Hero", "Kotori"),
+                allowed: true,
+            },
+            {
+                id: "blocked",
+                apply: (text) => `${text} [blocked]`,
+                allowed: false,
+            },
+        ],
+    });
+
+    const profile = buildProfile({ scriptCollections: ["global"] });
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\\p{L}\\\p{M}\\\p{N}_]",
+        defaultPronouns: ["she"],
+    });
+    const { matches, names } = collectNames("Hero rallies forward.", profile, regexes);
+
+    assert.equal(matches.preprocessedText, "Kotori rallies forward.");
+    assert.ok(names.includes("Kotori"), "expected transformed text to yield a Kotori match");
+});
+
+test("profiles without script opt-ins keep the original text", () => {
+    configureScriptsByType({
+        [SCRIPT_TYPES.GLOBAL]: [
+            { id: "noop", apply: (text) => `${text} mutated` },
+        ],
+    });
+
+    const profile = buildProfile({ scriptCollections: [] });
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\\p{L}\\\p{M}\\\p{N}_]",
+        defaultPronouns: ["she"],
+    });
+    const { matches } = collectNames("Kotori", profile, regexes);
+
+    assert.equal(matches.preprocessedText, "Kotori");
+});

--- a/test/simulate-tester-stream.test.js
+++ b/test/simulate-tester-stream.test.js
@@ -219,6 +219,8 @@ test("simulateTesterStream records per-character tester outputs", () => {
     assert.ok(kotoriEntry, "expected Kotori to appear in tester outputs");
     assert.ok(kotoriEntry.summary.switches + kotoriEntry.summary.skips + kotoriEntry.summary.vetoes > 0,
         "expected Kotori tester summary to track events");
+    assert.equal(snapshot.preprocessedText, state.lastPreprocessedText,
+        "tester snapshot should expose the latest preprocessed buffer");
 });
 
 test("simulateTesterStream syncs tester events into the shared decision log", () => {

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -2,15 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { register } from "node:module";
 
-import { renderActiveCharacters } from "../src/ui/render/activeCharacters.js";
-import { createScenePanelRefreshHandler } from "../src/ui/render/panel.js";
-import { compileProfileRegexes } from "../src/detector-core.js";
-
 await register(new URL("./module-mock-loader.js", import.meta.url));
 
 const extensionSettingsStore = {};
 globalThis.__extensionSettingsStore = extensionSettingsStore;
 
+const { renderActiveCharacters } = await import("../src/ui/render/activeCharacters.js");
+const { createScenePanelRefreshHandler } = await import("../src/ui/render/panel.js");
+const { compileProfileRegexes } = await import("../src/detector-core.js");
 const { getWinner, extensionName, adjustWindowForTrim, handleStream, remapMessageKey, state, collectScenePanelState, __testables } = await import("../index.js");
 
 const {


### PR DESCRIPTION
## Summary
- add a shared regex script preprocessor that collects allowed global, preset, and scoped scripts and applies them before detection
- allow profiles to opt into script collections, capture preprocessed buffers in detector output, and surface the processed text in the Live Tester UI/state
- expand the test suite with preprocessor coverage and update existing tests to use the regex engine mock

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917acad90488325904e16dc21339e64)