### PR TITLE
Add tokenizer-aware detection metadata and tests

### DIFF
--- a/src/ui/render/activeCharacters.js
+++ b/src/ui/render/activeCharacters.js
@@ -75,6 +75,18 @@ function renderCard(entry, { displayNames, now, pinned = false }) {
         if (Number.isFinite(lastEvent.charIndex)) {
             eventParts.push(`#${lastEvent.charIndex + 1}`);
         }
+        if (Number.isFinite(lastEvent.tokenIndex)) {
+            const tokenStart = lastEvent.tokenIndex + 1;
+            const tokenLength = Number.isFinite(lastEvent.tokenLength) && lastEvent.tokenLength > 1
+                ? lastEvent.tokenLength
+                : null;
+            if (tokenLength) {
+                const tokenEnd = tokenStart + tokenLength - 1;
+                eventParts.push(`T#${tokenStart}…${tokenEnd}`);
+            } else {
+                eventParts.push(`T#${tokenStart}`);
+            }
+        }
         if (when) {
             eventParts.push(when);
         }

--- a/src/ui/render/liveLog.js
+++ b/src/ui/render/liveLog.js
@@ -118,6 +118,18 @@ function renderEvent(entry, displayNames, now) {
     if (Number.isFinite(entry.charIndex)) {
         metaParts.push(`#${entry.charIndex + 1}`);
     }
+    if (Number.isFinite(entry.tokenIndex)) {
+        const tokenStart = entry.tokenIndex + 1;
+        const tokenLength = Number.isFinite(entry.tokenLength) && entry.tokenLength > 1
+            ? entry.tokenLength
+            : null;
+        if (tokenLength) {
+            const tokenEnd = tokenStart + tokenLength - 1;
+            metaParts.push(`T#${tokenStart}…${tokenEnd}`);
+        } else {
+            metaParts.push(`T#${tokenStart}`);
+        }
+    }
     if (entry.outfit?.label) {
         metaParts.push(entry.outfit.label);
     }
@@ -148,7 +160,11 @@ export function renderLiveLog(target, panelState = {}) {
     const events = Array.isArray(analytics.events) ? analytics.events : [];
     const stats = analytics.stats instanceof Map ? analytics.stats : null;
     const buffer = typeof analytics.buffer === "string" ? analytics.buffer : "";
-    const tokenCount = buffer.trim() ? buffer.trim().split(/\s+/).filter(Boolean).length : 0;
+    const tokenCount = Number.isFinite(analytics.tokenCount)
+        ? analytics.tokenCount
+        : buffer.trim()
+            ? buffer.trim().split(/\s+/).filter(Boolean).length
+            : 0;
     const charCount = buffer.length;
     const now = Number.isFinite(panelState.now) ? panelState.now : Date.now();
 

--- a/src/ui/render/sceneRoster.js
+++ b/src/ui/render/sceneRoster.js
@@ -77,6 +77,18 @@ function describeTesterSummary(testerEntry, now) {
         if (Number.isFinite(lastEvent.charIndex)) {
             detailParts.push(`#${lastEvent.charIndex + 1}`);
         }
+        if (Number.isFinite(lastEvent.tokenIndex)) {
+            const tokenStart = lastEvent.tokenIndex + 1;
+            const tokenLength = Number.isFinite(lastEvent.tokenLength) && lastEvent.tokenLength > 1
+                ? lastEvent.tokenLength
+                : null;
+            if (tokenLength) {
+                const tokenEnd = tokenStart + tokenLength - 1;
+                detailParts.push(`T#${tokenStart}…${tokenEnd}`);
+            } else {
+                detailParts.push(`T#${tokenStart}`);
+            }
+        }
         const detail = detailParts.length ? ` (${detailParts.join(" · ")})` : "";
         const when = Number.isFinite(lastEvent.timestamp) ? formatRelativeTime(lastEvent.timestamp, now) : null;
         const line = `Last ${label}${detail}${when ? ` · ${when}` : ""}`;

--- a/test/simulate-tester-stream.test.js
+++ b/test/simulate-tester-stream.test.js
@@ -173,8 +173,12 @@ test("first-token pronoun yields a detection when falling back to the pending su
     }).filter(match => match.matchKind === "pronoun");
     assert.ok(pronounMatches.length > 0, "expected a pronoun match from the detector core");
     assert.equal(pronounMatches[0].matchIndex, 0, "pronoun detection should start at the first token");
+    assert.equal(pronounMatches[0].tokenIndex, 0, "pronoun detection should begin with the first token index");
     const expectedEnd = pronounMatches[0].matchIndex + (pronounMatches[0].matchLength || 1) - 1;
     assert.equal(pronounEvents[0].charIndex, expectedEnd, "pronoun detection should report the ending index of the match span");
+    const expectedTokenEnd = pronounMatches[0].tokenIndex + (pronounMatches[0].tokenLength || 1) - 1;
+    const eventTokenEnd = pronounEvents[0].tokenIndex + ((pronounEvents[0].tokenLength || 1) - 1);
+    assert.equal(eventTokenEnd, expectedTokenEnd, "pronoun detection should report the ending token span");
     assert.equal(msgState.pendingSubject, "Kotori", "pending subject should persist until a non-pronoun confirmation occurs");
 });
 

--- a/test/token-distance-scoring.test.js
+++ b/test/token-distance-scoring.test.js
@@ -1,0 +1,170 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+await register(new URL("./module-mock-loader.js", import.meta.url));
+
+import { registerTokenizer } from "../tokenizers.js";
+const { compileProfileRegexes, collectDetections } = await import("../src/detector-core.js");
+const { getWinner } = await import("../index.js");
+
+const SAMPLE_TEXT = "Alice moved quietly across the chamber. Moments later, Alice whispered a warning.";
+
+function registerTestTokenizers() {
+    registerTokenizer("cs-mock-whitespace", {
+        name: "Mock Whitespace",
+        tokenize(text) {
+            const input = typeof text === "string" ? text : String(text ?? "");
+            if (!input) {
+                return { ids: [], offsets: [], chunks: [] };
+            }
+            const ids = [];
+            const offsets = [];
+            const chunks = [];
+            const pattern = /\S+/g;
+            let match;
+            while ((match = pattern.exec(input)) !== null) {
+                const chunk = match[0];
+                ids.push(ids.length + 1);
+                offsets.push({ start: match.index, end: match.index + chunk.length });
+                chunks.push(chunk);
+            }
+            return { ids, offsets, chunks };
+        },
+    });
+
+    registerTokenizer("cs-mock-bigram", {
+        name: "Mock Bigrams",
+        tokenize(text) {
+            const input = typeof text === "string" ? text : String(text ?? "");
+            if (!input) {
+                return { ids: [], offsets: [], chunks: [] };
+            }
+            const ids = [];
+            const offsets = [];
+            const chunks = [];
+            for (let index = 0; index < input.length; index += 2) {
+                const end = Math.min(input.length, index + 2);
+                const chunk = input.slice(index, end);
+                ids.push(ids.length + 1);
+                offsets.push({ start: index, end });
+                chunks.push(chunk);
+            }
+            return { ids, offsets, chunks };
+        },
+    });
+}
+
+function buildProfile(overrides = {}) {
+    return {
+        patterns: ["Alice"],
+        ignorePatterns: [],
+        vetoPatterns: [],
+        defaultCostume: "",
+        debug: false,
+        globalCooldownMs: 0,
+        perTriggerCooldownMs: 0,
+        failedTriggerCooldownMs: 0,
+        maxBufferChars: 128,
+        repeatSuppressMs: 0,
+        tokenProcessThreshold: 0,
+        mappings: [],
+        enableOutfits: false,
+        detectAttribution: false,
+        detectAction: false,
+        detectVocative: false,
+        detectPossessive: false,
+        detectPronoun: false,
+        detectGeneral: true,
+        pronounVocabulary: ["she"],
+        attributionVerbs: [],
+        actionVerbs: [],
+        detectionBias: 0,
+        enableSceneRoster: false,
+        prioritySpeakerWeight: 5,
+        priorityAttributionWeight: 4,
+        priorityActionWeight: 3,
+        priorityPronounWeight: 2,
+        priorityVocativeWeight: 2,
+        priorityPossessiveWeight: 1,
+        priorityNameWeight: 1,
+        rosterBonus: 0,
+        rosterPriorityDropoff: 0,
+        distancePenaltyWeight: 1,
+        ...overrides,
+    };
+}
+
+function detectWithTokenizer(profile, tokenizerId, options = {}) {
+    const configured = { ...profile, tokenizerId };
+    const { regexes } = compileProfileRegexes(configured, {
+        unicodeWordPattern: "[\\p{L}\\p{M}\\p{N}_]",
+        defaultPronouns: configured.pronounVocabulary,
+    });
+    return collectDetections(SAMPLE_TEXT, configured, regexes, {
+        priorityWeights: { name: 1 },
+        ...options,
+    });
+}
+
+registerTestTokenizers();
+
+const baseProfile = buildProfile();
+
+function extractMinChar(matches) {
+    const first = matches.find((entry) => entry.matchKind === "name");
+    if (!first) {
+        return 0;
+    }
+    const length = Number.isFinite(first.matchLength) ? first.matchLength : 1;
+    return first.matchIndex + length;
+}
+
+test("collectDetections exposes token metadata for configured tokenizer", () => {
+    const matches = detectWithTokenizer(baseProfile, "cs-mock-whitespace");
+    assert.ok(Number.isFinite(matches.tokenCount), "expected total token count on match collection");
+    const first = matches.find((entry) => entry.matchKind === "name");
+    assert.ok(first, "expected at least one name match");
+    assert.ok(Number.isFinite(first.tokenIndex), "match should include token index");
+    assert.ok(Number.isFinite(first.tokenLength) && first.tokenLength > 0, "match should include token length");
+});
+
+test("token-aware minimum filtering skips prior detections across tokenizers", () => {
+    const whitespaceMatches = detectWithTokenizer(baseProfile, "cs-mock-whitespace");
+    const minChar = extractMinChar(whitespaceMatches);
+
+    const filteredWhitespace = detectWithTokenizer(baseProfile, "cs-mock-whitespace", { minIndex: minChar });
+    const filteredBigrams = detectWithTokenizer(baseProfile, "cs-mock-bigram", { minIndex: minChar });
+
+    assert.equal(filteredWhitespace.length, 1, "whitespace tokenizer should leave only the latest match");
+    assert.equal(filteredBigrams.length, 1, "bigram tokenizer should leave only the latest match");
+    assert.equal(filteredWhitespace[0].matchIndex, filteredBigrams[0].matchIndex, "filtered match should share char index");
+});
+
+test("distance scoring prefers the most recent detection regardless of tokenizer", () => {
+    const whitespaceMatches = detectWithTokenizer(baseProfile, "cs-mock-whitespace");
+    const bigramMatches = detectWithTokenizer(baseProfile, "cs-mock-bigram");
+
+    const whitespaceWinner = getWinner(whitespaceMatches, 0, SAMPLE_TEXT.length, {
+        rosterSet: null,
+        rosterBonus: 0,
+        rosterPriorityDropoff: 0,
+        distancePenaltyWeight: 1,
+        priorityMultiplier: 100,
+        tokenLength: Number.isFinite(whitespaceMatches.tokenCount) ? whitespaceMatches.tokenCount : null,
+    });
+
+    const bigramWinner = getWinner(bigramMatches, 0, SAMPLE_TEXT.length, {
+        rosterSet: null,
+        rosterBonus: 0,
+        rosterPriorityDropoff: 0,
+        distancePenaltyWeight: 1,
+        priorityMultiplier: 100,
+        tokenLength: Number.isFinite(bigramMatches.tokenCount) ? bigramMatches.tokenCount : null,
+    });
+
+    assert.ok(whitespaceWinner, "expected a winner for whitespace tokenizer");
+    assert.ok(bigramWinner, "expected a winner for bigram tokenizer");
+    assert.equal(whitespaceWinner.name, bigramWinner.name, "winners should agree across tokenizers");
+    assert.equal(whitespaceWinner.matchIndex, bigramWinner.matchIndex, "winner character index should match");
+});

--- a/tokenizers.js
+++ b/tokenizers.js
@@ -1,0 +1,126 @@
+const tokenizers = {
+    DEFAULT: "basic-whitespace",
+};
+
+const registry = new Map();
+
+function normalizeTokenizerId(value) {
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed) {
+            return trimmed;
+        }
+    }
+    return tokenizers.DEFAULT;
+}
+
+function ensureTokenizer(id) {
+    const normalized = normalizeTokenizerId(id);
+    if (registry.has(normalized)) {
+        return registry.get(normalized);
+    }
+    return registry.get(tokenizers.DEFAULT);
+}
+
+function defineHiddenProperty(target, key, value) {
+    try {
+        Object.defineProperty(target, key, {
+            value,
+            enumerable: false,
+            configurable: true,
+            writable: true,
+        });
+    } catch (err) {
+        target[key] = value;
+    }
+}
+
+function tokenizeWhitespace(text) {
+    const input = typeof text === "string" ? text : String(text ?? "");
+    if (!input) {
+        return { ids: [], offsets: [], chunks: [] };
+    }
+    const ids = [];
+    const offsets = [];
+    const chunks = [];
+    const pattern = /\S+/g;
+    let match;
+    while ((match = pattern.exec(input)) !== null) {
+        const token = match[0];
+        const start = match.index;
+        const end = start + token.length;
+        ids.push(ids.length + 1);
+        offsets.push({ start, end });
+        chunks.push(token);
+    }
+    return { ids, offsets, chunks };
+}
+
+export function registerTokenizer(id, implementation) {
+    const normalized = normalizeTokenizerId(id);
+    if (!implementation || typeof implementation.tokenize !== "function") {
+        throw new TypeError("Tokenizer implementation must expose a tokenize(text) function");
+    }
+    registry.set(normalized, implementation);
+}
+
+function bootstrapDefaults() {
+    if (registry.has(tokenizers.DEFAULT)) {
+        return;
+    }
+    registerTokenizer(tokenizers.DEFAULT, {
+        name: "Whitespace",
+        tokenize: tokenizeWhitespace,
+    });
+}
+
+bootstrapDefaults();
+
+export function getTextTokens(tokenizerId, text) {
+    bootstrapDefaults();
+    const tokenizer = ensureTokenizer(tokenizerId);
+    if (!tokenizer || typeof tokenizer.tokenize !== "function") {
+        return [];
+    }
+    const result = tokenizer.tokenize(text);
+    if (!result || !Array.isArray(result.ids)) {
+        return [];
+    }
+    const ids = result.ids.slice();
+    if (Array.isArray(result.chunks)) {
+        defineHiddenProperty(ids, "chunks", result.chunks.slice());
+    }
+    if (Array.isArray(result.offsets)) {
+        defineHiddenProperty(ids, "offsets", result.offsets.map(({ start, end }) => ({
+            start: Number.isFinite(start) ? start : 0,
+            end: Number.isFinite(end) ? end : 0,
+        })));
+    }
+    return ids;
+}
+
+export async function getTokenCountAsync(text, tokenizerId = null) {
+    const tokens = getTextTokens(tokenizerId, text);
+    if (Array.isArray(tokens) && tokens.length > 0) {
+        return tokens.length;
+    }
+    const input = typeof text === "string" ? text : String(text ?? "");
+    if (!input) {
+        return 0;
+    }
+    return tokenizeWhitespace(input).ids.length;
+}
+
+export function getFriendlyTokenizerName(mainApi = "") {
+    bootstrapDefaults();
+    const tokenizer = ensureTokenizer(mainApi);
+    const label = typeof tokenizer?.name === "string" && tokenizer.name
+        ? tokenizer.name
+        : "Whitespace";
+    return {
+        tokenizerName: label,
+        tokenizerId: normalizeTokenizerId(mainApi),
+    };
+}
+
+export { tokenizers };


### PR DESCRIPTION
## Summary
- add a tokenizer registry and helpers for retrieving token spans and counts
- integrate token-aware offsets throughout detection, scoring, analytics, and tester UI
- cover token distance handling with new regression fixtures and updated stream simulations

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c22cf660832580a7686d0f9729b7)