### PR TITLE
Fix regex script preprocessor import path

### DIFF
--- a/src/core/script-preprocessor.js
+++ b/src/core/script-preprocessor.js
@@ -1,4 +1,4 @@
-import { getScriptsByType, runRegexScript, SCRIPT_TYPES } from "../../../../regex/engine.js";
+import { getScriptsByType, runRegexScript, SCRIPT_TYPES } from "../../regex/engine.js";
 
 const SCRIPT_COLLECTION_DEFINITIONS = [
     { key: "global", type: SCRIPT_TYPES.GLOBAL },


### PR DESCRIPTION
## Summary
- correct the regex engine import path used by the script preprocessor so it resolves within the extension bundle

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917aba8d9a083259be7f81410921bc7)