### PR TITLE
Fix extension loader MIME errors by using host API shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Host API shims.** Replaced direct SillyTavern core imports with a runtime bridge so third-party builds load without MIME type or cross-origin module errors.
 - **Regex script imports.** Corrected the regex engine import path so script collections load in SillyTavern without triggering MIME type errors.
 - **Fuzzy matcher import path.** Bundled the Fuse.js ESM build with the extension so browsers stop throwing bare-specifier errors when the name preprocessor loads.
 - **Toggle styling isolation.** Master and inline switches now render with self-contained tracks so other extensions can no longer distort their shape.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,15 @@
-import { extension_settings, getContext, renderExtensionTemplateAsync } from "../../../extensions.js";
-import { saveSettingsDebounced, saveChatDebounced, event_types, eventSource, system_message_types } from "../../../../script.js";
-import { executeSlashCommandsOnChatInput, registerSlashCommand } from "../../../slash-commands.js";
+import {
+    extension_settings,
+    getContext,
+    renderExtensionTemplateAsync,
+    saveSettingsDebounced,
+    saveChatDebounced,
+    event_types,
+    eventSource,
+    system_message_types,
+    executeSlashCommandsOnChatInput,
+    registerSlashCommand,
+} from "./src/platform/sillytavern-api.js";
 import {
     DEFAULT_ACTION_VERBS_PRESENT,
     DEFAULT_ACTION_VERBS_THIRD_PERSON,

--- a/src/platform/sillytavern-api.js
+++ b/src/platform/sillytavern-api.js
@@ -1,0 +1,94 @@
+const host = typeof globalThis !== "undefined" ? globalThis : {};
+
+const missingWarnings = host.__costumeSwitchMissingWarnings || (host.__costumeSwitchMissingWarnings = new Set());
+
+function warnOnce(name) {
+    if (missingWarnings.has(name)) {
+        return;
+    }
+    missingWarnings.add(name);
+    if (typeof host.console?.warn === "function") {
+        host.console.warn(`[CostumeSwitch] Host API '${name}' is unavailable; falling back to a stub.`);
+    }
+}
+
+function toFunction(value, name, fallback) {
+    if (typeof value === "function") {
+        return value.bind(host);
+    }
+    warnOnce(name);
+    return fallback;
+}
+
+function toObject(value, name, fallback) {
+    if (value && typeof value === "object") {
+        return value;
+    }
+    warnOnce(name);
+    return fallback;
+}
+
+function createEventSourceFallback() {
+    const noop = () => {};
+    return {
+        on: noop,
+        off: noop,
+        once: noop,
+        emit: noop,
+    };
+}
+
+const noop = () => {};
+
+const extensionSettingsStore = (() => {
+    if (host.extension_settings && typeof host.extension_settings === "object") {
+        return host.extension_settings;
+    }
+    if (host.extensionSettings && typeof host.extensionSettings === "object") {
+        return host.extensionSettings;
+    }
+    const shared = host.__extensionSettingsStore || (host.__extensionSettingsStore = {});
+    return shared;
+})();
+
+export const extension_settings = extensionSettingsStore;
+
+export const saveSettingsDebounced = toFunction(host.saveSettingsDebounced, "saveSettingsDebounced", noop);
+export const saveChatDebounced = toFunction(host.saveChatDebounced, "saveChatDebounced", noop);
+export const executeSlashCommandsOnChatInput = toFunction(host.executeSlashCommandsOnChatInput, "executeSlashCommandsOnChatInput", async () => false);
+export const registerSlashCommand = toFunction(host.registerSlashCommand, "registerSlashCommand", noop);
+
+export const event_types = toObject(host.event_types, "event_types", {});
+export const eventSource = toObject(host.eventSource, "eventSource", createEventSourceFallback());
+export const system_message_types = toObject(host.system_message_types, "system_message_types", { NARRATOR: "narrator" });
+
+export function getContext() {
+    if (typeof host.getContext === "function") {
+        try {
+            return host.getContext();
+        } catch (error) {
+            warnOnce(`getContext (threw: ${error?.message ?? error})`);
+        }
+    }
+
+    const baseContext = {
+        extensionSettings: extensionSettingsStore,
+        saveSettingsDebounced,
+        saveChatDebounced,
+    };
+
+    const extra = host.__mockContext;
+    if (extra && typeof extra === "object") {
+        return { ...baseContext, ...extra };
+    }
+
+    return baseContext;
+}
+
+export async function renderExtensionTemplateAsync(namespace, template, data) {
+    if (typeof host.renderExtensionTemplateAsync === "function") {
+        return host.renderExtensionTemplateAsync(namespace, template, data);
+    }
+    warnOnce("renderExtensionTemplateAsync");
+    return "<div id=\"cs-scene-panel\"></div>";
+}


### PR DESCRIPTION
## Summary
- add a SillyTavern host API shim that safely exposes required globals with fallbacks for testing
- update the extension entry point to import the shim so the loader no longer requests core files outside the third-party sandbox
- document the host API bridge in the changelog for the upcoming release notes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d1e0695883258a80b3cb01a33095)