### PR TITLE
Fix Costume Switch host imports for third-party autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Third-party autoloader compatibility.** Updated every SillyTavern core import to account for the new `third-party/` path so browsers fetch the correct modules instead of tripping MIME type errors during startup.
 - **Host API shims.** Replaced direct SillyTavern core imports with a runtime bridge so third-party builds load without MIME type or cross-origin module errors.
 - **Regex script imports.** Corrected the regex engine import path so script collections load in SillyTavern without triggering MIME type errors.
 - **Fuzzy matcher import path.** Bundled the Fuse.js ESM build with the extension so browsers stop throwing bare-specifier errors when the name preprocessor loads.

--- a/expressions/index.js
+++ b/expressions/index.js
@@ -1,23 +1,23 @@
-import { Fuse } from '../../../lib.js';
+import { Fuse } from '../../../../lib.js';
 
-import { characters, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types, this_chid } from '../../../script.js';
-import { dragElement, isMobile } from '../../RossAscends-mods.js';
-import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
-import { loadMovingUIState, performFuzzySearch, power_user } from '../../power-user.js';
-import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar, isFalseBoolean } from '../../utils.js';
-import { hideMutedSprites, selected_group } from '../../group-chats.js';
-import { isJsonSchemaSupported } from '../../textgen-settings.js';
-import { debounce_timeout } from '../../constants.js';
-import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { SlashCommand } from '../../slash-commands/SlashCommand.js';
-import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
-import { SlashCommandEnumValue, enumTypes } from '../../slash-commands/SlashCommandEnumValue.js';
-import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
-import { slashCommandReturnHelper } from '../../slash-commands/SlashCommandReturnHelper.js';
+import { characters, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types, this_chid } from '../../../../script.js';
+import { dragElement, isMobile } from '../../../../RossAscends-mods.js';
+import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../../../extensions.js';
+import { loadMovingUIState, performFuzzySearch, power_user } from '../../../../power-user.js';
+import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar, isFalseBoolean } from '../../../../utils.js';
+import { hideMutedSprites, selected_group } from '../../../../group-chats.js';
+import { isJsonSchemaSupported } from '../../../../textgen-settings.js';
+import { debounce_timeout } from '../../../../constants.js';
+import { SlashCommandParser } from '../../../../slash-commands/SlashCommandParser.js';
+import { SlashCommand } from '../../../../slash-commands/SlashCommand.js';
+import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../../../slash-commands/SlashCommandArgument.js';
+import { SlashCommandEnumValue, enumTypes } from '../../../../slash-commands/SlashCommandEnumValue.js';
+import { commonEnumProviders } from '../../../../slash-commands/SlashCommandCommonEnumsProvider.js';
+import { slashCommandReturnHelper } from '../../../../slash-commands/SlashCommandReturnHelper.js';
 import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
-import { Popup, POPUP_RESULT } from '../../popup.js';
-import { t } from '../../i18n.js';
-import { removeReasoningFromString } from '../../reasoning.js';
+import { Popup, POPUP_RESULT } from '../../../../popup.js';
+import { t } from '../../../../i18n.js';
+import { removeReasoningFromString } from '../../../../reasoning.js';
 export { MODULE_NAME };
 
 /**
@@ -1848,7 +1848,7 @@ async function onClickExpressionUpload(event) {
                 spriteName = fileNameWithoutExtension;
             }
             else {
-                /** @type {import('../../popup.js').CustomPopupButton[]} */
+                /** @type {import('../../../../popup.js').CustomPopupButton[]} */
                 const customButtons = [];
                 if (clickedFileName) {
                     customButtons.push({
@@ -2373,7 +2373,7 @@ function migrateSettings() {
         /** @type {(args: {return: string, filter: string}) => Promise<string>} */
         callback: async (args) => {
             let returnType =
-                /** @type {import('../../slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
+                /** @type {import('../../../../slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
                 (args.return);
 
             const list = await getExpressionsList({ filterAvailable: !isFalseBoolean(args.filter) });

--- a/regex/engine.js
+++ b/regex/engine.js
@@ -1,8 +1,8 @@
-import { characters, saveSettingsDebounced, substituteParams, substituteParamsExtended, this_chid } from '../../../script.js';
-import { extension_settings, writeExtensionField } from '../../extensions.js';
-import { getPresetManager } from '../../preset-manager.js';
-import { regexFromString } from '../../utils.js';
-import { lodash } from '../../../lib.js';
+import { characters, saveSettingsDebounced, substituteParams, substituteParamsExtended, this_chid } from '../../../../script.js';
+import { extension_settings, writeExtensionField } from '../../../../extensions.js';
+import { getPresetManager } from '../../../../preset-manager.js';
+import { regexFromString } from '../../../../utils.js';
+import { lodash } from '../../../../lib.js';
 
 /**
  * @enum {number} Regex scripts types

--- a/regex/index.js
+++ b/regex/index.js
@@ -1,17 +1,17 @@
-import { characters, eventSource, event_types, getCurrentChatId, messageFormatting, reloadCurrentChat, saveSettingsDebounced, this_chid } from '../../../script.js';
-import { extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
-import { selected_group } from '../../group-chats.js';
-import { callGenericPopup, Popup, POPUP_TYPE } from '../../popup.js';
-import { SlashCommand } from '../../slash-commands/SlashCommand.js';
-import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
-import { commonEnumProviders, enumIcons } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
-import { SlashCommandEnumValue, enumTypes } from '../../slash-commands/SlashCommandEnumValue.js';
-import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { download, equalsIgnoreCaseAndAccents, escapeHtml, getFileText, getSortableDelay, isFalseBoolean, isTrueBoolean, regexFromString, setInfoBlock, uuidv4 } from '../../utils.js';
+import { characters, eventSource, event_types, getCurrentChatId, messageFormatting, reloadCurrentChat, saveSettingsDebounced, this_chid } from '../../../../script.js';
+import { extension_settings, renderExtensionTemplateAsync } from '../../../../extensions.js';
+import { selected_group } from '../../../../group-chats.js';
+import { callGenericPopup, Popup, POPUP_TYPE } from '../../../../popup.js';
+import { SlashCommand } from '../../../../slash-commands/SlashCommand.js';
+import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../../../slash-commands/SlashCommandArgument.js';
+import { commonEnumProviders, enumIcons } from '../../../../slash-commands/SlashCommandCommonEnumsProvider.js';
+import { SlashCommandEnumValue, enumTypes } from '../../../../slash-commands/SlashCommandEnumValue.js';
+import { SlashCommandParser } from '../../../../slash-commands/SlashCommandParser.js';
+import { download, equalsIgnoreCaseAndAccents, escapeHtml, getFileText, getSortableDelay, isFalseBoolean, isTrueBoolean, regexFromString, setInfoBlock, uuidv4 } from '../../../../utils.js';
 import { allowPresetScripts, allowScopedScripts, disallowPresetScripts, disallowScopedScripts, getCurrentPresetAPI, getCurrentPresetName, getRegexScripts, getScriptsByType, isPresetScriptsAllowed, isScopedScriptsAllowed, regex_placement, runRegexScript, saveScriptsByType, SCRIPT_TYPE_UNKNOWN, SCRIPT_TYPES, substitute_find_regex } from './engine.js';
-import { t } from '../../i18n.js';
-import { accountStorage } from '../../util/AccountStorage.js';
-import { getPresetManager } from '../../preset-manager.js';
+import { t } from '../../../../i18n.js';
+import { accountStorage } from '../../../../util/AccountStorage.js';
+import { getPresetManager } from '../../../../preset-manager.js';
 
 // Re-exports for legacy extensions
 export { getRegexScripts };
@@ -1988,7 +1988,7 @@ jQuery(async () => {
     /**
      * @typedef {object} ScriptDecorators
      * @property {string} typename
-     * @property {import('../../slash-commands/SlashCommandEnumValue.js').EnumType} color
+     * @property {import('../../../../slash-commands/SlashCommandEnumValue.js').EnumType} color
      * @property {string} icon
      */
 

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -1,11 +1,11 @@
 export async function resolve(specifier, context, defaultResolve) {
-    if (specifier === "../../../extensions.js") {
+    if (specifier === "../../../../extensions.js") {
         return { url: "node:mock/extensions", shortCircuit: true };
     }
     if (specifier === "../../../../script.js") {
         return { url: "node:mock/script", shortCircuit: true };
     }
-    if (specifier === "../../../slash-commands.js") {
+    if (specifier === "../../../../slash-commands.js") {
         return { url: "node:mock/slash", shortCircuit: true };
     }
     if (specifier === "../regex/engine.js" || specifier === "../../regex/engine.js" || specifier === "../../../../regex/engine.js") {

--- a/token-counter/index.js
+++ b/token-counter/index.js
@@ -1,13 +1,13 @@
-import { main_api } from '../../../script.js';
-import { getContext } from '../../extensions.js';
-import { SlashCommand } from '../../slash-commands/SlashCommand.js';
-import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizers } from '../../tokenizers.js';
-import { resetScrollHeight, debounce } from '../../utils.js';
-import { debounce_timeout } from '../../constants.js';
-import { POPUP_TYPE, callGenericPopup } from '../../popup.js';
-import { renderExtensionTemplateAsync } from '../../extensions.js';
-import { t } from '../../i18n.js';
+import { main_api } from '../../../../script.js';
+import { getContext } from '../../../../extensions.js';
+import { SlashCommand } from '../../../../slash-commands/SlashCommand.js';
+import { SlashCommandParser } from '../../../../slash-commands/SlashCommandParser.js';
+import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizers } from '../../../../tokenizers.js';
+import { resetScrollHeight, debounce } from '../../../../utils.js';
+import { debounce_timeout } from '../../../../constants.js';
+import { POPUP_TYPE, callGenericPopup } from '../../../../popup.js';
+import { renderExtensionTemplateAsync } from '../../../../extensions.js';
+import { t } from '../../../../i18n.js';
 
 async function doTokenCounter() {
     const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api);


### PR DESCRIPTION
## Summary
- update host module import paths so scripts load correctly when the extension lives under the third-party directory
- align expressions, regex, and token counter modules plus the module mock loader with the new SillyTavern path depth
- document the fix in the changelog for the upcoming 3.6.0 release

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d3d5928c8325be00ba8a4a34fba8)