### PR TITLE
Fix SillyTavern host API bridge timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **Regex engine host shims.** Routed regex helpers through the in-extension SillyTavern bridge so startup no longer fetches core `script.js` or `lib.js` files, fixing the MIME errors that blocked Firefox from loading Costume Switcher.
 - **Third-party autoloader compatibility.** Updated every SillyTavern core import to account for the new `third-party/` path so browsers fetch the correct modules instead of tripping MIME type errors during startup.
 - **Host API shims.** Replaced direct SillyTavern core imports with a runtime bridge so third-party builds load without MIME type or cross-origin module errors.
+- **Host API availability timing.** Deferred host bridge lookups until call-time so SillyTavern can finish registering its APIs without flooding the console with fallback warnings.
 - **Regex script imports.** Corrected the regex engine import path so script collections load in SillyTavern without triggering MIME type errors.
 - **Fuzzy matcher import path.** Bundled the Fuse.js ESM build with the extension so browsers stop throwing bare-specifier errors when the name preprocessor loads.
 - **Toggle styling isolation.** Master and inline switches now render with self-contained tracks so other extensions can no longer distort their shape.


### PR DESCRIPTION
## Summary
- add lazy host bridge helpers so Costume Switch rebinds to SillyTavern APIs when they become available
- proxy host-backed objects to avoid premature stub fallbacks and stop the console warning spam
- document the timing fix in the unreleased changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917df1381ac832589480e7b9b5ac07f)