### PR TITLE
Fix SillyTavern loader paths and vendor Fuse

### DIFF
--- a/expressions/index.js
+++ b/expressions/index.js
@@ -1,4 +1,4 @@
-import { Fuse } from '../../../../lib.js';
+import Fuse from "../src/vendor/fuse.mjs";
 
 import { characters, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types, this_chid } from '../../../../script.js';
 import { dragElement, isMobile } from '../../../../RossAscends-mods.js';

--- a/src/platform/sillytavern-api.js
+++ b/src/platform/sillytavern-api.js
@@ -279,15 +279,15 @@ async function importHostModule(specifier, label) {
 
 async function loadHostBindings() {
     const sources = [];
-    const extensionModule = await importHostModule("../../../../extensions.js", "extensions");
+    const extensionModule = await importHostModule("../../../../../extensions.js", "extensions");
     if (extensionModule) {
         sources.push(extensionModule);
     }
-    const scriptModule = await importHostModule("../../../../script.js", "core script");
+    const scriptModule = await importHostModule("../../../../../script.js", "core script");
     if (scriptModule) {
         sources.push(scriptModule);
     }
-    const slashModule = await importHostModule("../../../../slash-commands.js", "slash commands");
+    const slashModule = await importHostModule("../../../../../slash-commands.js", "slash commands");
     if (slashModule) {
         sources.push(slashModule);
     }

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -1,11 +1,11 @@
 export async function resolve(specifier, context, defaultResolve) {
-    if (specifier === "../../../../extensions.js") {
+    if (specifier === "../../../../../extensions.js") {
         return { url: "node:mock/extensions", shortCircuit: true };
     }
-    if (specifier === "../../../../script.js") {
+    if (specifier === "../../../../../script.js") {
         return { url: "node:mock/script", shortCircuit: true };
     }
-    if (specifier === "../../../../slash-commands.js") {
+    if (specifier === "../../../../../slash-commands.js") {
         return { url: "node:mock/slash", shortCircuit: true };
     }
     if (specifier === "../regex/engine.js" || specifier === "../../regex/engine.js" || specifier === "../../../../regex/engine.js") {


### PR DESCRIPTION
## Summary
- update the SillyTavern bridge to load host modules from the correct third-party path
- vendor the Fuse.js ESM build for the expressions helper and point the extension at it
- adjust the module mock loader to mirror the new SillyTavern specifiers

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e6d8ba6c8325b1f378fcd924cf80)