### PR TITLE
Use official SillyTavern module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
 
 ### Fixed
+- **Host module imports.** Costume Switcher now mirrors the official SillyTavern extension import pattern so the browser loads `script.js`, `extensions.js`, and `slash-commands.js` without triggering MIME-type errors.
 - **Regex engine host shims.** Routed regex helpers through the in-extension SillyTavern bridge so startup no longer fetches core `script.js` or `lib.js` files, fixing the MIME errors that blocked Firefox from loading Costume Switcher.
 - **Third-party autoloader compatibility.** Updated every SillyTavern core import to account for the new `third-party/` path so browsers fetch the correct modules instead of tripping MIME type errors during startup.
 - **SillyTavern module loader.** Load SillyTavern's extension, core script, and slash-command modules on startup so the extension binds to the real host APIs without relying on brittle runtime bridges.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import {
-    ensureSillyTavernModuleBindings,
     extension_settings,
     getContext,
     renderExtensionTemplateAsync,
@@ -10903,7 +10902,6 @@ function getSettingsObj() {
 if (typeof window !== "undefined" && typeof jQuery === "function") {
     jQuery(async () => {
         try {
-            await ensureSillyTavernModuleBindings();
             const { store } = getSettingsObj();
             extension_settings[extensionName] = store[extensionName];
 


### PR DESCRIPTION
## Summary
- swap the runtime host bridge for direct SillyTavern module imports so bindings match the core extension layout
- drop the async host-loader bootstrap and update the changelog to document the import change

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e9f5b1a88325a8738e504e7c9ab8)