### PR TITLE
Fix host module import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **SillyTavern module loader.** Load SillyTavern's extension, core script, and slash-command modules on startup so the extension binds to the real host APIs without relying on brittle runtime bridges.
 - **Host API availability timing.** The startup sequence now waits for the SillyTavern modules to resolve before wiring the UI, eliminating the late-binding bridge and the warning spam that came with it.
 - **Regex script imports.** Corrected the regex engine import path so script collections load in SillyTavern without triggering MIME type errors.
+- **Absolute host imports.** Fetch SillyTavern's `extensions.js`, `script.js`, `slash-commands.js`, and regex engine directly from `/scripts/` so third-party installs stop hitting MIME-type errors when the folder depth changes.
 - **Fuzzy matcher import path.** Bundled the Fuse.js ESM build with the extension so browsers stop throwing bare-specifier errors when the name preprocessor loads.
 - **Toggle styling isolation.** Master and inline switches now render with self-contained tracks so other extensions can no longer distort their shape.
 - **Scene panel user message handling.** User-authored chat updates no longer trigger roster wipes or scene panel refreshes, so the control center stays stable and message counters persist while players talk.

--- a/src/core/script-preprocessor.js
+++ b/src/core/script-preprocessor.js
@@ -1,4 +1,4 @@
-import { getScriptsByType, runRegexScript, SCRIPT_TYPES } from "../../regex/engine.js";
+import { getScriptsByType, runRegexScript, SCRIPT_TYPES } from "/scripts/extensions/regex/engine.js";
 
 const SCRIPT_COLLECTION_DEFINITIONS = [
     { key: "global", type: SCRIPT_TYPES.GLOBAL },

--- a/src/platform/sillytavern-api.js
+++ b/src/platform/sillytavern-api.js
@@ -1,6 +1,6 @@
-import * as extensionsModule from "../../../../../extensions.js";
-import * as scriptModule from "../../../../../script.js";
-import * as slashModule from "../../../../../slash-commands.js";
+import * as extensionsModule from "/scripts/extensions.js";
+import * as scriptModule from "/scripts/script.js";
+import * as slashModule from "/scripts/slash-commands.js";
 
 const host = typeof globalThis !== "undefined" ? globalThis : {};
 

--- a/test/module-mock-loader.js
+++ b/test/module-mock-loader.js
@@ -1,14 +1,19 @@
 export async function resolve(specifier, context, defaultResolve) {
-    if (specifier === "../../../../../extensions.js") {
+    if (specifier === "../../../../../extensions.js" || specifier === "/scripts/extensions.js") {
         return { url: "node:mock/extensions", shortCircuit: true };
     }
-    if (specifier === "../../../../../script.js") {
+    if (specifier === "../../../../../script.js" || specifier === "/scripts/script.js") {
         return { url: "node:mock/script", shortCircuit: true };
     }
-    if (specifier === "../../../../../slash-commands.js") {
+    if (specifier === "../../../../../slash-commands.js" || specifier === "/scripts/slash-commands.js") {
         return { url: "node:mock/slash", shortCircuit: true };
     }
-    if (specifier === "../regex/engine.js" || specifier === "../../regex/engine.js" || specifier === "../../../../regex/engine.js") {
+    if (
+        specifier === "../regex/engine.js" ||
+        specifier === "../../regex/engine.js" ||
+        specifier === "../../../../regex/engine.js" ||
+        specifier === "/scripts/extensions/regex/engine.js"
+    ) {
         return { url: "node:mock/regex-engine", shortCircuit: true };
     }
     return defaultResolve(specifier, context, defaultResolve);

--- a/test/regex-preprocessor.test.js
+++ b/test/regex-preprocessor.test.js
@@ -5,7 +5,7 @@ import { register } from "node:module";
 await register(new URL("./module-mock-loader.js", import.meta.url));
 
 const { compileProfileRegexes, collectDetections } = await import("../src/detector-core.js");
-const { SCRIPT_TYPES } = await import("../regex/engine.js");
+const { SCRIPT_TYPES } = await import("/scripts/extensions/regex/engine.js");
 
 function configureScriptsByType(map) {
     const store = globalThis.__regexMockStore || (globalThis.__regexMockStore = { scripts: {} });


### PR DESCRIPTION
## Summary
- load SillyTavern's core modules via absolute `/scripts/` paths so the extension no longer depends on its install depth
- point the regex preprocessor at the shared `/scripts/extensions/regex/engine.js` entry point and document the fix
- update the module mock loader and regex preprocessor tests to follow the new import locations

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ffac2db88325a242fd45c5fdca13)