### PR TITLE
Fix SillyTavern host imports

### DIFF
--- a/src/platform/sillytavern-api.js
+++ b/src/platform/sillytavern-api.js
@@ -1,6 +1,6 @@
-import * as extensionsModule from "../../../../extensions.js";;
-import * as scriptModule from "../../../../extensions.js";;
-import * as slashModule from "../../../../slash-commands.js";;
+import * as extensionsModule from "/scripts/extensions.js";
+import * as scriptModule from "/scripts/script.js";
+import * as slashModule from "/scripts/slash-commands.js";
 
 const host = typeof globalThis !== "undefined" ? globalThis : {};
 


### PR DESCRIPTION
## Summary
- switch the SillyTavern platform shim to import the host modules from `/scripts/...` so it follows the official extension pattern and works regardless of folder depth

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190615073c83258d5c64ffeace280a)