### PR TITLE
Clarify regex and fuzzy matching guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space as soon as any module is hidden, so two-up layouts immediately expand instead of waiting until only a single section remains.
 - **Live log export parity.** Copying the live log now produces a full report with detection summaries, switch analytics, skip reasons, and roster state—matching the fidelity of the live pattern tester output.
 - **Scene panel layout cleanup.** Retired the legacy collapse handle so the crest header and toolbar own panel visibility, keeping the frame tidy without the extra toggle stub.
+- **Regex & fuzzy UX copy.** Settings toggles now spell out real-world use cases for the regex preprocessor tiers and fuzzy tolerance presets, with matching README guidance so new users know why and when to enable them.
 
 ### Fixed
 - **Legacy clone fallback.** Replaced direct `structuredClone` calls with a resilient deep clone helper so Electron builds and browsers without the native API can load Costume Switcher without crashing on startup.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Under the hood the extension listens to streaming output from your model, scores
     3. [Character Patterns & Filters](#character-patterns--filters)
     4. [Presets & Focus](#presets--focus)
     5. [Detection Strategy](#detection-strategy)
+        1. [Regex Preprocessor quick guide](#regex-preprocessor-quick-guide)
+        2. [Fuzzy name matching quick guide](#fuzzy-name-matching-quick-guide)
     6. [Performance & Bias](#performance--bias)
     7. [Outfit Lab](#outfit-lab)
         1. [Prepare your character folders](#1-prepare-your-character-folders)
@@ -167,6 +169,26 @@ Kickstart new profiles with curated presets, configure a **Default Costume** to 
 
 ### Detection Strategy
 Toggle the individual detectors the engine can use. Tooltips in the UI explain the common scenarios for each detection type. Enable **Scene Roster** to maintain a rolling list of characters active in the conversation and adjust the **Scene Roster TTL (messages)** to control how long they stay on that list.
+
+#### Regex Preprocessor quick guide
+Live chats rarely look like tidy handbook samples. The regex preprocessor is the “tidy up the transcript before anyone reads it” layer that runs before detections and outfit logic make a decision. Each profile can opt into three script collections without editing JSON:
+
+- **Global scripts** – Safe punctuation, spacing, and honorific cleanup for every profile. Use this whenever you pull text from AI models that like curly quotes, narrators that attach honorifics ("Alice-san"), or logs copied from streams with odd spacing.
+- **Preset scripts** – Curated bundles for community roleplay formats or popular stream layouts. Turn this on when your group shares a common markup style (bracketed actions, emoji markers, etc.) so everyone benefits from the same cleanup rules.
+- **Scoped scripts** – Per-character or per-profile helpers that only activate when their owner is in play. These are perfect for bilingual sheets that need kana → romaji guards, sci-fi logs that swap call signs, or any bespoke filter that should not affect the rest of your roster.
+
+Because the preprocessor runs in the live six-stage pipeline, the cleaned text feeds directly into live `/costume` calls, and the Live Pattern Tester simply mirrors what already happened in real time.
+
+#### Fuzzy name matching quick guide
+Fuzzy matching is the “don’t panic when the spelling drifts” safety net. Both detection engines share the same normalization buffer, so the settings you pick here apply equally to live chat and the tester. Choose a preset from **Name Matching → Fuzzy Tolerance** based on how messy your chat usually is:
+
+- **Off** – Use when you are debugging or when the cast names are short, unique, and always typed correctly.
+- **Auto / Low Confidence** – Best everyday mode. The engine only attempts fuzzy rescue when a detector posts a weak score or when it spots accent-heavy text, keeping confident matches strict.
+- **Accent-only** – Ideal for bilingual chats that simply need Á→A or ゆり→Yuri remapping without touching other typos.
+- **Always** – Fast-paced chats with constant misspellings benefit from always-on fuzzy rescue so “Ailce” still maps to Alice mid-stream.
+- **Custom threshold** – Set your own low-confidence score ceiling when you know exactly how aggressive the fallback should be.
+
+Pair the tolerance with the **Translate Accents** toggle whenever a scene swaps alphabets or diacritics frequently. The shared buffer ensures the extension rescues live detections immediately, while the Live Pattern Tester gives you a safe sandbox to preview how each preset behaves.
 
 ### Performance & Bias
 Fine-tune responsiveness and tie-breaking behaviour:

--- a/settings.html
+++ b/settings.html
@@ -293,7 +293,15 @@
                       <small>Profile or character-specific filters for translations or custom markup.</small>
                     </span>
                   </label>
-                  <small class="cs-helper-text">Global scripts handle safe cleanup for every chat, Preset scripts mirror curated SillyTavern bundles, and Scoped scripts run only when your characters or profiles provide their own filters.</small>
+                  <div class="cs-helper-text">
+                    <p><strong>When to toggle each tier:</strong></p>
+                    <ul>
+                      <li><strong>Global</strong> keeps every chat readable by stripping stray honorifics, punctuation glitches, and streamer transcript noise.</li>
+                      <li><strong>Preset</strong> borrows curated bundles for common RP formats so you do not have to maintain regex rules by hand.</li>
+                      <li><strong>Scoped</strong> activates only when a profile or character ships custom guards (kana → romaji swaps, sci-fi call signs, etc.).</li>
+                    </ul>
+                    <p>The preprocessor runs in live streams before detections score, and the Live Tester simply mirrors what already happened.</p>
+                  </div>
                 </div>
                 <div class="cs-field-group cs-field-group--stacked">
                   <label class="cs-inline-label" for="cs-fuzzy-tolerance">Name Matching</label>
@@ -321,7 +329,17 @@
                       <small>Swap accented/translated characters (Á → A, ゆり → Yuri) before comparing.</small>
                     </span>
                   </label>
-                  <small class="cs-helper-text">Fuzzy tolerance decides when to rescue misspelled or diacritic-heavy names. Auto lets low-confidence detections and accented text borrow fuzzy scoring, Accent-only keeps the guardrails tight, and Low Confidence defers fuzzy matching to weaker hits. Enable accent translation when bilingual logs or diacritics frequently hide character names.</small>
+                  <div class="cs-helper-text">
+                    <p><strong>How each preset behaves:</strong></p>
+                    <ul>
+                      <li><strong>Off</strong> is for debugging or strict chats where names never drift.</li>
+                      <li><strong>Auto/Low Confidence</strong> only attempts rescue when scores sag, keeping confident matches exact.</li>
+                      <li><strong>Accent-only</strong> focuses on translating diacritics so bilingual logs stay aligned.</li>
+                      <li><strong>Always</strong> keeps fast, typo-heavy chats stable by remapping every near miss.</li>
+                      <li><strong>Custom</strong> lets you set the score that must be met before fuzzy fallback triggers.</li>
+                    </ul>
+                    <p>Pair the preset with <strong>Translate Accents</strong> whenever a scene swaps alphabets; the shared buffer feeds both live detections and the tester.</p>
+                  </div>
                 </div>
                 <div class="cs-field-group">
                   <label class="cs-inline-label" for="cs-scene-roster-enable">Scene Awareness</label>


### PR DESCRIPTION
## Summary
- add user-facing explanations and use cases for the regex preprocessor and fuzzy name matching inside the README
- expand the detection tab helper text so each toggle describes practical scenarios and highlights that the behaviour applies to live streams
- document the UX copy refresh in the changelog for v3.6.0

## Testing
- Not run (documentation and copy updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191e2a91088325aeae9fd48a890cc3)