### PR TITLE
Enhance tester preprocessing diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Name matching controls.** The Detection tab now includes fuzzy tolerance presets, a custom low-confidence threshold, and an accent translation toggle so profiles can decide how aggressively diacritics and near-miss names are reconciled.
 
 ### Improved
+- **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
 - **Coverage toggle in the control center.** Coverage suggestions now share the toolbar's quick toggles so the panel can hide or restore vocabulary guidance without opening settings.

--- a/settings.html
+++ b/settings.html
@@ -605,6 +605,18 @@
                             <div class="cs-tester-title">Preprocessed Text</div>
                             <p class="cs-helper-text">Buffer after running allowed regex scripts.</p>
                             <pre id="cs-test-preprocessed" class="cs-tester-preprocessed__output cs-tester-list-placeholder" data-placeholder="No scripts applied yet.">No scripts applied yet.</pre>
+                            <div class="cs-preprocessor-meta">
+                                <div class="cs-preprocessor-column">
+                                    <div class="cs-tester-title cs-tester-title--sub">Applied Scripts</div>
+                                    <ul id="cs-preprocessor-script-list" class="cs-script-list">
+                                        <li class="cs-tester-list-placeholder">No scripts executed.</li>
+                                    </ul>
+                                </div>
+                                <div class="cs-preprocessor-column cs-preprocessor-column--badge">
+                                    <div class="cs-tester-title cs-tester-title--sub">Name Normalization</div>
+                                    <div id="cs-fuzzy-summary" class="cs-fuzzy-pill" title="Fuzzy normalization disabled.">Fuzzy: Off</div>
+                                </div>
+                            </div>
                         </div>
                         <div class="cs-tester-split">
                             <div class="cs-tester-pane">

--- a/style.css
+++ b/style.css
@@ -1328,6 +1328,115 @@
     color: var(--text-color);
 }
 
+#costume-switcher-settings.cs-theme .cs-preprocessor-meta {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+#costume-switcher-settings.cs-theme .cs-preprocessor-column {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry {
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.02);
+    padding: 8px 10px;
+    font-size: 0.88rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__collection {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-muted);
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__name {
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__actions {
+    margin-left: auto;
+    display: flex;
+    gap: 6px;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__action {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-color);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry__description {
+    display: none;
+    margin-top: 6px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+}
+
+#costume-switcher-settings.cs-theme .cs-script-entry.is-expanded .cs-script-entry__description {
+    display: block;
+}
+
+#costume-switcher-settings.cs-theme .cs-preprocessor-column--badge {
+    justify-content: flex-start;
+}
+
+#costume-switcher-settings.cs-theme .cs-fuzzy-pill {
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 6px 10px;
+    font-size: 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-color);
+}
+
+#costume-switcher-settings.cs-theme .cs-fuzzy-pill.is-active {
+    border-color: var(--green);
+    color: var(--green);
+}
+
+#costume-switcher-settings.cs-theme .cs-detection-note {
+    display: block;
+    font-size: 0.8rem;
+    margin-top: 4px;
+    color: var(--text-muted);
+}
+
 #costume-switcher-settings.cs-theme .cs-tester-list {
   list-style: none;
   margin: 0;

--- a/test/fuzzy-detection.test.js
+++ b/test/fuzzy-detection.test.js
@@ -66,6 +66,7 @@ test("collectDetections normalizes accented candidates when fuzzy tolerance acti
     assert.equal(renee.resolution?.canonical, "Renée");
     assert.equal(renee.resolution?.changed, true);
     assert.ok(matches.fuzzyResolution.aliasCount >= 2);
+    assert.equal(matches.fuzzyResolution.mode, "auto");
 });
 
 test("resolveOutfitForMatch reuses fuzzy resolution for mapping lookup", () => {

--- a/test/regex-preprocessor.test.js
+++ b/test/regex-preprocessor.test.js
@@ -60,6 +60,11 @@ test("preprocessor pipelines scripts in collection priority order", () => {
 
     assert.equal(matches.preprocessedText, "Kotori →global →preset →scoped");
     assert.ok(matches.length > 0, "expected a detection after preprocessing");
+    assert.deepEqual(
+        matches.preprocessorScripts.map(entry => entry?.script?.id),
+        ["global", "preset", "scoped"],
+        "expected applied script order to match pipeline",
+    );
 });
 
 test("preprocessor only runs scripts that are allowed", () => {


### PR DESCRIPTION
## Summary
- surface the regex scripts and fuzzy tolerance used during tester runs, including UI affordances and report metadata
- add normalization notes to detection logs and copy over the new diagnostics for support exports
- cover the new script ordering and fuzzy mode reporting with unit tests and documentation updates

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194edc15508325888474ba0f1435e7)