### PR TITLE
Fix live tester fuzzy snapshot handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **Regex & fuzzy UX copy.** Settings toggles now spell out real-world use cases for the regex preprocessor tiers and fuzzy tolerance presets, with matching README guidance so new users know why and when to enable them.
 
 ### Fixed
+- **Live tester fuzzy snapshots.** Streaming simulations now honor the preprocessed buffer produced by the match finder, so the fuzzy tolerance pill, copy-to-clipboard report, and diagnostics stay in sync with the text that actually triggered fuzzy rescues.
 - **Legacy clone fallback.** Replaced direct `structuredClone` calls with a resilient deep clone helper so Electron builds and browsers without the native API can load Costume Switcher without crashing on startup.
 - **Host module imports.** Costume Switcher now mirrors the official SillyTavern extension import pattern so the browser loads `script.js`, `extensions.js`, and `slash-commands.js` without triggering MIME-type errors.
 - **Regex engine host shims.** Routed regex helpers through the in-extension SillyTavern bridge so startup no longer fetches core `script.js` or `lib.js` files, fixing the MIME errors that blocked Firefox from loading Costume Switcher.

--- a/test/simulate-tester-stream.test.js
+++ b/test/simulate-tester-stream.test.js
@@ -227,6 +227,26 @@ test("simulateTesterStream records per-character tester outputs", () => {
         "tester snapshot should expose the latest preprocessed buffer");
 });
 
+test("simulateTesterStream accepts a preprocessed text snapshot override", () => {
+    const profile = setupProfile();
+    const bufKey = "tester-preprocessed-override";
+    const msgState = createMessageState(profile);
+    state.perMessageStates = new Map([[bufKey, msgState]]);
+    state.perMessageBuffers = new Map([[bufKey, ""]]);
+
+    clearLiveTesterOutputs();
+
+    const text = "Kotori waves hello.";
+    const overrideText = "[Kotori] waves hello.";
+    simulateTesterStream(text, profile, bufKey, { preprocessedText: overrideText });
+
+    const snapshot = getLiveTesterOutputsSnapshot();
+    assert.equal(snapshot.preprocessedText, overrideText,
+        "tester outputs should respect the provided preprocessed text snapshot");
+    assert.equal(state.lastPreprocessedText, overrideText,
+        "state should retain the override preprocessed text after the simulation");
+});
+
 test("simulateTesterStream syncs tester events into the shared decision log", () => {
     const profile = setupProfile();
     const bufKey = "tester-shared-log";


### PR DESCRIPTION
## Summary
- keep the live tester's preprocessed text and fuzzy resolution snapshots intact during simulations so the diagnostics and copied reports reflect the active fuzzy settings
- allow `simulateTesterStream` to accept a provided preprocessed text override and document the fix in the changelog
- add coverage that exercises the new snapshot override behavior

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195947bf0c8325a5ab718bada09252)