### PR TITLE
Guard fuzzy fallback tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - **Regex & fuzzy UX copy.** Settings toggles now spell out real-world use cases for the regex preprocessor tiers and fuzzy tolerance presets, with matching README guidance so new users know why and when to enable them.
 
 ### Fixed
+- **Fuzzy fallback lowercase guard.** The fallback scanner now ignores lowercase connectors such as “and/but” unless profiles
+  explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.
 - **Live tester fuzzy snapshots.** Streaming simulations now honor the preprocessed buffer produced by the match finder, so the fuzzy tolerance pill, copy-to-clipboard report, and diagnostics stay in sync with the text that actually triggered fuzzy rescues.
 - **Legacy clone fallback.** Replaced direct `structuredClone` calls with a resilient deep clone helper so Electron builds and browsers without the native API can load Costume Switcher without crashing on startup.

--- a/index.js
+++ b/index.js
@@ -368,6 +368,7 @@ const PROFILE_DEFAULTS = {
     detectPronoun: true,
     detectGeneral: false,
     scanDialogueActions: false,
+    scanLowercaseFallbackTokens: false,
     pronounVocabulary: [...DEFAULT_PRONOUNS],
     attributionVerbs: [...DEFAULT_ATTRIBUTION_VERB_FORMS],
     actionVerbs: [...DEFAULT_ACTION_VERB_FORMS],


### PR DESCRIPTION
## Summary
- require fuzzy fallback tokens to resemble proper nouns and add a profile flag to opt into lowercase scanning when needed
- guard the contextual fallback helpers with the same predicate and expose the lowercase opt-in through the detector defaults
- add regression tests covering the lowercase connector guard and document the behavior change in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919647e77588325be4a8b4f0bc454b4)