### PR TITLE
Fix tester ranking display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 ### Fixed
 - **Fuzzy fallback lowercase guard.** The fallback scanner now ignores lowercase connectors such as “and/but” unless profiles
   explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
+- **Top character canonical labels.** Live tester and scene panel leaderboards now always show the normalized character name,
+  even when a fuzzy fallback trigger originated from filler words like “Now,” keeping phantom entries out of the rankings.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.
 - **Live tester fuzzy snapshots.** Streaming simulations now honor the preprocessed buffer produced by the match finder, so the fuzzy tolerance pill, copy-to-clipboard report, and diagnostics stay in sync with the text that actually triggered fuzzy rescues.
 - **Legacy clone fallback.** Replaced direct `structuredClone` calls with a resilient deep clone helper so Electron builds and browsers without the native API can load Costume Switcher without crashing on startup.

--- a/SillyTavern-CostumeSwitch-main/index.js
+++ b/SillyTavern-CostumeSwitch-main/index.js
@@ -6124,6 +6124,7 @@ export {
     getVerbInflections,
     getWinner,
     findBestMatch,
+    rankSceneCharacters,
     adjustWindowForTrim,
     simulateTesterStream,
     buildVariantFolderPath,

--- a/index.js
+++ b/index.js
@@ -1087,17 +1087,18 @@ function rankSceneCharacters(matches, options = {}) {
 
     matches.forEach((match, idx) => {
         if (!match || !match.name) return;
-        const canonical = match.name;
+        const canonical = typeof match.name === "string" ? match.name.trim() : "";
         const normalized = normalizeCostumeName(canonical);
         if (!normalized) return;
 
-        const displayName = String(match.rawName || canonical).trim() || normalized;
+        const rawName = typeof match.rawName === "string" ? match.rawName.trim() : "";
+        const displayName = canonical || normalized;
         const key = normalized.toLowerCase();
         let entry = summary.get(key);
         if (!entry) {
             entry = {
                 name: displayName,
-                rawName: match.rawName || displayName,
+                rawName: rawName || displayName,
                 normalized,
                 count: 0,
                 bestPriority: -Infinity,
@@ -11297,6 +11298,7 @@ export {
     getVerbInflections,
     getWinner,
     findBestMatch,
+    rankSceneCharacters,
     updateMessageAnalytics,
     adjustWindowForTrim,
     simulateTesterStream,

--- a/test/rank-scene-characters.test.js
+++ b/test/rank-scene-characters.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+await register(new URL("./module-mock-loader.js", import.meta.url));
+
+const { rankSceneCharacters } = await import("../index.js");
+
+test("rankSceneCharacters prefers canonical names in summaries", () => {
+    const matches = [
+        { name: "Yoshinon", rawName: "Now", matchKind: "fuzzy-fallback", matchIndex: 10, priority: 1 },
+        { name: "Yoshinon", rawName: "Yoshinon", matchKind: "action", matchIndex: 200, priority: 3 },
+    ];
+    const ranking = rankSceneCharacters(matches, {
+        profile: { distancePenaltyWeight: 0, rosterBonus: 0 },
+    });
+    assert.equal(ranking[0].name, "Yoshinon");
+    assert.equal(ranking[0].rawName, "Now");
+});


### PR DESCRIPTION
## Summary
- ensure the tester’s top character ranking always displays the canonical name even when the first detection came from a fuzzy fallback token
- expose the ranking helper for tests and document the fix in the changelog
- add a regression test that reproduces the "Now" fallback case to prove the canonical name is shown

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69196310bb6c8325bda36e9ccc91dfc5)