### PR TITLE
Harden fuzzy fallback name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 ### Fixed
 - **Fuzzy fallback lowercase guard.** The fallback scanner now ignores lowercase connectors such as “and/but” unless profiles
   explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
+- **Fuzzy fallback overlap guard.** Capitalized filler words must now share at least half of their characters with a real
+  pattern slot before fuzzy rescue runs, blocking adverbs like “Now” from being remapped to characters such as Yoshinon.
 - **Top character canonical labels.** Live tester and scene panel leaderboards now always show the normalized character name,
   even when a fuzzy fallback trigger originated from filler words like “Now,” keeping phantom entries out of the rankings.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.

--- a/test/fuzzy-detection.test.js
+++ b/test/fuzzy-detection.test.js
@@ -215,6 +215,40 @@ test("collectDetections can opt into lowercase fallback scanning when requested"
     assert.ok(connectorMatches.length >= 1, "expected lowercase connector when opt-in enabled");
 });
 
+test("collectDetections ignores capitalized words with low character overlap", () => {
+    const profile = {
+        patternSlots: [
+            { name: "Yoshinon" },
+            { name: "Nia" },
+        ],
+        ignorePatterns: [],
+        attributionVerbs: [],
+        actionVerbs: [],
+        pronounVocabulary: ["she"],
+        detectAttribution: false,
+        detectAction: false,
+        detectVocative: false,
+        detectPossessive: false,
+        detectPronoun: false,
+        detectGeneral: true,
+        fuzzyTolerance: "auto",
+    };
+
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\p{L}\\p{M}]",
+        defaultPronouns: ["she"],
+    });
+
+    const sample = "Now, at her eye level, the conversation paused.";
+    const matches = collectDetections(sample, profile, regexes, {
+        priorityWeights: { name: 1 },
+    });
+
+    const fallbackMatches = matches.filter(entry => entry.matchKind === "fuzzy-fallback");
+    const nowMatch = fallbackMatches.find(entry => entry.rawName === "Now");
+    assert.equal(nowMatch, undefined, "capitalized adverbs should not fuzzy-match characters");
+});
+
 test("resolveOutfitForMatch reuses fuzzy resolution for mapping lookup", () => {
     const profileDraft = {
         enableOutfits: true,


### PR DESCRIPTION
## Summary
- gate fuzzy fallback rescues on a minimum character-overlap ratio so capitalized adverbs like "Now" no longer map to real characters
- add regression coverage for the new guard and document the behaviour in the changelog

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a115a5538832585ae998fadaafb39)