### PR TITLE
Tighten fuzzy fallback edit-distance guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 ### Fixed
 - **Fuzzy fallback lowercase guard.** The fallback scanner now ignores lowercase connectors such as “and/but” unless profiles
   explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
+- **Fuzzy fallback overlap guard.** Capitalized filler words must now share at least half of their characters with a real
+  pattern slot before fuzzy rescue runs, blocking adverbs like “Now” from being remapped to characters such as Yoshinon.
+- **Fuzzy fallback edit-distance guard.** Near matches still reconcile to their roster slots, but proper nouns like “Milky” now
+  fail the normalized edit-distance check so product names and unrelated capitalized words stop being promoted to real
+  characters during fuzzy rescues.
 - **Top character canonical labels.** Live tester and scene panel leaderboards now always show the normalized character name,
   even when a fuzzy fallback trigger originated from filler words like “Now,” keeping phantom entries out of the rankings.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.

--- a/src/detector-core.js
+++ b/src/detector-core.js
@@ -424,7 +424,11 @@ function collectFuzzyFallbackMatches({
         if (rangesOverlap(ranges, start, end)) {
             return;
         }
-        const resolution = preprocessName(token.value, { priority: fallbackPriorityValue });
+        const isLowercaseToken = token.value === token.value.toLowerCase();
+        const resolution = preprocessName(token.value, {
+            priority: fallbackPriorityValue,
+            allowLooseFuzzyMatch: allowLowercaseFallbackTokens && isLowercaseToken,
+        });
         if (!resolution || !resolution.canonical || resolution.method !== "fuzzy" || !resolution.changed) {
             return;
         }
@@ -526,7 +530,11 @@ function collectContextualFuzzyFallbackMatches({
             const resolutionPriority = Number.isFinite(context.resolutionPriority)
                 ? context.resolutionPriority
                 : context.priority;
-            const resolution = preprocessName(candidate, { priority: resolutionPriority });
+            const isLowercaseCandidate = candidate === candidate.toLowerCase();
+            const resolution = preprocessName(candidate, {
+                priority: resolutionPriority,
+                allowLooseFuzzyMatch: allowLowercaseFallbackTokens && isLowercaseCandidate,
+            });
             if (!resolution || !resolution.canonical || resolution.method !== "fuzzy" || !resolution.changed) {
                 return;
             }


### PR DESCRIPTION
## Summary
- add a normalized Damerau–Levenshtein check and short affix exception so Fuse rescues only fire when a token truly resembles a rostered name
- let lowercase-only fallback scans request looser fuzzy matching while general scans continue to require the stricter edit-distance guard
- document and cover the new safeguards with regression tests to prove real typos like "Miki" still resolve while brand names such as "Milky" no longer map to characters

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a115a5538832585ae998fadaafb39)