### PR TITLE
Restore fuzzy fallback scanning without general detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - **Top character canonical labels.** Live tester and scene panel leaderboards now always show the normalized character name,
   even when a fuzzy fallback trigger originated from filler words like “Now,” keeping phantom entries out of the rankings.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.
+- **Fuzzy fallback general scan.** The standalone fallback sweep now runs whenever fuzzy tolerance is enabled, even if general detection is disabled, so misspelled names typed outside scripted cues still remap to the right characters.
 - **Live tester fuzzy snapshots.** Streaming simulations now honor the preprocessed buffer produced by the match finder, so the fuzzy tolerance pill, copy-to-clipboard report, and diagnostics stay in sync with the text that actually triggered fuzzy rescues.
 - **Legacy clone fallback.** Replaced direct `structuredClone` calls with a resilient deep clone helper so Electron builds and browsers without the native API can load Costume Switcher without crashing on startup.
 - **Host module imports.** Costume Switcher now mirrors the official SillyTavern extension import pattern so the browser loads `script.js`, `extensions.js`, and `slash-commands.js` without triggering MIME-type errors.

--- a/src/detector-core.js
+++ b/src/detector-core.js
@@ -1319,7 +1319,7 @@ export function collectDetections(text, profile = {}, regexes = {}, options = {}
         }
     }
 
-    if (profile.detectGeneral !== false && tolerance?.enabled) {
+    if (tolerance?.enabled) {
         const fallbackMatches = collectFuzzyFallbackMatches({
             text: sourceText,
             preprocessName,

--- a/test/fuzzy-detection.test.js
+++ b/test/fuzzy-detection.test.js
@@ -180,6 +180,43 @@ test("collectDetections rescues action cues when general detection disabled", ()
     assert.equal(matches.fuzzyResolution.used, true);
 });
 
+test("collectDetections rescues standalone fuzzy tokens when general detection disabled", () => {
+    const profile = {
+        patternSlots: [
+            { name: "Alice" },
+        ],
+        ignorePatterns: [],
+        attributionVerbs: [],
+        actionVerbs: [],
+        pronounVocabulary: ["she"],
+        detectAttribution: false,
+        detectAction: false,
+        detectVocative: false,
+        detectPossessive: false,
+        detectPronoun: false,
+        detectGeneral: false,
+        fuzzyTolerance: "auto",
+    };
+
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\p{L}\\p{M}]",
+        defaultPronouns: ["she"],
+    });
+
+    const sample = "Ailce waited near the hatch.";
+    const matches = collectDetections(sample, profile, regexes, {
+        priorityWeights: { name: 1 },
+        unicodeWordPattern: "[\\p{L}\\p{M}]",
+    });
+
+    const fallback = matches.find(entry => entry.matchKind === "fuzzy-fallback");
+    assert.ok(fallback, "expected standalone fuzzy fallback match");
+    assert.equal(fallback.name, "Alice");
+    assert.equal(fallback.rawName, "Ailce");
+    assert.equal(fallback.nameResolution?.method, "fuzzy");
+    assert.equal(matches.fuzzyResolution.used, true);
+});
+
 test("collectDetections ignores lowercase connectors for fuzzy fallback tokens", () => {
     const profile = {
         patternSlots: [


### PR DESCRIPTION
## Summary
- always run the standalone fuzzy fallback scanner whenever fuzzy tolerance is enabled so misspelled names are rescued even if general detection is off
- add regression coverage for general-detection-disabled profiles and document the fix in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1c0ee12483259f9a28bea7c78b55)