### PR TITLE
Add toggle for lowercase fuzzy fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Regex preprocessor opt-ins.** Profiles can opt into allowed global, preset, and scoped regex scripts, and the Live Tester now reveals the preprocessed text they run against.
 - **Regex preprocessor controls in Detection.** Added dedicated checkboxes under Detection so profiles can opt into global, preset, or scoped regex collections without editing JSON, complete with inline helper text describing when to enable each tier.
 - **Name matching controls.** The Detection tab now includes fuzzy tolerance presets, a custom low-confidence threshold, and an accent translation toggle so profiles can decide how aggressively diacritics and near-miss names are reconciled.
+- **Lowercase fallback toggle.** Name Matching also exposes a **Scan Lowercase Cues** checkbox so chats that intentionally lowercase speaker/system prompts can opt back into fuzzy rescues for those cues without re-enabling noisy lowercase scans globally.
 
 ### Improved
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Choose a preset from **Name Matching → Fuzzy Tolerance** based on how messy yo
 
 To see the difference, paste `"Ailce reached for her staff."` into the Live Pattern Tester. With fuzzy matching off the action detector ignores the typo. Enable **Auto** and the detector rewrites the hit to **Alice** because the edit distance is only one letter, and the score now clears the decision gate. Pair the tolerance with the **Translate Accents** toggle whenever a scene swaps alphabets or diacritics frequently—the shared buffer ensures the extension rescues live detections immediately, while the tester mirrors every fuzzy rescue so you can preview the outcome.
 
+Need to scan lowercase cues or system prompts (for example, when a preset intentionally lowercases speaker labels)? Flip on **Scan Lowercase Cues** under Name Matching. It re-enables the lowercase sweep for fuzzy fallback rescues so those intentionally lowercased cues can still remap to your cast. Leave it off for normal chats so filler words like “and/but” stay ignored.
+
 ### Performance & Bias
 Fine-tune responsiveness and tie-breaking behaviour:
 - **Global Cooldown (ms)** – Minimum time between any two costume changes.

--- a/index.js
+++ b/index.js
@@ -218,6 +218,7 @@ const AUTO_SAVE_RECOMPILE_KEYS = new Set([
     'actionVerbs',
     'pronounVocabulary',
     'scriptCollections',
+    'scanLowercaseFallbackTokens',
 ]);
 const AUTO_SAVE_FOCUS_LOCK_KEYS = new Set(['patterns']);
 const AUTO_SAVE_REASON_OVERRIDES = {
@@ -239,6 +240,7 @@ const AUTO_SAVE_REASON_OVERRIDES = {
     detectPossessive: 'possessive detection',
     detectPronoun: 'pronoun detection',
     detectGeneral: 'general name detection',
+    scanLowercaseFallbackTokens: 'lowercase fallback scanning',
     fuzzyTolerance: 'name matching tolerance',
     translateFuzzyNames: 'accent translation',
     scriptCollections: 'regex preprocessor',
@@ -4084,6 +4086,7 @@ const uiMapping = {
     detectPossessive: { selector: '#cs-detect-possessive', type: 'checkbox' },
     detectPronoun: { selector: '#cs-detect-pronoun', type: 'checkbox' },
     detectGeneral: { selector: '#cs-detect-general', type: 'checkbox' },
+    scanLowercaseFallbackTokens: { selector: '#cs-scan-lowercase-fallback', type: 'checkbox' },
     fuzzyTolerance: { selector: '#cs-fuzzy-tolerance', type: 'fuzzyTolerance' },
     translateFuzzyNames: { selector: '#cs-translate-fuzzy-names', type: 'checkbox' },
     attributionVerbs: { selector: '#cs-attribution-verbs', type: 'csvTextarea' },

--- a/settings.html
+++ b/settings.html
@@ -329,6 +329,14 @@
                       <small>Swap accented/translated characters (Á → A, ゆり → Yuri) before comparing.</small>
                     </span>
                   </label>
+                  <label class="cs-toggle cs-toggle--inline" title="Allow fuzzy fallback to scan lowercase speaker cues or system prompts when chats intentionally strip capitalization.">
+                    <input id="cs-scan-lowercase-fallback" type="checkbox" />
+                    <span class="cs-toggle-indicator"></span>
+                    <span>
+                      <strong>Scan Lowercase Cues</strong>
+                      <small>Let fuzzy fallback scan lowercase speaker cues and system prompts. Keep off unless your scripts intentionally lowercase names.</small>
+                    </span>
+                  </label>
                   <div class="cs-helper-text">
                     <p><strong>How each preset behaves:</strong></p>
                     <ul>


### PR DESCRIPTION
## Summary
- add a Scan Lowercase Cues checkbox to the Name Matching settings with helper copy and screenshot coverage
- register the new control in the profile persistence/auto-save plumbing so Live Tester reruns trigger regex recompiles when toggled
- document when to enable the toggle in the README and changelog so the UI guidance matches the engine behaviour

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2e11c44883258458b8f4be6884b4)