### PR TITLE
Add fuzzy fallback tuning controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Regex preprocessor controls in Detection.** Added dedicated checkboxes under Detection so profiles can opt into global, preset, or scoped regex collections without editing JSON, complete with inline helper text describing when to enable each tier.
 - **Name matching controls.** The Detection tab now includes fuzzy tolerance presets, a custom low-confidence threshold, and an accent translation toggle so profiles can decide how aggressively diacritics and near-miss names are reconciled.
 - **Lowercase fallback toggle.** Name Matching also exposes a **Scan Lowercase Cues** checkbox so chats that intentionally lowercase speaker/system prompts can opt back into fuzzy rescues for those cues without re-enabling noisy lowercase scans globally.
+- **Fuzzy fallback tuning.** Added optional score caps and cooldown distance inputs under Name Matching to clamp distant rescues and throttle repeated fallback matches without editing JSON.
 
 ### Improved
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ Choose a preset from **Name Matching → Fuzzy Tolerance** based on how messy yo
 
 To see the difference, paste `"Ailce reached for her staff."` into the Live Pattern Tester. With fuzzy matching off the action detector ignores the typo. Enable **Auto** and the detector rewrites the hit to **Alice** because the edit distance is only one letter, and the score now clears the decision gate. Pair the tolerance with the **Translate Accents** toggle whenever a scene swaps alphabets or diacritics frequently—the shared buffer ensures the extension rescues live detections immediately, while the tester mirrors every fuzzy rescue so you can preview the outcome.
 
+Fine-tune how those rescues behave with the advanced controls under **Name Matching**:
+
+- **Max fuzzy fallback score** – (Optional) Caps Fuse rescue scores between `0` and `1`. Set it around `0.4–0.6` to stop distant capitalized words from remapping to characters when the preset tolerance is already permissive; leave it blank to rely on the preset alone.
+- **Fallback cooldown (characters)** – (Optional) Requires a minimum character gap before the same name can be rescued again. Keep the default 200-character window to dampen repeated spam, or lower it for tight call-and-response transcripts where back-to-back mentions should still resolve.
+
 Need to scan lowercase cues or system prompts (for example, when a preset intentionally lowercases speaker labels)? Flip on **Scan Lowercase Cues** under Name Matching. It re-enables the lowercase sweep for fuzzy fallback rescues so those intentionally lowercased cues can still remap to your cast. Leave it off for normal chats so filler words like “and/but” stay ignored.
 
 ### Performance & Bias

--- a/settings.html
+++ b/settings.html
@@ -337,6 +337,16 @@
                       <small>Let fuzzy fallback scan lowercase speaker cues and system prompts. Keep off unless your scripts intentionally lowercase names.</small>
                     </span>
                   </label>
+                  <div class="cs-number-field">
+                    <label for="cs-fuzzy-fallback-max-score">Max fuzzy fallback score</label>
+                    <input id="cs-fuzzy-fallback-max-score" class="text_pole" type="number" min="0" max="1" step="0.01" inputmode="decimal" placeholder="Optional (0–1)" title="Clamp Fuse-powered fallback rescues to scores at or below this value. Leave blank to rely on the active tolerance and block only distant outliers." data-change-notice="Auto-saving fuzzy fallback score cap." />
+                    <small>Limit fuzzy rescues to the nearest matches. Set a cap near 0.4–0.6 to prevent distant capitalized words from mapping to live characters.</small>
+                  </div>
+                  <div class="cs-number-field">
+                    <label for="cs-fuzzy-fallback-cooldown">Fallback cooldown (characters)</label>
+                    <input id="cs-fuzzy-fallback-cooldown" class="text_pole" type="number" min="0" step="1" inputmode="numeric" placeholder="Default: 200" title="Require this many characters to pass before the same name can be rescued again. Leave blank to rely on the built-in 200 character guard." data-change-notice="Auto-saving fuzzy fallback cooldown." />
+                    <small>Throttle repeated rescues. Keep the default 200-character padding to stop spammy repeats, or lower it for tight call-and-response logs.</small>
+                  </div>
                   <div class="cs-helper-text">
                     <p><strong>How each preset behaves:</strong></p>
                     <ul>

--- a/test/fuzzy-detection.test.js
+++ b/test/fuzzy-detection.test.js
@@ -440,6 +440,40 @@ test("collectDetections throttles repeated fuzzy fallback candidates", () => {
     assert.equal(fallbackMatches[0]?.rawName, "Ailce");
 });
 
+test("collectDetections honors custom fuzzy fallback cooldown distances", () => {
+    const profile = {
+        patternSlots: [
+            { name: "Alice" },
+        ],
+        ignorePatterns: [],
+        attributionVerbs: [],
+        actionVerbs: [],
+        pronounVocabulary: ["she"],
+        detectAttribution: false,
+        detectAction: false,
+        detectVocative: false,
+        detectPossessive: false,
+        detectPronoun: false,
+        detectGeneral: false,
+        fuzzyTolerance: "auto",
+        fuzzyFallbackCooldown: 0,
+    };
+
+    const { regexes } = compileProfileRegexes(profile, {
+        unicodeWordPattern: "[\\p{L}\\p{M}]",
+        defaultPronouns: ["she"],
+    });
+
+    const sample = "Ailce waved. Ailce waved again. Ailce waved a third time.";
+    const matches = collectDetections(sample, profile, regexes, {
+        priorityWeights: { name: 1 },
+        unicodeWordPattern: "[\\p{L}\\p{M}]",
+    });
+
+    const fallbackMatches = matches.filter(entry => entry.matchKind === "fuzzy-fallback");
+    assert.ok(fallbackMatches.length > 1, "expected repeated fuzzy fallback candidates to register without cooldown padding");
+});
+
 test("resolveOutfitForMatch reuses fuzzy resolution for mapping lookup", () => {
     const profileDraft = {
         enableOutfits: true,

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -102,6 +102,26 @@ test('normalizeProfile normalizes script collection opt-ins', () => {
         'script collections should normalize to an ordered opt-in list');
 });
 
+test('normalizeProfile preserves fuzzy fallback tuning defaults', () => {
+    const defaults = {
+        ...PROFILE_DEFAULTS,
+        fuzzyFallbackMaxScore: null,
+        fuzzyFallbackCooldown: null,
+    };
+
+    const withCustomValues = normalizeProfile({
+        fuzzyFallbackMaxScore: 0.45,
+        fuzzyFallbackCooldown: 40,
+    }, defaults);
+
+    assert.equal(withCustomValues.fuzzyFallbackMaxScore, 0.45);
+    assert.equal(withCustomValues.fuzzyFallbackCooldown, 40);
+
+    const roundTrip = normalizeProfile({}, defaults);
+    assert.equal(roundTrip.fuzzyFallbackMaxScore, null);
+    assert.equal(roundTrip.fuzzyFallbackCooldown, null);
+});
+
 test('mappingHasIdentity accepts partially configured character slots', () => {
     assert.equal(mappingHasIdentity({}), false, 'empty mapping should not persist');
     assert.equal(mappingHasIdentity({ name: 'Draft Character' }), true, 'name-only mapping should persist');


### PR DESCRIPTION
## Summary
- add defaults, autosave reasons, and UI wiring for fuzzy fallback score caps and cooldown distances
- document the new name matching controls and guidance for when to adjust them
- cover fallback tuning in tests to confirm profile normalization and cooldown effects

## Testing
- node --test test/fuzzy-detection.test.js test/profiles.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a30cd6ba0832581418a59296d8f1d)