### PR TITLE
Ensure fuzzy fallback rescues run with active tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
   an optional `fuzzyFallbackMaxScore`), preventing distant capitalized words from mapping onto live characters.
 - **Top character canonical labels.** Live tester and scene panel leaderboards now always show the normalized character name,
   even when a fuzzy fallback trigger originated from filler words like “Now,” keeping phantom entries out of the rankings.
+- **Fuzzy fallback gating.** Contextual and standalone fuzzy sweeps now run any time fuzzy tolerance is enabled, even when no
+  other detectors report matches or the source priority is missing, so near-miss names such as “Kotory” and “Rien” still resolve
+  cleanly.
 - **Fuzzy fallback rescues.** Near-miss character names such as “Ailce” now trigger the fuzzy fallback scanner even when only speaker/action cues are enabled, and the default tolerance accepts one-letter swaps so low-confidence detections remap to the right character instead of being ignored entirely.
 - **Fuzzy fallback possessives.** Trailing apostrophe possessives are stripped before fuzzy matching so misspellings like “Shido’s” or “Kotory’s” still resolve to the correct characters instead of being skipped.
 - **Fuzzy fallback cooldown.** Contextual and standalone fuzzy collectors now pad prior match ranges and enforce a canonical/token cooldown so repeated mentions stop requeueing detections or spamming tester logs.

--- a/src/core/name-preprocessor.js
+++ b/src/core/name-preprocessor.js
@@ -188,9 +188,9 @@ function shouldApplyFuzzy(tolerance, { priority = null, hasAccents = false } = {
     if (!tolerance || !tolerance.enabled) {
         return false;
     }
+    const normalizedPriority = Number.isFinite(priority) ? priority : null;
     const lowConfidence = tolerance.lowConfidenceThreshold != null
-        && Number.isFinite(priority)
-        && priority <= tolerance.lowConfidenceThreshold;
+        && (normalizedPriority == null || normalizedPriority <= tolerance.lowConfidenceThreshold);
     const accentTrigger = tolerance.accentSensitive && hasAccents;
     if (tolerance.lowConfidenceThreshold == null && !tolerance.accentSensitive) {
         return true;

--- a/src/detector-core.js
+++ b/src/detector-core.js
@@ -1570,28 +1570,25 @@ export function collectDetections(text, profile = {}, regexes = {}, options = {}
                 resolutionPriority: fallbackPriority,
             });
         }
-        if (fallbackContexts.length) {
-            const contextualFallbacks = collectContextualFuzzyFallbackMatches({
-                text: sourceText,
-                preprocessName,
-                tolerance,
-                candidateInitials,
-                existingMatches: matches,
-                contexts: fallbackContexts,
-                tokenOffsets,
-                quoteRanges,
-                matchOptions,
-                allowLowercaseFallbackTokens,
-                fallbackMaxScore: fallbackScoreLimit,
-                fallbackCooldown: fallbackMatchCooldown,
-            });
-            if (contextualFallbacks.length) {
-                matches.push(...contextualFallbacks);
-            }
-        }
-    }
 
-    if (tolerance?.enabled) {
+        const contextualFallbacks = collectContextualFuzzyFallbackMatches({
+            text: sourceText,
+            preprocessName,
+            tolerance,
+            candidateInitials,
+            existingMatches: matches,
+            contexts: fallbackContexts,
+            tokenOffsets,
+            quoteRanges,
+            matchOptions,
+            allowLowercaseFallbackTokens,
+            fallbackMaxScore: fallbackScoreLimit,
+            fallbackCooldown: fallbackMatchCooldown,
+        });
+        if (contextualFallbacks.length) {
+            matches.push(...contextualFallbacks);
+        }
+
         const fallbackMatches = collectSimpleFuzzyFallbackMatches({
             text: sourceText,
             preprocessName,


### PR DESCRIPTION
## Summary
- always run contextual and standalone fuzzy fallback collectors whenever fuzzy tolerance is enabled
- treat missing priorities as low-confidence when applying fuzzy rescues in the name preprocessor
- document the gating fix and add tests for Kotory/Reine misspellings under auto fuzzy tolerance

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3a22b2d483259d15b6b6e444e1d2)