### PR TITLE
Add fuzzy idle warning to tester stream UI

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -664,7 +664,7 @@
                             </ul>
                             <div class="cs-roster-health">
                                 <div class="cs-tester-title cs-tester-title--sub">Roster Health</div>
-                                <div id="cs-test-roster-warning" class="cs-roster-warning">No TTL warnings triggered.</div>
+                                <div id="cs-test-roster-warning" class="cs-roster-warning">No tester warnings triggered.</div>
                             </div>
                         </div>
                     </section>


### PR DESCRIPTION
## Summary
- surface a tester warning when fuzzy tolerance is enabled but no candidates are normalized, with guidance on enabling detection contexts
- update the roster warning placeholder text to cover non-TTL notices
- add a UI test covering the fuzzy idle warning scenario

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3c97f9fc8325bf740ecd688df8d0)