### PR TITLE
Clarify fuzzy matching guidance in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Because these exports are refreshed on every message, you can wire them directly
 ## Troubleshooting Checklist
 1. **No switches happen:** verify streaming is enabled, the master toggle is on, at least one detection method is selected, and the characters appear in the patterns list exactly as they do in the story.
 2. **The wrong character is chosen:** run the Live Pattern Tester, read the skip reasons, and adjust Detection Bias or enable Scene Roster to give dialogue tags more weight.
-3. **Switches flicker between characters:** raise the global cooldown, tweak per-trigger cooldowns, or disable **Detect General Mentions** for subtle references.
+3. **Switches flicker between characters:** raise the global cooldown, tweak per-trigger cooldowns, or disable **Detect General Name Mentions** for subtle references.
 4. **Reports show a veto:** check the Veto Phrases list to confirm the text did not match an OOC filter.
 5. **Profiles do not persist:** ensure you click **Save** after editing and confirm the SillyTavern browser tab has permission to write local storage.
 

--- a/SillyTavern-CostumeSwitch-main/README.md
+++ b/SillyTavern-CostumeSwitch-main/README.md
@@ -343,7 +343,7 @@ Because these exports are refreshed on every message, you can wire them directly
 ## Troubleshooting Checklist
 1. **No switches happen:** verify streaming is enabled, the master toggle is on, at least one detection method is selected, and the characters appear in the patterns list exactly as they do in the story.
 2. **The wrong character is chosen:** run the Live Pattern Tester, read the skip reasons, and adjust Detection Bias or enable Scene Roster to give dialogue tags more weight.
-3. **Switches flicker between characters:** raise the global cooldown, tweak per-trigger cooldowns, or disable **Detect General Mentions** for subtle references.
+3. **Switches flicker between characters:** raise the global cooldown, tweak per-trigger cooldowns, or disable **Detect General Name Mentions** for subtle references.
 4. **Reports show a veto:** check the Veto Phrases list to confirm the text did not match an OOC filter.
 5. **Profiles do not persist:** ensure you click **Save** after editing and confirm the SillyTavern browser tab has permission to write local storage.
 

--- a/SillyTavern-CostumeSwitch-main/settings.html
+++ b/SillyTavern-CostumeSwitch-main/settings.html
@@ -262,7 +262,7 @@
                   <label class="cs-toggle" title="USE WITH CAUTION: Triggers on any mention of a character's name anywhere in the text. Can cause flickering.">
                     <input id="cs-detect-general" type="checkbox" />
                     <span class="cs-toggle-indicator"></span>
-                    <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Mentions</span>
+                    <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Name Mentions</span>
                   </label>
                 </div>
                 <small class="cs-helper-text">Enable the dialogue scan toggle if you work with transcripts that embed narration inside quoted speech, such as “the squad leader recounted, ‘Form up.’”.</small>

--- a/index.js
+++ b/index.js
@@ -7602,7 +7602,7 @@ function simulateTesterStream(combined, profile, bufKey, options = {}) {
     if (hasInputText && fuzzyToleranceEnabled && !fuzzySnapshot?.used && !detectedAnyCandidates && fuzzyCandidates > 0) {
         rosterWarnings.push({
             type: "fuzzy-idle",
-            message: "Fuzzy tolerance is enabled, but no names were normalized. Enable General Name detection or verify attribution/action verbs so detections exist for fuzzy matching.",
+            message: "Fuzzy tolerance is enabled, but no names were normalized. Turn on Detect General Name Mentions or confirm Detect Attribution and Detect Action are enabled so fuzzy matching has candidates.",
         });
     }
 

--- a/settings.html
+++ b/settings.html
@@ -263,7 +263,7 @@
                   <label class="cs-toggle" title="USE WITH CAUTION: Triggers on any mention of a character's name anywhere in the text. Can cause flickering.">
                     <input id="cs-detect-general" type="checkbox" />
                     <span class="cs-toggle-indicator"></span>
-                    <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Mentions</span>
+                    <span><i class="fa-solid fa-magnifying-glass"></i>Detect General Name Mentions</span>
                   </label>
                 </div>
                 <small class="cs-helper-text">Enable the dialogue scan toggle if you work with transcripts that embed narration inside quoted speech, such as “the squad leader recounted, ‘Form up.’”. Use the Regex Preprocessor options below to opt into allowed script collections when you need extra cleanup or translation guards.</small>
@@ -316,6 +316,7 @@
                       <option value="custom">Custom threshold</option>
                     </select>
                   </div>
+                  <small class="cs-helper-text">Fuzzy tolerance needs live detections to normalize. Keep Detect General Name Mentions on or make sure Detect Attribution and Detect Action stay enabled so fuzzy rescue has names to compare.</small>
                   <div id="cs-fuzzy-tolerance-custom-wrapper" class="cs-number-field" hidden>
                     <label for="cs-fuzzy-tolerance-custom">Custom Low-Confidence Threshold</label>
                     <input id="cs-fuzzy-tolerance-custom" class="text_pole" type="number" min="0" step="1" inputmode="numeric" placeholder="e.g., 3" title="Only use fuzzy matching when a detector scores at or below this priority value." />

--- a/test/simulate-tester-stream.test.js
+++ b/test/simulate-tester-stream.test.js
@@ -291,8 +291,8 @@ test("simulateTesterStream surfaces a fuzzy idle warning when tolerance is enabl
     assert.equal(result.events.length, 0, "expected no detection events when all detectors are disabled");
     const warning = result.rosterWarnings.find(entry => entry?.type === "fuzzy-idle");
     assert.ok(warning, "fuzzy idle warning should be surfaced when tolerance is enabled but unused");
-    assert.match(warning.message, /general name detection/i, "warning should recommend enabling General Name detection");
-    assert.match(warning.message, /attribution\/action verbs/i, "warning should mention attribution or action verbs for fuzzy context");
+    assert.match(warning.message, /detect general name mentions/i, "warning should recommend enabling General Name detection");
+    assert.match(warning.message, /detect attribution and detect action/i, "warning should mention attribution or action verbs for fuzzy context");
 });
 
 test("incremental analytics handles long streaming messages without full rescans", () => {


### PR DESCRIPTION
## Summary
- align the fuzzy idle warning copy with the actual detection toggle labels
- rename the General detection toggle to "Detect General Name Mentions" and add helper text near fuzzy tolerance
- refresh docs and tests to reflect the updated guidance

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a42ee0424832587381306b24de1f5)