### PR TITLE
Zone off fuzzy name matching controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - **Lowercase fallback toggle.** Name Matching also exposes a **Scan Lowercase Cues** checkbox so chats that intentionally lowercase speaker/system prompts can opt back into fuzzy rescues for those cues without re-enabling noisy lowercase scans globally.
 - **Fuzzy fallback tuning.** Added optional score caps and cooldown distance inputs under Name Matching to clamp distant rescues and throttle repeated fallback matches without editing JSON.
 
+### Changed
+- **Fuzzy name matching zoning.** Temporarily fenced off the fuzzy controls in settings with a release note so users know the feature will reopen in v3.6.1 once stability work wraps up.
+
 ### Improved
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.

--- a/settings.html
+++ b/settings.html
@@ -303,7 +303,11 @@
                     <p>The preprocessor runs in live streams before detections score, and the Live Tester simply mirrors what already happened.</p>
                   </div>
                 </div>
-                <div class="cs-field-group cs-field-group--stacked">
+                <div class="cs-field-group cs-field-group--stacked cs-zone-off" aria-disabled="true" aria-describedby="cs-fuzzy-lockout">
+                  <div id="cs-fuzzy-lockout" class="cs-zone-off-banner" role="note">
+                    <strong>Fuzzy name matching is cooling off.</strong>
+                    <span>Finalized controls land in v3.6.1, so this area is zoned off for now.</span>
+                  </div>
                   <label class="cs-inline-label" for="cs-fuzzy-tolerance">Name Matching</label>
                   <div class="cs-number-field">
                     <label for="cs-fuzzy-tolerance">Fuzzy Tolerance Preset</label>

--- a/style.css
+++ b/style.css
@@ -109,6 +109,49 @@
   line-height: 1.4;
 }
 
+#costume-switcher-settings.cs-theme .cs-zone-off {
+  position: relative;
+}
+
+#costume-switcher-settings.cs-theme .cs-zone-off > :not(.cs-zone-off-banner) {
+  opacity: 0.45;
+}
+
+#costume-switcher-settings.cs-theme .cs-zone-off::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgba(3, 6, 16, 0.78);
+  backdrop-filter: blur(2px);
+  z-index: 2;
+  pointer-events: auto;
+}
+
+#costume-switcher-settings.cs-theme .cs-zone-off-banner {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 26px 24px;
+  gap: 6px;
+  color: rgba(255, 255, 255, 0.92);
+  pointer-events: none;
+}
+
+#costume-switcher-settings.cs-theme .cs-zone-off-banner strong {
+  font-size: 1rem;
+}
+
+#costume-switcher-settings.cs-theme .cs-zone-off-banner span {
+  font-size: 0.88rem;
+  color: color-mix(in srgb, var(--accent) 80%, rgba(255, 255, 255, 0.9));
+}
+
 #costume-switcher-settings.cs-theme .cs-card-body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a lockout banner to the fuzzy name matching settings so the UI clearly states they will return in v3.6.1 and users cannot adjust the unstable controls
- provide the supporting CSS overlay that darkens the zoned-off section while keeping the copy readable
- document the temporary zoning in the unreleased changelog

## Testing
- not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d806eae58832597ca9348ad9969ab)