### PR TITLE
Improve scene panel mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1865,6 +1865,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     overflow-y: auto;
     padding-right: 4px;
     scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
 }
 
 .cs-scene-panel__sections::-webkit-scrollbar {
@@ -1978,6 +1979,18 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+}
+
+.cs-scene-panel__toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.cs-scene-panel__toolbar-group--toggles {
+    min-width: 0;
+    flex: 1 1 140px;
 }
 
 #cs-scene-panel,
@@ -2764,6 +2777,7 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     min-height: 0;
     overflow-y: auto;
     padding-right: 4px;
+    -webkit-overflow-scrolling: touch;
 }
 
 .cs-scene-panel__sheet-body::-webkit-scrollbar {
@@ -3069,15 +3083,98 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
         width: min(100%, 92vw);
         inset: auto 4vw 4vw 4vw;
         height: auto;
-        max-height: 70vh;
+        max-height: min(78vh, calc(100vh - (var(--topBarBlockSize, 3.25rem) + 24px)));
+        gap: 0;
     }
 
     .cs-scene-panel__content {
         padding: 16px;
+        gap: 12px;
+    }
+
+    .cs-scene-panel__headline,
+    .cs-scene-panel__title {
+        min-width: 0;
+    }
+
+    .cs-scene-panel__toolbar {
+        width: 100%;
+    }
+
+    .cs-scene-panel__toolbar-group {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .cs-scene-panel__toolbar-group--primary {
+        justify-content: flex-start;
+    }
+
+    .cs-scene-panel__toolbar-group--toggles {
+        justify-content: flex-start;
     }
 
     .cs-scene-panel__summon[data-panel-visible="true"] {
         right: 4vw;
         bottom: 4vw;
+    }
+}
+
+@media (max-width: 720px) {
+    .cs-scene-panel {
+        width: auto;
+        left: 12px;
+        right: 12px;
+        top: calc(var(--topBarBlockSize, 3.25rem) + 10px);
+        bottom: auto;
+        height: auto;
+        max-height: calc(100vh - (var(--topBarBlockSize, 3.25rem) + 24px));
+    }
+
+    .cs-scene-panel__header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .cs-scene-panel__headline,
+    .cs-scene-panel__title {
+        width: 100%;
+    }
+
+    .cs-scene-panel__toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .cs-scene-panel__toolbar-group {
+        justify-content: flex-start;
+    }
+
+    .cs-scene-panel__toolbar-group--primary {
+        row-gap: 10px;
+    }
+
+    .cs-scene-panel__sections {
+        padding-right: 2px;
+    }
+
+    .cs-scene-panel__content {
+        padding: 14px;
+    }
+
+    .cs-scene-panel__section-actions {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .cs-scene-panel__summon {
+        right: max(env(safe-area-inset-right, 12px), 12px);
+        bottom: max(env(safe-area-inset-bottom, 12px), 12px);
+    }
+
+    .cs-scene-panel__summon[data-panel-visible="true"] {
+        right: max(env(safe-area-inset-right, 12px), 12px);
+        bottom: max(env(safe-area-inset-bottom, 12px), 12px);
     }
 }

--- a/ui/templates/scenePanel.html
+++ b/ui/templates/scenePanel.html
@@ -14,38 +14,42 @@
                 </div>
             </div>
             <div class="cs-scene-panel__toolbar" data-scene-panel="toolbar">
-                <button id="cs-scene-panel-toggle" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-panel" aria-pressed="true" title="Hide scene panel">
-                    <i class="fa-solid fa-eye" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle scene panel visibility</span>
-                </button>
-                <button id="cs-scene-panel-toggle-auto-open" class="cs-scene-panel__icon-button" type="button" data-scene-panel="auto-open-results" aria-pressed="true" title="Disable auto-open on new results">
-                    <i class="fa-solid fa-bolt" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle auto-open on new results</span>
-                </button>
-                <button id="cs-scene-section-toggle-roster" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-roster" aria-pressed="true" title="Hide roster section">
-                    <i class="fa-solid fa-users" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle roster section</span>
-                </button>
-                <button id="cs-scene-section-toggle-active" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-active" aria-pressed="true" title="Hide active characters section">
-                    <i class="fa-solid fa-user-clock" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle active characters section</span>
-                </button>
-                <button id="cs-scene-section-toggle-log" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-log" aria-pressed="true" title="Hide live log section">
-                    <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle live log section</span>
-                </button>
-                <button id="cs-scene-section-toggle-coverage" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-coverage" aria-pressed="true" title="Hide coverage suggestions section">
-                    <i class="fa-solid fa-language" aria-hidden="true"></i>
-                    <span class="visually-hidden">Toggle coverage suggestions section</span>
-                </button>
-                <button id="cs-scene-refresh" class="cs-scene-panel__icon-button" type="button" data-scene-panel="refresh">
-                    <i class="fa-solid fa-rotate" aria-hidden="true"></i>
-                    <span class="visually-hidden">Refresh roster</span>
-                </button>
-                <label class="cs-scene-panel__toggle" data-scene-panel="auto-pin" for="cs-scene-auto-pin">
-                    <input id="cs-scene-auto-pin" type="checkbox" />
-                    <span>Auto-pin top active</span>
-                </label>
+                <div class="cs-scene-panel__toolbar-group cs-scene-panel__toolbar-group--primary">
+                    <button id="cs-scene-panel-toggle" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-panel" aria-pressed="true" title="Hide scene panel">
+                        <i class="fa-solid fa-eye" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle scene panel visibility</span>
+                    </button>
+                    <button id="cs-scene-panel-toggle-auto-open" class="cs-scene-panel__icon-button" type="button" data-scene-panel="auto-open-results" aria-pressed="true" title="Disable auto-open on new results">
+                        <i class="fa-solid fa-bolt" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle auto-open on new results</span>
+                    </button>
+                    <button id="cs-scene-section-toggle-roster" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-roster" aria-pressed="true" title="Hide roster section">
+                        <i class="fa-solid fa-users" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle roster section</span>
+                    </button>
+                    <button id="cs-scene-section-toggle-active" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-active" aria-pressed="true" title="Hide active characters section">
+                        <i class="fa-solid fa-user-clock" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle active characters section</span>
+                    </button>
+                    <button id="cs-scene-section-toggle-log" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-log" aria-pressed="true" title="Hide live log section">
+                        <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle live log section</span>
+                    </button>
+                    <button id="cs-scene-section-toggle-coverage" class="cs-scene-panel__icon-button" type="button" data-scene-panel="toggle-coverage" aria-pressed="true" title="Hide coverage suggestions section">
+                        <i class="fa-solid fa-language" aria-hidden="true"></i>
+                        <span class="visually-hidden">Toggle coverage suggestions section</span>
+                    </button>
+                    <button id="cs-scene-refresh" class="cs-scene-panel__icon-button" type="button" data-scene-panel="refresh">
+                        <i class="fa-solid fa-rotate" aria-hidden="true"></i>
+                        <span class="visually-hidden">Refresh roster</span>
+                    </button>
+                </div>
+                <div class="cs-scene-panel__toolbar-group cs-scene-panel__toolbar-group--toggles">
+                    <label class="cs-scene-panel__toggle" data-scene-panel="auto-pin" for="cs-scene-auto-pin">
+                        <input id="cs-scene-auto-pin" type="checkbox" />
+                        <span>Auto-pin top active</span>
+                    </label>
+                </div>
             </div>
         </header>
         <div class="cs-scene-panel__sections" data-scene-panel="sections">


### PR DESCRIPTION
## Summary
- organize the scene panel toolbar into grouped rows that can wrap on small screens
- add responsive spacing, safe-area positioning, and touch scrolling tweaks to the scene panel styles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69561f4a4fc08325b644d24af3708cb7)