### PR TITLE
Normalize saved outfit variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 ### Fixed
 - **Fuzzy fallback lowercase guard.** The fallback scanner now ignores lowercase connectors such as “and/but” unless profiles
   explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
+- **Outfit Lab variation persistence.** Outfit variations added to character slots now survive saves and page reloads instead of
+  reappearing as empty cards.
 - **Fuzzy fallback overlap guard.** Capitalized filler words must now share at least half of their characters with a real
   pattern slot before fuzzy rescue runs, blocking adverbs like “Now” from being remapped to characters such as Yoshinon.
 - **Fuzzy fallback score cap.** Fallback rescues now require a valid Fuse score that stays under the configured tolerance (or

--- a/test/profile-utils.test.js
+++ b/test/profile-utils.test.js
@@ -1,16 +1,18 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import assert from "node:assert/strict";
+import test from "node:test";
 
 import {
     normalizePatternSlot,
     preparePatternSlotsForSave,
+    prepareMappingsForSave,
+    normalizeMappingEntry,
     reconcilePatternSlotReferences,
-} from '../profile-utils.js';
+} from "../profile-utils.js";
 
-test('reconcilePatternSlotReferences reuses existing slot objects and updates fields', () => {
-    const existingSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al'] });
-    Object.defineProperty(existingSlot, '__slotId', {
-        value: 'slot-1',
+test("reconcilePatternSlotReferences reuses existing slot objects and updates fields", () => {
+    const existingSlot = normalizePatternSlot({ name: "Alice", aliases: ["Al"] });
+    Object.defineProperty(existingSlot, "__slotId", {
+        value: "slot-1",
         enumerable: false,
         configurable: true,
         writable: true,
@@ -20,41 +22,80 @@ test('reconcilePatternSlotReferences reuses existing slot objects and updates fi
     const prepared = preparePatternSlotsForSave(existingSlots, new Set());
     assert.equal(prepared.length, 1);
 
-    const nextSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al', 'Aly'] });
-    Object.defineProperty(nextSlot, '__slotId', {
-        value: 'slot-1',
+    const nextSlot = normalizePatternSlot({ name: "Alice", aliases: ["Al", "Aly"] });
+    Object.defineProperty(nextSlot, "__slotId", {
+        value: "slot-1",
         enumerable: false,
         configurable: true,
         writable: true,
     });
 
     const reconciled = reconcilePatternSlotReferences(existingSlots, [nextSlot]);
-    assert.equal(reconciled[0], existingSlot, 'existing reference should be reused');
-    assert.deepEqual(reconciled[0].aliases, ['Al', 'Aly']);
-    assert.notEqual(reconciled[0].aliases, nextSlot.aliases, 'aliases should be cloned');
+    assert.equal(reconciled[0], existingSlot, "existing reference should be reused");
+    assert.deepEqual(reconciled[0].aliases, ["Al", "Aly"]);
+    assert.notEqual(reconciled[0].aliases, nextSlot.aliases, "aliases should be cloned");
 
     const updatedPrepared = preparePatternSlotsForSave(reconciled, new Set());
-    assert.deepEqual(updatedPrepared[0].aliases, ['Al', 'Aly']);
+    assert.deepEqual(updatedPrepared[0].aliases, ["Al", "Aly"]);
 });
 
-test('reconcilePatternSlotReferences returns new objects for unseen slots', () => {
-    const existingSlot = normalizePatternSlot({ name: 'Alice', aliases: ['Al'] });
-    Object.defineProperty(existingSlot, '__slotId', {
-        value: 'slot-1',
+test("reconcilePatternSlotReferences returns new objects for unseen slots", () => {
+    const existingSlot = normalizePatternSlot({ name: "Alice", aliases: ["Al"] });
+    Object.defineProperty(existingSlot, "__slotId", {
+        value: "slot-1",
         enumerable: false,
         configurable: true,
         writable: true,
     });
 
-    const newSlot = normalizePatternSlot({ name: 'Bob', aliases: ['Bobby'] });
-    Object.defineProperty(newSlot, '__slotId', {
-        value: 'slot-2',
+    const newSlot = normalizePatternSlot({ name: "Bob", aliases: ["Bobby"] });
+    Object.defineProperty(newSlot, "__slotId", {
+        value: "slot-2",
         enumerable: false,
         configurable: true,
         writable: true,
     });
 
     const reconciled = reconcilePatternSlotReferences([existingSlot], [newSlot]);
-    assert.notEqual(reconciled[0], existingSlot, 'new slot should not reuse unrelated reference');
-    assert.equal(reconciled[0], newSlot, 'new slot should be returned as provided');
+    assert.notEqual(reconciled[0], existingSlot, "new slot should not reuse unrelated reference");
+    assert.equal(reconciled[0], newSlot, "new slot should be returned as provided");
+});
+
+test("prepareMappingsForSave keeps outfit variants intact through save/load cycles", () => {
+    const mapping = normalizeMappingEntry({
+        name: "Nova",
+        defaultFolder: "nova/base",
+        outfits: [
+            {
+                folder: "nova/stealth",
+                triggers: ["shadow", "/cloak/"],
+                matchKinds: ["Speaker", "action"],
+                awareness: { requires: ["Lena"], excludes: ["Drake"] },
+                priority: "5",
+            },
+        ],
+    });
+
+    const saved = prepareMappingsForSave([mapping]);
+    assert.equal(saved.length, 1);
+    assert.deepEqual(saved[0].outfits[0], {
+        folder: "nova/stealth",
+        triggers: ["shadow", "/cloak/"],
+        matchKinds: ["speaker", "action"],
+        awareness: { requires: ["Lena"], excludes: ["Drake"] },
+        priority: 5,
+    });
+});
+
+test("prepareMappingsForSave rescues string outfit entries", () => {
+    const saved = prepareMappingsForSave([
+        {
+            name: "Rin",
+            defaultFolder: "rin/base",
+            outfits: ["rin/alt"],
+        },
+    ]);
+
+    assert.equal(saved[0].outfits.length, 1);
+    assert.deepEqual(saved[0].outfits[0], { folder: "rin/alt", triggers: [], priority: 0 });
 });


### PR DESCRIPTION
## Summary
- normalize outfit variant data before saving profiles so string entries become editable objects
- add regression tests around outfit variant persistence through save/load cycles
- document the outfit variation persistence fix in the changelog

## Testing
- npm test -- test/profile-utils.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfb1ef56c8325a703af40fd55fb64)