### PR TITLE
Preserve outfit lab trigger persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
   explicitly opt into lowercase scanning, preventing common words from appearing as phantom characters in tester rankings.
 - **Outfit Lab variation persistence.** Outfit variations added to character slots now survive saves and page reloads instead of
   reappearing as empty cards.
+- **Outfit Lab trigger persistence.** Regex-based outfit triggers and awareness rules are preserved during saves so folders,
+  match kinds, and exclusion lists stay intact after reloading profiles.
 - **Fuzzy fallback overlap guard.** Capitalized filler words must now share at least half of their characters with a real
   pattern slot before fuzzy rescue runs, blocking adverbs like “Now” from being remapped to characters such as Yoshinon.
 - **Fuzzy fallback score cap.** Fallback rescues now require a valid Fuse score that stays under the configured tolerance (or

--- a/profile-utils.js
+++ b/profile-utils.js
@@ -3,6 +3,10 @@ function safeClone(value) {
         return undefined;
     }
 
+    if (value instanceof RegExp) {
+        return new RegExp(value.source, value.flags || "");
+    }
+
     if (typeof structuredClone === 'function') {
         try {
             return structuredClone(value);
@@ -15,6 +19,9 @@ function safeClone(value) {
         const json = JSON.stringify(value);
         return json === undefined ? undefined : JSON.parse(json);
     } catch (err) {
+        if (value instanceof RegExp) {
+            return new RegExp(value.source, value.flags || "");
+        }
         if (Array.isArray(value)) {
             return value.map((item) => safeClone(item));
         }
@@ -164,6 +171,19 @@ function cloneStringList(source) {
         }
         if (Array.isArray(item)) {
             item.forEach((nested) => {
+                if (nested == null) {
+                    return;
+                }
+                if (nested instanceof RegExp) {
+                    const pattern = nested.source;
+                    const flags = nested.flags || "";
+                    const literal = `/${pattern}/${flags}`;
+                    const trimmed = literal.trim();
+                    if (trimmed) {
+                        result.push(trimmed);
+                    }
+                    return;
+                }
                 if (typeof nested === 'string') {
                     const trimmed = nested.trim();
                     if (trimmed) {
@@ -171,6 +191,16 @@ function cloneStringList(source) {
                     }
                 }
             });
+            return;
+        }
+        if (item instanceof RegExp) {
+            const pattern = item.source;
+            const flags = item.flags || "";
+            const literal = `/${pattern}/${flags}`;
+            const trimmed = literal.trim();
+            if (trimmed) {
+                result.push(trimmed);
+            }
             return;
         }
         if (typeof item === 'string') {

--- a/test/profile-utils.test.js
+++ b/test/profile-utils.test.js
@@ -99,3 +99,30 @@ test("prepareMappingsForSave rescues string outfit entries", () => {
     assert.equal(saved[0].outfits.length, 1);
     assert.deepEqual(saved[0].outfits[0], { folder: "rin/alt", triggers: [], priority: 0 });
 });
+
+test("prepareMappingsForSave preserves regex-based outfit variations", () => {
+    const saved = prepareMappingsForSave([
+        {
+            name: "Kaia",
+            defaultFolder: "kaia/base",
+            outfits: [
+                {
+                    folder: "kaia/winter",
+                    triggers: [/snow/i, "blizzard"],
+                    matchKinds: ["Action"],
+                    awareness: { requiresAny: ["Lena"], excludes: [/Drake/i] },
+                    priority: 3,
+                },
+            ],
+        },
+    ]);
+
+    assert.equal(saved[0].outfits.length, 1);
+    assert.deepEqual(saved[0].outfits[0], {
+        folder: "kaia/winter",
+        triggers: ["/snow/i", "blizzard"],
+        matchKinds: ["action"],
+        awareness: { requiresAny: ["Lena"], excludes: ["/Drake/i"] },
+        priority: 3,
+    });
+});


### PR DESCRIPTION
## Summary
- handle RegExp values when cloning profile data so outfit lab mappings keep regex triggers and awareness filters intact
- cover regex-based outfit variants with a regression test in `test/profile-utils.test.js`
- note the trigger persistence fix in the changelog

## Testing
- node --test test/profile-utils.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfecc4d3483259020a8b8d692dae7)