### PR TITLE
Preserve long message detections after buffer trims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - **Live tester isolation.** Running pattern simulations no longer injects tester roster data or log events into the side panel.
 - **Scene completion gating.** Live tester streams no longer trigger the command center's completion handlers, so roster capture waits for real assistant messages to finish.
 - **Roster activation regression.** Freshly detected characters now mark as active again when they enter the roster instead of staying flagged as inactive.
+- **Long-message buffer retention.** Stream processing now evaluates tokens before trimming and raises the default buffer to 5,000 characters (with UI guidance for low-end devices) so early mentions in lengthy replies still trigger costume switches.
 - **Manual refresh recovery.** The refresh control reloads the latest assistant outcome so the side panel actually updates instead of simply re-rendering stale data.
 
 ## v3.5.0

--- a/settings.html
+++ b/settings.html
@@ -464,6 +464,7 @@
                   <input id="cs-failed-trigger-cooldown" class="text_pole" type="number" min="0" title="Backoff delay after a failed switch attempt before trying again." />
                   <label for="cs-max-buffer-chars">Max Buffer Size (chars)</label>
                   <input id="cs-max-buffer-chars" class="text_pole" type="number" min="0" title="Maximum characters of recent text to keep while scanning the stream." />
+                  <small class="cs-helper-text">Raise this if long replies mention characters early; lower it on low-end devices to conserve memory.</small>
                   <label for="cs-token-process-threshold">Token Process Threshold (chars)</label>
                   <input id="cs-token-process-threshold" class="text_pole" type="number" min="0" title="How many characters to wait before checking. Lower is more reactive but uses more CPU." />
                 </div>


### PR DESCRIPTION
## Summary
- process streaming tokens before trimming both live and tester buffers so matches survive long replies
- raise the default stream buffer to 5,000 characters and add UI guidance for low-end devices handling long outputs
- add a regression test and changelog entry covering early mentions that would previously fall out of the buffer

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9d59e3448325933b5f05fd317b1b)