### PR TITLE
Fix streaming detection after buffer trims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - **Scene panel idle refresh.** Chat-change hooks now ignore updates that don't alter the latest assistant message, so editing system prompts or sending player chatter no longer clears or replays roster detections.
 - **Scene panel auto-open triggers.** Auto-open on streaming or new results now re-enables the side panel when it was hidden, so updates bring the workspace back instead of staying out of view.
 - **Buffer window trimming.** Streaming keeps matching after the max buffer limit trims older text, so outfit switching and live diagnostics continue instead of stalling at the limit.
+- **Live stream character switching.** Incremental detection now keeps scanning trimmed buffers during long generations, so /costume switches continue firing while outputs stream past the max buffer window.
 - **Coverage fallback in the scene panel.** The side panel now reuses the latest tester coverage analysis when no live buffer is
   streaming so vocabulary suggestions stay visible between messages.
 - **Skip reason flood control.** Live diagnostics cap repeated skip notices to keep recent switch and veto activity surfaced in

--- a/index.js
+++ b/index.js
@@ -10789,8 +10789,9 @@ const handleStream = (...args) => {
         const maxBuffer = resolveMaxBufferChars(profile);
         const trimmedChars = Math.max(0, appended.length - maxBuffer);
         const combined = trimmedChars > 0 ? appended.slice(-maxBuffer) : appended;
-        const detectionBuffer = appended;
-        const bufferOffset = Number.isFinite(msgState.bufferOffset) ? msgState.bufferOffset : 0;
+        const baseBufferOffset = Number.isFinite(msgState.bufferOffset) ? msgState.bufferOffset : 0;
+        const bufferOffset = baseBufferOffset + trimmedChars;
+        const detectionBuffer = combined;
         const deltaAbsoluteStart = Math.max(previousProcessedLength, bufferOffset);
         const startIndex = Math.max(0, deltaAbsoluteStart - bufferOffset);
         const newestAbsoluteIndex = detectionBuffer.length > 0


### PR DESCRIPTION
## Summary
- adjust streaming buffer offsets so incremental detection keeps running after trims
- document the live stream switching fix in the changelog

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9fa2aa5c8325877ea53ab3999d16)