### PR TITLE
Preserve full streamed message buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Improved
 - **Detection buffer conditioning.** Detection now mirrors the expressions pipeline by substituting macros, stripping markdown clutter, and windowing the freshest 500 characters while keeping trimmed offsets aligned for streaming scans.
+- **Streaming buffer retention.** Live streams and the simulator now keep the full assistant message instead of trimming to the buffer window, so early cues remain eligible for switches even during lengthy generations.
 - **Outfit availability filtering.** Character matches without mapped outfits are filtered out before switching, and skip reasons surface in tester logs so missing folders are clear while debugging.
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.

--- a/settings.html
+++ b/settings.html
@@ -401,8 +401,8 @@
                   <input id="cs-per-trigger-cooldown" class="text_pole" type="number" min="0" title="How long to wait before the same detection type can fire again." />
                   <label for="cs-failed-trigger-cooldown">Failed Trigger Cooldown (ms)</label>
                   <input id="cs-failed-trigger-cooldown" class="text_pole" type="number" min="0" title="Backoff delay after a failed switch attempt before trying again." />
-                  <label for="cs-max-buffer-chars">Max Buffer Size (chars)</label>
-                  <input id="cs-max-buffer-chars" class="text_pole" type="number" min="0" title="Maximum characters of recent text to keep while scanning the stream." />
+                  <label for="cs-max-buffer-chars">Stream Buffer Safety (chars)</label>
+                  <input id="cs-max-buffer-chars" class="text_pole" type="number" min="0" title="Full streamed messages are kept; this value only caps extremely long outputs to protect memory usage." />
                   <small class="cs-helper-text">Raise this if long replies mention characters early; lower it on low-end devices to conserve memory.</small>
                 </div>
                 <div class="cs-slider-field">

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -640,6 +640,101 @@ test("handleStream merges incremental matches without duplication", () => {
     }
 });
 
+test("handleStream retains the full streaming buffer when text exceeds the window", () => {
+    resetSceneState();
+    clearLiveTesterOutputs();
+
+    state.perMessageStates = new Map();
+    state.perMessageBuffers = new Map();
+    state.messageStats = new Map();
+    state.messageMatches = new Map();
+    state.topSceneRanking = new Map();
+    state.topSceneRankingUpdatedAt = new Map();
+    state.currentGenerationKey = null;
+
+    const settings = extensionSettingsStore[extensionName];
+    const originalProfile = settings.profiles.Default;
+    const originalCompiled = state.compiledRegexes;
+    const original$ = globalThis.$;
+
+    const stubElement = {
+        length: 0,
+        find: () => stubElement,
+        filter: () => stubElement,
+        first: () => stubElement,
+        append: () => stubElement,
+        insertAfter: () => stubElement,
+        text: () => stubElement,
+        html: () => stubElement,
+        toggleClass: () => stubElement,
+        stop: () => stubElement,
+        fadeIn: () => stubElement,
+        fadeOut: (duration, callback) => {
+            if (typeof callback === "function") {
+                callback();
+            }
+            return stubElement;
+        },
+        removeClass: () => stubElement,
+        addClass: () => stubElement,
+        prop: () => stubElement,
+        attr: () => stubElement,
+        on: () => stubElement,
+        off: () => stubElement,
+    };
+    globalThis.$ = () => stubElement;
+
+    settings.profiles.Default = {
+        patterns: ["Kotori", "Shido"],
+        detectAttribution: false,
+        detectAction: false,
+        detectGeneral: true,
+        detectPronoun: false,
+        detectVocative: false,
+        detectPossessive: false,
+        maxBufferChars: 24,
+    };
+
+    const compiled = compileProfileRegexes(settings.profiles.Default);
+    state.compiledRegexes = { ...compiled.regexes, effectivePatterns: compiled.effectivePatterns };
+
+    try {
+        const profile = settings.profiles.Default;
+        __testables.createMessageState(profile, "m0", { messageRole: "assistant" });
+        state.currentGenerationKey = "m0";
+
+        const longChunk = `Kotori greets the crowd and keeps talking ${"x".repeat(120)} still going.`;
+        handleStream(0, longChunk);
+
+        const buffer = state.perMessageBuffers.get("m0") || "";
+        const cache = state.messageMatches.get("m0");
+
+        assert.ok(buffer.startsWith("Kotori"), "buffer should preserve the leading cue");
+        assert.ok(buffer.length >= longChunk.length, "buffer should retain the full streamed content");
+        assert.ok(cache?.matches?.some((match) => match.name === "Kotori"), "detection should still find early cues");
+        assert.equal(cache.matches[0].absoluteIndex, 0, "leading match should remain at the start of the buffer");
+    } finally {
+        settings.profiles.Default = originalProfile;
+        state.compiledRegexes = originalCompiled;
+        if (state.statusTimer) {
+            clearTimeout(state.statusTimer);
+            state.statusTimer = null;
+        }
+        if (typeof original$ === "undefined") {
+            globalThis.$ = () => stubElement;
+        } else {
+            globalThis.$ = original$;
+        }
+        state.currentGenerationKey = null;
+        state.perMessageStates = new Map();
+        state.perMessageBuffers = new Map();
+        state.messageStats = new Map();
+        state.messageMatches = new Map();
+        state.topSceneRanking = new Map();
+        state.topSceneRankingUpdatedAt = new Map();
+    }
+});
+
 test("collectScenePanelState analytics updatedAt reflects latest scene activity", () => {
     resetSceneState();
     clearLiveTesterOutputs();


### PR DESCRIPTION
## Summary
- keep streaming buffers intact while processing detections, sharing the same safety window between live and simulated flows
- clarify the stream buffer safety setting and document the full-message buffering change
- add coverage for long streaming inputs to ensure early cues are preserved

## Testing
- node --test test/stream-window.test.js test/simulate-tester-stream.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb7da2b7483258f229e74526b8aa5)