### PR TITLE
Clamp streaming buffers to safety window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Improved
 - **Detection buffer conditioning.** Detection now mirrors the expressions pipeline by substituting macros, stripping markdown clutter, and windowing the freshest 500 characters while keeping trimmed offsets aligned for streaming scans.
 - **Streaming buffer retention.** Live streams and the simulator now keep the full assistant message instead of trimming to the buffer window, so early cues remain eligible for switches even during lengthy generations.
+- **Streaming buffer safety cap.** Live stream buffers now trim the stored window to a high safety limit to avoid runaway token growth during unusually long generations.
 - **Outfit availability filtering.** Character matches without mapped outfits are filtered out before switching, and skip reasons surface in tester logs so missing folders are clear while debugging.
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.

--- a/index.js
+++ b/index.js
@@ -6103,6 +6103,8 @@ function trimDecisionEvents(events, max = MAX_RECENT_DECISION_EVENTS) {
 const __testables = {
     trimDecisionEvents,
     recordDecisionEvent,
+    buildStreamingBuffers,
+    STREAM_BUFFER_SAFETY_CHARS,
 };
 
 function recordLastVetoMatch(match, { source = 'live', persist = true } = {}) {
@@ -7061,11 +7063,12 @@ function buildStreamingBuffers(previousBuffer, nextChunk, profile, msgState) {
         ? appended.length - safetyLimit
         : 0;
     const detectionBuffer = trimmedChars > 0 ? appended.slice(-safetyLimit) : appended;
+    const appendedWindow = detectionBuffer;
     const baseBufferOffset = Number.isFinite(msgState?.bufferOffset) ? msgState.bufferOffset : 0;
     const bufferOffset = baseBufferOffset + trimmedChars;
 
     return {
-        appended,
+        appended: appendedWindow,
         detectionBuffer,
         trimmedChars,
         bufferOffset,

--- a/test/stream-window.test.js
+++ b/test/stream-window.test.js
@@ -90,6 +90,24 @@ test("adjustWindowForTrim grows processed length with new characters", () => {
     assert.equal(msgState.processedLength, 150);
 });
 
+test("buildStreamingBuffers trims stored stream windows to the safety cap", () => {
+    const profile = { maxBufferChars: 5000 };
+    const msgState = { bufferOffset: 0 };
+    const largeChunk = "a".repeat(__testables.STREAM_BUFFER_SAFETY_CHARS + 5000);
+
+    const { appended, detectionBuffer, trimmedChars, bufferOffset } = __testables.buildStreamingBuffers(
+        "",
+        largeChunk,
+        profile,
+        msgState,
+    );
+
+    assert.equal(appended.length, __testables.STREAM_BUFFER_SAFETY_CHARS);
+    assert.equal(detectionBuffer.length, __testables.STREAM_BUFFER_SAFETY_CHARS);
+    assert.equal(trimmedChars, 5000);
+    assert.equal(bufferOffset, 5000);
+});
+
 test("handleStream logs focus lock status when locked", () => {
     const original$ = globalThis.$;
     const stubElement = {


### PR DESCRIPTION
## Summary
- cap stored live and simulated streaming buffers at the safety window while keeping offsets aligned
- expose the streaming buffer helper for tests and cover the safety cap behavior
- document the stream buffer safety clamp in the changelog

## Testing
- npm test -- test/stream-window.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cbc71560c8325a1bd22512d7d99d4)