### PR TITLE
Add Scene Control Center popup accessible from Extensions (magic wand) menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Detection engine upgrade.** Main Detection Engine v4 and Outfit Detection Engine v2 now ship with the shared preprocessing, token-aware streaming, and fuzzy/translation reconciliation layers so detections stay accurate even when inputs arrive noisy or translated mid-stream.
 - **Fuzzy name preprocessing.** Added an optional normalization layer shared by detection and outfit matching that reuses classification sampling, translation toggles, and Fuse-powered lookups to reconcile misspelled or accented names before scoring.
 - **Scene panel command center.** Polished the side panel with a branded header, roster manager drawer, log viewer, auto-pin highlight toggle, and quick focus-lock controls so every button delivers meaningful actions.
+- **Scene control center popup.** Added a magic-wand menu entry that opens the Scene Control Center in a centered popup so mobile layouts can access the panel without the side dock.
 - **Summon toggle for the scene panel.** Hide the panel completely and bring it back with a floating summon button that stays available as a quick toggle so the chat column can reclaim the full width whenever you need extra room.
 - **Inline scene roster settings.** The footer button now opens an in-panel settings sheet with quick toggles for auto-open behavior, section visibility, and roster avatars.
 - **Roster expiry counter.** Every roster entry now displays the remaining message count before it expires, making it easy to spot characters that are about to drop from the scene.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { extension_settings, getContext, renderExtensionTemplateAsync } from "../../../extensions.js";
+import { callGenericPopup, POPUP_TYPE } from "../../../popup.js";
 import {
     saveSettingsDebounced,
     saveChatDebounced,
@@ -101,6 +102,8 @@ const STREAM_BUFFER_SAFETY_CHARS = 120000;
 const NO_EFFECTIVE_PATTERNS_MESSAGE = "All detection patterns were filtered out by ignored names. No detectors can run until you restore at least one allowed pattern.";
 const FOCUS_LOCK_NOTICE_INTERVAL = 2500;
 const MESSAGE_OUTCOME_STORAGE_KEY = "cs_scene_outcomes";
+const SCENE_CONTROL_POPUP_TITLE = "Scene Control Center";
+let scenePanelPopupState = null;
 
 function createFocusLockNotice() {
     return { at: 0, character: null, displayName: null, message: null, event: null };
@@ -141,6 +144,96 @@ const EXTENDED_ACTION_VERB_FORMS = buildVerbList(
     EXTENDED_ACTION_VERBS_PAST_PARTICIPLE,
     EXTENDED_ACTION_VERBS_PRESENT_PARTICIPLE,
 );
+
+function getExtensionsMenuContainer() {
+    const selectors = ["#extensionsMenu", "#extensions-menu", "#extensionsList", "#extensionsMenuContainer", "#extensions_menu"];
+    for (const selector of selectors) {
+        const $container = $(selector).first();
+        if ($container.length) {
+            return $container;
+        }
+    }
+    return null;
+}
+
+function restoreScenePanelFromPopup() {
+    if (!scenePanelPopupState) {
+        return;
+    }
+    const { panel, parent, nextSibling, observer } = scenePanelPopupState;
+    if (observer) {
+        observer.disconnect();
+    }
+    if (panel) {
+        panel.classList.remove("cs-scene-panel--popup");
+        panel.removeAttribute("data-cs-popup");
+        if (parent) {
+            if (nextSibling && nextSibling.parentElement === parent) {
+                parent.insertBefore(panel, nextSibling);
+            } else {
+                parent.appendChild(panel);
+            }
+        }
+    }
+    scenePanelPopupState = null;
+    requestScenePanelRender("popup-close", { immediate: true });
+}
+
+async function openSceneControlCenterPopup() {
+    if (scenePanelPopupState?.panel) {
+        return;
+    }
+    await mountScenePanelTemplate();
+    const panel = document.getElementById("cs-scene-panel");
+    if (!panel) {
+        console.warn(`${logPrefix} Scene panel is unavailable; unable to open popup.`);
+        return;
+    }
+    const parent = panel.parentElement;
+    const nextSibling = panel.nextElementSibling;
+    const dialog = $("<div class=\"cs-scene-panel-popup\" aria-live=\"polite\"></div>");
+    panel.classList.add("cs-scene-panel--popup");
+    panel.setAttribute("data-cs-popup", "true");
+    dialog.append(panel);
+    setScenePanelCollapsed(false);
+    requestScenePanelRender("popup-open", { immediate: true });
+    const observer = new MutationObserver(() => {
+        if (!dialog[0]?.isConnected) {
+            restoreScenePanelFromPopup();
+        }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    scenePanelPopupState = {
+        panel,
+        parent,
+        nextSibling,
+        observer,
+    };
+    callGenericPopup(dialog, POPUP_TYPE.TEXT, SCENE_CONTROL_POPUP_TITLE, {
+        wide: true,
+        large: true,
+        allowVerticalScrolling: false,
+    });
+}
+
+function addSceneControlCenterMenuButton() {
+    if ($("#cs_scene_panel_menu_button").length) {
+        return;
+    }
+    const $container = getExtensionsMenuContainer();
+    if (!$container) {
+        console.warn(`${logPrefix} Could not find an extensions menu container to attach the Scene Control Center popup.`);
+        return;
+    }
+    const buttonHtml = `
+        <div id="cs_scene_panel_menu_button" class="list-group-item flex-container flexGap5">
+            <div class="fa-solid fa-masks-theater extensionsMenuExtensionButton"></div>
+            <div class="flex1">Scene Control Center</div>
+        </div>
+    `;
+    $container.append(buttonHtml);
+    $("#cs_scene_panel_menu_button").on("click", openSceneControlCenterPopup);
+}
 
 // ======================================================================
 // PRESET PROFILES
@@ -11532,6 +11625,7 @@ if (typeof window !== "undefined" && typeof jQuery === "function") {
             $("#extensions_settings").append(settingsHtml);
 
             await mountScenePanelTemplate();
+            addSceneControlCenterMenuButton();
 
             const buildMeta = await fetchBuildMetadata();
             renderBuildMetadata(buildMeta);

--- a/settings.html
+++ b/settings.html
@@ -361,6 +361,7 @@
                     </label>
                   </div>
                   <small class="cs-helper-text">Experimental: The scene panel mirrors the live tester timeline for actual chat replies and may evolve as we refine it.</small>
+                  <small class="cs-helper-text">Tip: Use the Extensions (magic wand) menu in chat to open the Scene Control Center popup, handy for mobile layouts.</small>
                 </div>
                 <div class="cs-field-group">
                   <label for="cs-attribution-verbs">Attribution Verbs</label>
@@ -677,4 +678,3 @@
     </div>
   </div>
 </div>
-

--- a/style.css
+++ b/style.css
@@ -1815,6 +1815,29 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
     isolation: isolate;
 }
 
+.cs-scene-panel-popup {
+    width: min(92vw, 52rem);
+    max-width: 100%;
+    height: min(84vh, 48rem);
+    max-height: 84vh;
+    margin: 0 auto;
+    display: flex;
+}
+
+.cs-scene-panel--popup {
+    position: relative;
+    inset: auto;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    box-shadow: none;
+}
+
+.cs-scene-panel--popup .cs-scene-panel__content {
+    height: 100%;
+}
+
 .cs-scene-panel::before {
     content: "";
     position: absolute;


### PR DESCRIPTION
### Motivation
- Make the Scene Control Center available as a centered popup (like World Engine) so mobile users can access the panel without a side-docked layout.
- Reuse the existing scene panel UI to avoid duplicating rendering and state handling.
- Provide a resilient flow that restores the panel back to its original container when the popup closes.
- Surface the new entry in the settings copy and changelog so users know how to open the popup from the magic-wand menu.

### Description
- Added `callGenericPopup` import and implemented `openSceneControlCenterPopup`, `restoreScenePanelFromPopup`, and `getExtensionsMenuContainer` to move the existing `#cs-scene-panel` into a centered popup and restore it on close.
- Added `addSceneControlCenterMenuButton` and wired it into initialization so the new menu item is appended to the Extensions menu and opens the popup on click.
- Added popup-specific CSS rules (`.cs-scene-panel-popup` and `.cs-scene-panel--popup`) to `style.css` to adapt the panel for centered/dialog presentation.
- Updated `settings.html` helper text and `CHANGELOG.md` to document the new popup access point.

### Testing
- No automated tests were run as part of this change.
- Manual runtime verification was not executed in this environment (UI interactions require the SillyTavern host).
- Code compiles / lints were not invoked here; changes are limited to DOM wiring, CSS, and copy updates.
- Further integration testing should validate popup open/close, panel restore, and mobile layout behavior in the running application.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963053d72108325a08f34e5d4c2b6d4)