### PR TITLE
Fix scene control center popup rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - **Scene control center button resilience.** Panel and summon buttons now reset their visual styles within the extension so conflicting theme overrides from other mods can no longer hide or neutralize them.
 - **Scene summon toggle stability.** Restored the summon control's inline visibility guard without the heavy polling loop, preventing slowdowns while keeping the button visible when other mods interfere.
 - **Scene control center refresh.** Event subscriptions now match additional SillyTavern generation hooks, so the roster, live diagnostics, and status copy update right after streaming and message completion without needing manual history edits.
+- **Scene control center popup rendering.** Opening the popup now forces the panel visible even when the docked panel is hidden, preventing empty modal windows.
 - **Stream start detection resiliency.** Hidden and symbol-keyed SillyTavern events are now recognised when wiring the integration, keeping the side panel aware of streaming starts even when the host app reshuffles its hooks.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
 - **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.

--- a/src/ui/render/panel.js
+++ b/src/ui/render/panel.js
@@ -694,10 +694,12 @@ export function renderScenePanel(panelState = {}, { source = "scene" } = {}) {
     if (!container || (typeof container.length === "number" && container.length === 0)) {
         return;
     }
+    const { el: containerElement } = resolveContainer(container);
+    const isPopup = containerElement?.dataset?.csPopup === "true";
 
     const collapsed = Boolean(panelState.collapsed);
     const settings = panelState.settings || {};
-    const enabled = settings.enabled !== false;
+    const enabled = isPopup ? true : settings.enabled !== false;
 
     lastPanelEnabledState = enabled;
     lastPanelCollapsedState = collapsed;


### PR DESCRIPTION
### Motivation

- The Scene Control Center popup could appear blank because the panel renderer treated the docked panel's hidden state as meaning the popup should be hidden too. 
- When the panel is moved into the centered popup it must render its content regardless of the docked panel visibility so users on mobile/layouts can access it.

### Description

- Update `renderScenePanel` in `src/ui/render/panel.js` to detect when the panel is hosted inside the popup by resolving the container and checking the `data-cs-popup` flag and treat the popup host as enabled so content renders (`renderScenePanel` now forces `enabled` when `dataset.csPopup === "true"`).
- Use `resolveContainer` to obtain the real DOM element and detect the popup state via `containerElement?.dataset?.csPopup` before deciding enabled state.
- Add changelog entry to `CHANGELOG.md` documenting the popup rendering fix.

### Testing

- No automated tests were executed for this change.
- The change is limited to UI rendering logic in `renderScenePanel` and a documentation update in `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630edec3b08325870c3fb173b45918)