### PR TITLE
Improve streaming role handling and stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - **Scene control center popup rendering.** Opening the popup now forces the panel visible even when the docked panel is hidden, preventing empty modal windows.
 - **Stream start detection resiliency.** Hidden and symbol-keyed SillyTavern events are now recognised when wiring the integration, keeping the side panel aware of streaming starts even when the host app reshuffles its hooks.
 - **Streaming event detection.** The scene panel now tracks SillyTavern's symbol-based generation events, restoring auto-open behaviour and post-stream analytics updates for live messages.
+- **Streaming role detection stability.** Live streams now cache resolved roles and avoid treating token text as role metadata, preventing runaway per-token scans and restoring scene panel detections when assistant outputs include words like “user.”
 - **Character slot persistence.** Pattern cards stay linked to the active profile after auto-saves, so follow-up edits continue to stick instead of silently rolling back.
 - **Scene panel glow overflow.** The aurora backdrop now animates entirely inside the frame and keeps a generous bleed so no hard edges peek through mid-cycle.
 - **Live tester isolation.** Running pattern simulations no longer injects tester roster data or log events into the side panel.


### PR DESCRIPTION
### Motivation
- Streaming token handling could be misinterpreting token text (e.g. the literal word `user`) as role metadata and repeatedly re-resolving roles, which can overload the detection pipeline and leave the scene panel empty.
- The scene control center needs stable, single-pass detection during live assistant output so roster and live diagnostics remain populated while streaming.
- A cached generation role prevents per-token role resolution churn and restores expected auto-open/analytics behavior for assistant streams.

### Description
- Added a cached role field `state.currentGenerationRole` and wired it into `handleGenerationStart`, `handleStream`, `handleMessageRendered`, and `resetGlobalState` so roles are stored and cleared alongside `state.currentGenerationKey` (`index.js`).
- `handleStream` now prefers the cached role and only calls `resolveMessageRoleFromArgs` when the token arguments contain object-shaped role candidates, preventing token text from being misinterpreted as a role.
- Added a regression test `test("handleStream does not treat token text as a role indicator", ...)` to `test/stream-window.test.js` and updated `CHANGELOG.md` with the stability note.
- Files changed: `index.js`, `test/stream-window.test.js`, and `CHANGELOG.md`.

### Testing
- Added a unit test in `test/stream-window.test.js` covering token-only chunks not being treated as role metadata (test added but not fully runnable in CI env).
- Attempted to run `node --test test/stream-window.test.js`, which failed due to environment-specific host module resolution: "Cannot find module '/popup.js' imported from `index.js`".
- Existing test harness and stubs were preserved and the new test resets global state after execution to avoid cross-test pollution.
- No further automated test suite was executed successfully due to the host import error described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963115d2d4883259753163e52d80315)