### PR TITLE
Fix Scene Control Center popup sizing/behavior and make stream parsing cycle-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@
 - **Detection buffer conditioning.** Detection now mirrors the expressions pipeline by substituting macros, stripping markdown clutter, and windowing the freshest 500 characters while keeping trimmed offsets aligned for streaming scans.
 - **Streaming buffer retention.** Live streams and the simulator now keep the full assistant message instead of trimming to the buffer window, so early cues remain eligible for switches even during lengthy generations.
 - **Streaming buffer safety cap.** Live stream buffers now trim the stored window to a high safety limit to avoid runaway token growth during unusually long generations.
+- **Stream payload resilience.** Stream message references now guard against circular payloads and nested arrays, preventing streaming crashes when SillyTavern emits rich token events.
 - **Outfit lab saving resilience.** Outfit Lab now syncs from the live form state before saves so manual and auto-saves reliably capture every outfit field.
 - **Outfit availability filtering.** Character matches without mapped outfits are filtered out before switching, and skip reasons surface in tester logs so missing folders are clear while debugging.
 - **Live tester preprocessing diagnostics.** The Match Flow panel now itemizes applied regex scripts, shows a fuzzy-tolerance badge, adds normalization notes to detections, and copies the summary data into reports so support can trace preprocessing effects.
 - **Scene control center aurora parity.** The roster headline now inherits the hero gradient and animated starfield from the main header so the command center shares the same nebula finish.
 - **Scene control center polish.** Refined the panel with a live-status banner, quick section navigation chips, richer hover states, and smoother animations to make the roster workspace feel faster and more intentional.
+- **Scene control center popup sizing.** The popup now respects small viewport heights and widths so it fits on mobile screens without overflowing.
 - **Coverage toggle in the control center.** Coverage suggestions now share the toolbar's quick toggles so the panel can hide or restore vocabulary guidance without opening settings.
 - **Scene panel master toggle placement.** The hide/show switch now anchors to the base of the hero card so it stays visually connected to the gradient header instead of floating above it.
 - **Adaptive section sizing.** Remaining scene panel sections now stretch to fill the freed space as soon as any module is hidden, so two-up layouts immediately expand instead of waiting until only a single section remains.

--- a/style.css
+++ b/style.css
@@ -1817,9 +1817,9 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 
 .cs-scene-panel-popup {
     width: min(92vw, 52rem);
-    max-width: 100%;
+    max-width: calc(100vw - 24px);
     height: min(84vh, 48rem);
-    max-height: 84vh;
+    max-height: calc(100vh - (var(--topBarBlockSize, 3.25rem) + 24px));
     margin: 0 auto;
     display: flex;
 }
@@ -3211,6 +3211,12 @@ body[data-theme="moonlit-echoes"] #costume-switcher-settings.cs-theme .cs-build-
 }
 
 @media (max-width: 720px) {
+    .cs-scene-panel-popup {
+        width: calc(100vw - 20px);
+        height: calc(100vh - (var(--topBarBlockSize, 3.25rem) + 20px));
+        max-height: calc(100vh - (var(--topBarBlockSize, 3.25rem) + 20px));
+    }
+
     .cs-scene-panel {
         width: auto;
         left: 12px;


### PR DESCRIPTION
### Motivation
- Prevent crashes during streaming when SillyTavern emits rich or circular token payloads that caused the parser to recurse indefinitely.
- Make the Scene Control Center popup usable on mobile by ensuring it fits small viewports and allows scrolling.
- Avoid opening an empty/disabled panel when the popup is summoned by temporarily enabling the panel while the popup is open and restoring the prior state when closed.
- Record the user-facing changes in `CHANGELOG.md` to reflect the stability and UI fixes.

### Description
- Update `parseMessageReference` to accept an optional `seen` `WeakSet`, guard against cycles, and recursively handle nested arrays and `messages` to make stream message reference extraction cycle-safe.
- Change `openSceneControlCenterPopup` to force-enable the scene panel while the popup is open, store the previous `enabled` state, and restore it in `restoreScenePanelFromPopup` using `ensureScenePanelSettings` and `updateScenePanelSettingControls`.
- Allow popup scrolling by setting `allowVerticalScrolling: true` for the `callGenericPopup` call and adjust CSS for `.cs-scene-panel-popup` (`max-width`/`max-height`) plus add a mobile `@media (max-width: 720px)` override so the popup fits on small screens.
- Add changelog entries describing `Stream payload resilience` and `Scene control center popup sizing` improvements in `CHANGELOG.md`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963136ad65c8325b49345cbfa7bc0b7)