### PR TITLE
Add streaming snapshot polling for live messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **Detection buffer conditioning.** Detection now mirrors the expressions pipeline by substituting macros, stripping markdown clutter, and windowing the freshest 500 characters while keeping trimmed offsets aligned for streaming scans.
 - **Streaming buffer retention.** Live streams and the simulator now keep the full assistant message instead of trimming to the buffer window, so early cues remain eligible for switches even during lengthy generations.
 - **Streaming buffer safety cap.** Live stream buffers now trim the stored window to a high safety limit to avoid runaway token growth during unusually long generations.
+- **Streaming snapshot polling.** Live streaming now polls the authoritative chat log every second and processes only the delta from the latest assistant message, keeping memory overhead low while still feeding the existing buffer logic.
 - **Stream payload resilience.** Stream message references now guard against circular payloads and nested arrays, preventing streaming crashes when SillyTavern emits rich token events.
 - **Outfit lab saving resilience.** Outfit Lab now syncs from the live form state before saves so manual and auto-saves reliably capture every outfit field.
 - **Outfit availability filtering.** Character matches without mapped outfits are filtered out before switching, and skip reasons surface in tester logs so missing folders are clear while debugging.


### PR DESCRIPTION
### Motivation

- Reduce per-token buffering and memory usage by reading authoritative assistant message text from the chat log instead of relying solely on token events.
- Feed existing streaming buffer/detection logic with stable full-message snapshots and only process the delta since the last snapshot.
- Keep detection behavior and roster updates intact while simplifying the token handler to only manage generation lifecycle state.

### Description

- Added a new snapshot polling interval constant `STREAM_SNAPSHOT_INTERVAL_MS`, state field `streamSnapshotTimer`, and supporting functions `resolveStreamSnapshotMessage`, `runStreamSnapshotTick`, `startStreamSnapshotTimer`, and `stopStreamSnapshotTimer` to poll the chat log and build per-tick deltas.
- Reused existing `processStreamChunk` and `buildStreamingBuffers` logic by feeding the delta substring (computed with `snapshotText.slice(previousProcessedLength)`) so detections operate unchanged while snapshots are immediately discarded. 
- Wired snapshot timer lifecycle into generation events by starting it in `handleGenerationStart`, simplifying `handleStream` to only start/stop the timer and track generation role/key, and invoking a final snapshot in `handleMessageRendered` before stopping the timer.
- Cleaned up global teardown (`resetGlobalState`) to clear the snapshot timer and documented the change in `CHANGELOG.md`.

### Testing

- No automated tests were run for this change.
- Basic repository commit succeeded locally (code changes staged and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69643b73fe888325860f1b97a3dea7e9)